### PR TITLE
[feat] TLTag 구현

### DIFF
--- a/iOS/traveline/Resources/Colors.xcassets/DarkGray.colorset/Contents.json
+++ b/iOS/traveline/Resources/Colors.xcassets/DarkGray.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.165",
+          "green" : "0.165",
+          "red" : "0.165"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iOS/traveline/Resources/Colors.xcassets/DisabledGray.colorset/Contents.json
+++ b/iOS/traveline/Resources/Colors.xcassets/DisabledGray.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.740",
+          "blue" : "0.502",
+          "green" : "0.463",
+          "red" : "0.463"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iOS/traveline/Sources/Core/Extension/String+.swift
+++ b/iOS/traveline/Sources/Core/Extension/String+.swift
@@ -1,0 +1,15 @@
+//
+//  String+.swift
+//  traveline
+//
+//  Created by 김태현 on 2023/11/16.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+extension String {
+    
+    static let empty: String = ""
+    
+}

--- a/iOS/traveline/Sources/Core/Extension/UIView+.swift
+++ b/iOS/traveline/Sources/Core/Extension/UIView+.swift
@@ -1,0 +1,39 @@
+//
+//  UIView+.swift
+//  traveline
+//
+//  Created by 김태현 on 2023/11/15.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import UIKit
+
+extension UIView {
+    
+    /// view에 그림자 추가
+    func addShadow(
+        xOffset: CGFloat,
+        yOffset: CGFloat,
+        blur: CGFloat,
+        spread: CGFloat = 0.0,
+        color: UIColor,
+        alpha: Float
+    ) {
+        layer.masksToBounds = false
+        layer.shadowOffset = CGSize(width: xOffset, height: yOffset)
+        layer.shadowRadius = blur
+        layer.shadowColor = color.cgColor
+        layer.shadowOpacity = alpha
+        layer.shadowPath = (spread == 0) ? nil : UIBezierPath(rect: bounds.insetBy(dx: -spread, dy: -spread)).cgPath
+    }
+    
+    /// view에서 그림자 제거
+    func removeShadow() {
+        layer.shadowOffset = CGSize.zero
+        layer.shadowRadius = 0.0
+        layer.shadowColor = nil
+        layer.shadowOpacity = 0.0
+        layer.shadowPath = nil
+    }
+    
+}

--- a/iOS/traveline/Sources/Core/Extension/UIView+.swift
+++ b/iOS/traveline/Sources/Core/Extension/UIView+.swift
@@ -10,6 +10,11 @@ import UIKit
 
 extension UIView {
     
+    /// 여러 view를 순서대로 addSubview
+    func addSubviews(_ views: UIView...) {
+        views.forEach { addSubview($0) }
+    }
+    
     /// view에 그림자 추가
     func addShadow(
         xOffset: CGFloat,

--- a/iOS/traveline/Sources/Data/Network/Base/NetworkError.swift
+++ b/iOS/traveline/Sources/Data/Network/Base/NetworkError.swift
@@ -20,19 +20,19 @@ enum NetworkError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .urlError:
-            "유효하지 않은 url입니다."
+            return "유효하지 않은 url입니다."
         case .encodeError:
-            "인코딩에 실패했습니다."
+            return "인코딩에 실패했습니다."
         case .decodeError:
-            "디코딩에 실패했습니다."
+            return "디코딩에 실패했습니다."
         case .httpResponseError:
-            "잘못된 http 응답입니다."
+            return "잘못된 http 응답입니다."
         case .redirectionError:
-            "리다이레션 에러입니다."
+            return "리다이레션 에러입니다."
         case .clientError:
-            "잘못된 요청입니다."
+            return "잘못된 요청입니다."
         case .serverError:
-            "알 수 없는 오류입니다."
+            return "알 수 없는 오류입니다."
         }
     }
 }

--- a/iOS/traveline/Sources/DesignSystem/Component/TLLabel.swift
+++ b/iOS/traveline/Sources/DesignSystem/Component/TLLabel.swift
@@ -12,9 +12,11 @@ final class TLLabel: UILabel {
 
     private let travelineFont: TLFont
     private let alignment: NSTextAlignment
-    private let travelineColor: UIColor
-    private let labelText: String
+    private var travelineColor: UIColor
+    private var labelText: String
 
+    // MARK: - Initialize
+    
     init(
         frame: CGRect = .zero,
         font: TLFont,
@@ -36,6 +38,8 @@ final class TLLabel: UILabel {
         fatalError("init(coder:) has not been implemented")
     }
 
+    // MARK: - Functions
+    
     private func setupAttributes() {
         let attributedString = NSMutableAttributedString(string: labelText)
         let range = (labelText as NSString).range(of: labelText)
@@ -71,4 +75,14 @@ final class TLLabel: UILabel {
         attributedText = attributedString
     }
 
+    func setText(to text: String) {
+        labelText = text
+        setupAttributes()
+    }
+    
+    func setColor(to color: UIColor) {
+        travelineColor = color
+        setupAttributes()
+    }
+    
 }

--- a/iOS/traveline/Sources/DesignSystem/Component/TLLabel.swift
+++ b/iOS/traveline/Sources/DesignSystem/Component/TLLabel.swift
@@ -10,7 +10,7 @@ import UIKit
 
 final class TLLabel: UILabel {
 
-    private let travelineFont: TLFont
+    private var travelineFont: TLFont
     private let alignment: NSTextAlignment
     private var travelineColor: UIColor
     private var labelText: String
@@ -82,6 +82,11 @@ final class TLLabel: UILabel {
     
     func setColor(to color: UIColor) {
         travelineColor = color
+        setupAttributes()
+    }
+    
+    func setFont(to font: TLFont) {
+        travelineFont = font
         setupAttributes()
     }
     

--- a/iOS/traveline/Sources/DesignSystem/Component/TLTag/TLTag.swift
+++ b/iOS/traveline/Sources/DesignSystem/Component/TLTag/TLTag.swift
@@ -87,6 +87,17 @@ final class TLTag: UIButton {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {        
+        if style == .cancellable {
+            let width = bounds.width
+            let touchArea = bounds.inset(by: UIEdgeInsets(top: 0, left: width - 30, bottom: 0, right: 0))
+            
+            return touchArea.contains(point)
+        }
+        
+        return super.point(inside: point, with: event)
+    }
+    
     // MARK: - Functions
     
     private func updateTagSelected() {

--- a/iOS/traveline/Sources/DesignSystem/Component/TLTag/TLTag.swift
+++ b/iOS/traveline/Sources/DesignSystem/Component/TLTag/TLTag.swift
@@ -62,7 +62,6 @@ final class TLTag: UIButton {
     private var style: TLTagStyle
     private let tagColor: UIColor
     private let defaultColor: UIColor = TLColor.lightGray
-    private let defaultHeight: CGFloat = 34.0
 
     // MARK: - Initialize
     
@@ -75,6 +74,7 @@ final class TLTag: UIButton {
         self.style = style
         self.tagColor = color
         tagTitleLabel.setText(to: name)
+        tagTitleLabel.setFont(to: style.font)
         
         super.init(frame: frame)
         
@@ -117,7 +117,7 @@ private extension TLTag {
         }
         
         layer.masksToBounds = false
-        innerView.layer.cornerRadius = defaultHeight / 2
+        innerView.layer.cornerRadius = style.height / 2
     }
     
     func setupLayout() {
@@ -132,7 +132,7 @@ private extension TLTag {
             innerView.leadingAnchor.constraint(equalTo: leadingAnchor),
             innerView.trailingAnchor.constraint(equalTo: trailingAnchor),
             innerView.bottomAnchor.constraint(equalTo: bottomAnchor),
-            innerView.heightAnchor.constraint(equalToConstant: defaultHeight),
+            innerView.heightAnchor.constraint(equalToConstant: style.height),
             
             stackView.topAnchor.constraint(equalTo: innerView.topAnchor, constant: style.verticalInset),
             stackView.leadingAnchor.constraint(equalTo: innerView.leadingAnchor, constant: style.horizontalInset),

--- a/iOS/traveline/Sources/DesignSystem/Component/TLTag/TLTag.swift
+++ b/iOS/traveline/Sources/DesignSystem/Component/TLTag/TLTag.swift
@@ -1,0 +1,170 @@
+//
+//  TravelineTag.swift
+//  traveline
+//
+//  Created by 김태현 on 2023/11/15.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import UIKit
+
+final class TLTag: UIButton {
+    
+    // MARK: - UI Components
+    
+    private let innerView: UIView = {
+        let view = UIView()
+        
+        view.isUserInteractionEnabled = false
+        view.backgroundColor = TLColor.darkGray
+        view.layer.borderWidth = 1.0
+        view.layer.borderColor = TLColor.lightGray.cgColor
+        
+        return view
+    }()
+    
+    private let stackView: UIStackView = {
+        let stackView = UIStackView()
+        
+        stackView.axis = .horizontal
+        stackView.distribution = .fill
+        stackView.alignment = .center
+        stackView.spacing = 4.0
+        stackView.isUserInteractionEnabled = false
+        
+        return stackView
+    }()
+    
+    private let tagTitleLabel: TLLabel = TLLabel(
+        font: .body2,
+        text: .empty,
+        color: TLColor.lightGray
+    )
+    
+    private let cancelImageView: UIImageView = {
+        let imageView = UIImageView()
+        
+        imageView.image = TLImage.Tag.close
+        imageView.contentMode = .scaleToFill
+        imageView.isHidden = true
+        
+        return imageView
+    }()
+    
+    // MARK: - Properties
+    
+    override var isSelected: Bool {
+        didSet {
+            updateTagSelected()
+        }
+    }
+    
+    private var style: TLTagStyle
+    private let tagColor: UIColor
+    private let defaultColor: UIColor = TLColor.lightGray
+    private let defaultHeight: CGFloat = 34.0
+
+    // MARK: - Initialize
+    
+    init(
+        frame: CGRect = .zero,
+        style: TLTagStyle,
+        name: String,
+        color: UIColor
+    ) {
+        self.style = style
+        self.tagColor = color
+        tagTitleLabel.setText(to: name)
+        
+        super.init(frame: frame)
+        
+        setupAttributes()
+        setupLayout()
+        setupStyle()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Functions
+    
+    private func updateTagSelected() {
+        if isSelected {
+            tagTitleLabel.setColor(to: tagColor)
+            innerView.layer.borderColor = tagColor.cgColor
+            setupShadow()
+        } else {
+            tagTitleLabel.setColor(to: defaultColor)
+            innerView.layer.borderColor = defaultColor.cgColor
+            innerView.removeShadow()
+        }
+    }
+    
+}
+
+// MARK: - Setup Functions
+
+private extension TLTag {
+    func setupAttributes() {
+        [
+            innerView,
+            stackView,
+            tagTitleLabel,
+            cancelImageView
+        ].forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+        
+        layer.masksToBounds = false
+        innerView.layer.cornerRadius = defaultHeight / 2
+    }
+    
+    func setupLayout() {
+        addSubview(innerView)
+        innerView.addSubview(stackView)
+        [tagTitleLabel, cancelImageView].forEach {
+            stackView.addArrangedSubview($0)
+        }
+        
+        NSLayoutConstraint.activate([
+            innerView.topAnchor.constraint(equalTo: topAnchor),
+            innerView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            innerView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            innerView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            innerView.heightAnchor.constraint(equalToConstant: defaultHeight),
+            
+            stackView.topAnchor.constraint(equalTo: innerView.topAnchor, constant: style.verticalInset),
+            stackView.leadingAnchor.constraint(equalTo: innerView.leadingAnchor, constant: style.horizontalInset),
+            stackView.trailingAnchor.constraint(equalTo: innerView.trailingAnchor, constant: -style.horizontalInset),
+            stackView.bottomAnchor.constraint(equalTo: innerView.bottomAnchor, constant: -style.verticalInset),
+            
+            cancelImageView.heightAnchor.constraint(equalToConstant: 12.0),
+            cancelImageView.widthAnchor.constraint(equalTo: cancelImageView.heightAnchor)
+        ])
+    }
+    
+    func setupStyle() {
+        switch style {
+        case .normal:
+            isUserInteractionEnabled = false
+            setupShadow()
+        case .cancellable:
+            innerView.layer.borderColor = defaultColor.cgColor
+            cancelImageView.isHidden = false
+            setupShadow()
+        case .selectable:
+            tagTitleLabel.setColor(to: defaultColor)
+        }
+    }
+    
+    func setupShadow() {
+        innerView.addShadow(
+            xOffset: 0,
+            yOffset: 4,
+            blur: 4,
+            color: tagColor,
+            alpha: 0.5
+        )
+    }
+}

--- a/iOS/traveline/Sources/DesignSystem/Component/TLTag/TLTagStyle.swift
+++ b/iOS/traveline/Sources/DesignSystem/Component/TLTag/TLTagStyle.swift
@@ -15,6 +15,24 @@ enum TLTagStyle {
 }
 
 extension TLTagStyle {
+    var font: TLFont {
+        switch self {
+        case .normal, .cancellable:
+            return .caption
+        case .selectable:
+            return .body2
+        }
+    }
+    
+    var height: CGFloat {
+        switch self {
+        case .normal, .cancellable:
+            return 30.0
+        case .selectable:
+            return 34.0
+        }
+    }
+    
     var horizontalInset: CGFloat {
         switch self {
         case .normal, .selectable:

--- a/iOS/traveline/Sources/DesignSystem/Component/TLTag/TLTagStyle.swift
+++ b/iOS/traveline/Sources/DesignSystem/Component/TLTag/TLTagStyle.swift
@@ -1,0 +1,30 @@
+//
+//  TLTagStyle.swift
+//  traveline
+//
+//  Created by 김태현 on 2023/11/15.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+enum TLTagStyle {
+    case normal
+    case cancellable
+    case selectable
+}
+
+extension TLTagStyle {
+    var horizontalInset: CGFloat {
+        switch self {
+        case .normal, .selectable:
+            return 16.0
+        case .cancellable:
+            return 10.0
+        }
+    }
+    
+    var verticalInset: CGFloat {
+        return 8.0
+    }
+}

--- a/iOS/traveline/Sources/DesignSystem/TLColor.swift
+++ b/iOS/traveline/Sources/DesignSystem/TLColor.swift
@@ -12,6 +12,8 @@ enum TLColor {
     static let main = TravelineAsset.Colors.main.color
     static let lightMain = TravelineAsset.Colors.lightMain.color
     static let black = TravelineAsset.Colors.black.color
+    static let disabledGray = TravelineAsset.Colors.disabledGray.color
+    static let darkGray = TravelineAsset.Colors.darkGray.color
     static let gray = TravelineAsset.Colors.gray.color
     static let lightGray = TravelineAsset.Colors.lightGray.color
     static let white = TravelineAsset.Colors.white.color


### PR DESCRIPTION
## 🌎 PR 요약
- 재사용 가능한 `TLTag` 구현
- Extension 추가
- darkGray, disabledGray 추가
- TLLabel 수정

🌱 작업한 브랜치
- ios-feature/#20-TravelineTag

## 📚 작업한 내용
### 1. 재사용 가능한 `TLTag` 구현
~~~swift
let selectableTag = TLTag(
    style: .selectable,
    name: "선택 가능",
    color: TLColor.Tag.period
)
~~~
- 위와 같은 방법으로 Tag를 생성할 수 있습니다. 🙂
- **Style**은 아래 사진 순서대로 `normal`, `cancellable`, `selectable` 3가지가 있어요!
![스크린샷 2023-11-16 오후 1 15 25](https://github.com/boostcampwm2023/iOS07-traveline/assets/51712973/02e06081-857a-4c0a-be73-2e587611c1be)
- `selectable` 태그에서는 `isSelected` 프로퍼티를 토글하면 border와 그림자가 적용됩니다.
![스크린샷 2023-11-16 오후 1 16 42](https://github.com/boostcampwm2023/iOS07-traveline/assets/51712973/b93378c6-9029-434b-9eaa-30d9fd55f83e)

### 2. 그림자 생성, 제거 Extension 추가
- 피그마의 형식에 맞추어 그림자를 추가할 수 있도록 UIView+ Extension을 추가했습니다. 아래와 같이 사용하면 됩니다 😉
- 태그에서는 있던 그림자를 제거해야할 소요가 있었는데요, 그래서 `removeShadow()`도 UIView+에 구현해두었습니다!

<img width="238" alt="스크린샷 2023-11-16 오후 1 18 15" src="https://github.com/boostcampwm2023/iOS07-traveline/assets/51712973/c7da68a1-d84d-46a6-9209-186ba812b69d">

~~~swift
innerView.addShadow(
    xOffset: 0,
    yOffset: 4,
    blur: 4,
    color: TLColor.black,
    alpha: 0.25
)

innerView.removeShadow()
~~~
- `spread`는 기본값 0으로 넣어뒀고, 수정이 필요하면 필드에서 추가해 호출하시면 됩니당

### 3. TLLabel 수정
- `TLLabel`을 사용하면서, text 값이 변경되는 경우를 처리해줘야겠다는 생각이 들어 색상과 함께 외부에서 변경할 수 있는 `setText,` `setColor` 메서드를 열어주었습니다 😀
- 추가로, `empty string`을 문자열 `""` 하드코딩이 아니라 `.empty`로 사용하기 위해 String+에 empty를 선언해주었습니다.
~~~swift
let testLabel: TLLabel = TLLabel(
    font: .body2,
    text: .empty,
    color: TLColor.lightGray
)

testLabel.setText(to: "오류")
textLabel.setColor(to: TLColor.error)
~~~

### 4. 태그 별 font, height 수정 완료
- 태그 별 font, height가 다른 부분을 확인을 못했는데 영인님이 짚어주신 덕분에 수정할 수 있었습니다 👍
![스크린샷 2023-11-16 오후 2 02 46](https://github.com/boostcampwm2023/iOS07-traveline/assets/51712973/85358b22-816e-48bb-a9bf-a4fff4ebeb93)

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 기존에 투명도가 있던 배경 (`backgroundGray`) 대신 비슷한 색상인 `darkGray`를 추가해 적용해주었습니당
- 피그마 디자인 상에서는 태그의 `borderWidth`가 `0.5`로 되어있는데, 실제로 적용해보니 너무 얇고 얼룩덜룩(?)하게 나오는거 같아서 `1.0`으로 설정해두었습니다
- 이미 공유 드리긴했지만, 그림자 색상의 `alpha` 값도 `0.34`에서 `0.5`로 수정되어 적용된 상태입니다 :)
- UIView+ Extension에 `addSubviews` 메서드도 구현해두었으니 사용하시면 됩니다!!
## 📸 동작 영상
https://github.com/boostcampwm2023/iOS07-traveline/assets/51712973/1e16fec7-1c56-40e8-afaf-ec5c4277e13d


## 관련 이슈
- Resolved: #20 
