### PR TITLE
[feat] users API 구현

### DIFF
--- a/BE/src/app.controller.ts
+++ b/BE/src/app.controller.ts
@@ -1,12 +1,29 @@
-import { Controller, Get } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  UploadedFile,
+  UseInterceptors,
+} from '@nestjs/common';
 import { AppService } from './app.service';
+import { StorageService } from './storage/storage.service';
+import { FileInterceptor } from '@nestjs/platform-express';
 
 @Controller()
 export class AppController {
-  constructor(private readonly appService: AppService) {}
+  constructor(
+    private readonly appService: AppService,
+    private readonly storageService: StorageService
+  ) {}
 
   @Get()
   getHello(): string {
     return this.appService.getHello();
+  }
+
+  @Post('/upload')
+  @UseInterceptors(FileInterceptor('file'))
+  async upload(@UploadedFile() file: Express.Multer.File) {
+    return this.storageService.upload(file);
   }
 }

--- a/BE/src/app.module.ts
+++ b/BE/src/app.module.ts
@@ -7,6 +7,7 @@ import { TimelinesModule } from './timelines/timelines.module';
 import { AuthModule } from './auth/auth.module';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { DatabaseModule } from './database/database.module';
+import { StorageModule } from './storage/storage.module';
 
 @Module({
   imports: [
@@ -14,6 +15,7 @@ import { DatabaseModule } from './database/database.module';
       envFilePath: `.env`,
       isGlobal: true,
     }),
+    StorageModule,
     UsersModule,
     PostingsModule,
     TimelinesModule,

--- a/BE/src/auth/auth.module.ts
+++ b/BE/src/auth/auth.module.ts
@@ -3,10 +3,11 @@ import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { UsersModule } from 'src/users/users.module';
 import { UsersService } from 'src/users/users.service';
+import { StorageService } from 'src/storage/storage.service';
 
 @Module({
   imports: [UsersModule],
   controllers: [AuthController],
-  providers: [AuthService, UsersService],
+  providers: [AuthService, UsersService, StorageService],
 })
 export class AuthModule {}

--- a/BE/src/storage/storage.module.ts
+++ b/BE/src/storage/storage.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { StorageService } from './storage.service';
+
+@Module({
+  providers: [StorageService],
+  exports: [StorageService],
+})
+export class StorageModule {}

--- a/BE/src/storage/storage.service.ts
+++ b/BE/src/storage/storage.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+import { v4 as uuidv4 } from 'uuid';
+import * as AWS from 'aws-sdk';
+
+@Injectable()
+export class StorageService {
+  private readonly s3: AWS.S3 = new AWS.S3({
+    endpoint: 'https://kr.object.ncloudstorage.com',
+    region: process.env.AWS_REGION,
+    credentials: {
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+    },
+  });
+  private readonly bucketName = 'traveline';
+
+  private generateFilename(originalname: string) {
+    const extension = originalname.split('.').pop();
+    const uniqueId = uuidv4();
+    return `${uniqueId}.${extension}`;
+  }
+
+  async upload(file: Express.Multer.File) {
+    const uploadParams = {
+      Bucket: this.bucketName,
+      Key: this.generateFilename(file.originalname),
+      Body: file.buffer,
+      ACL: 'public-read',
+    };
+
+    const result = await this.s3.upload(uploadParams).promise();
+
+    return {
+      imageUrl: result.Location,
+    };
+  }
+}

--- a/BE/src/users/entities/user.entity.ts
+++ b/BE/src/users/entities/user.entity.ts
@@ -14,9 +14,6 @@ export class User {
   @Column({ length: 255, nullable: true })
   avatar: string;
 
-  @Column({ length: 50, unique: true })
-  email: string;
-
   @OneToMany(() => Liked, (liked) => liked.users)
   likeds: Liked[];
 

--- a/BE/src/users/users.controller.ts
+++ b/BE/src/users/users.controller.ts
@@ -1,9 +1,19 @@
-import { Controller, Get, Body, Param, Put, Query } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Body,
+  Param,
+  Put,
+  Query,
+  UseInterceptors,
+  UploadedFile,
+} from '@nestjs/common';
 import { User } from './entities/user.entity';
 import { UsersService } from './users.service';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { CheckDuplicatedNameResponseDto } from './dto/check-duplicated-name-response.dto';
+import { FileInterceptor } from '@nestjs/platform-express';
 
 @Controller('users')
 @ApiTags('Users API')
@@ -20,8 +30,10 @@ export class UsersController {
     type: User,
   })
   findOne(@Param('id') id: string) {
-    return this.usersService.findOne(id);
+    console.log(id);
+    return this.usersService.findById(id);
   }
+  //테스트 완료
 
   @Put(':id')
   @ApiOperation({
@@ -31,11 +43,17 @@ export class UsersController {
   @ApiOkResponse({
     description: 'OK',
   })
-  update(@Param('id') id: string, @Body() updateUserDto: UpdateUserDto) {
-    return this.usersService.update(id, updateUserDto);
+  @UseInterceptors(FileInterceptor('file'))
+  update(
+    @Param('id') id: string,
+    @Body() updateUserDto: UpdateUserDto,
+    @UploadedFile() file: Express.Multer.File
+  ) {
+    return this.usersService.update(id, updateUserDto, file);
   }
+  //클라이언트 측에서 프로필사진/이름 중 하나라도 변경사항이 있을 때만 요청을 보내야 한다.
 
-  @Get('duplicate')
+  @Get('duplicate/check')
   @ApiOperation({
     summary: 'name 중복 검사',
     description: 'name과 동일한 이름이 DB에 존재하는지 확인한다.',
@@ -45,10 +63,6 @@ export class UsersController {
     type: CheckDuplicatedNameResponseDto,
   })
   checkDuplicatedName(@Query('name') name: string) {
-    this.usersService.checkDuplicatedName(name).then((result) => {
-      return {
-        isDuplicated: result,
-      };
-    });
+    return this.usersService.checkDuplicatedName(name);
   }
 }

--- a/BE/src/users/users.controller.ts
+++ b/BE/src/users/users.controller.ts
@@ -20,7 +20,7 @@ export class UsersController {
     type: User,
   })
   findOne(@Param('id') id: string) {
-    return this.usersService.findOne(+id);
+    return this.usersService.findOne(id);
   }
 
   @Put(':id')
@@ -32,7 +32,7 @@ export class UsersController {
     description: 'OK',
   })
   update(@Param('id') id: string, @Body() updateUserDto: UpdateUserDto) {
-    return this.usersService.update(+id, updateUserDto);
+    return this.usersService.update(id, updateUserDto);
   }
 
   @Get('duplicate')
@@ -45,8 +45,10 @@ export class UsersController {
     type: CheckDuplicatedNameResponseDto,
   })
   checkDuplicatedName(@Query('name') name: string) {
-    return {
-      isDuplicated: false,
-    };
+    this.usersService.checkDuplicatedName(name).then((result) => {
+      return {
+        isDuplicated: result,
+      };
+    });
   }
 }

--- a/BE/src/users/users.module.ts
+++ b/BE/src/users/users.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from './entities/user.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([User])],
   controllers: [UsersController],
   providers: [UsersService],
 })

--- a/BE/src/users/users.module.ts
+++ b/BE/src/users/users.module.ts
@@ -1,12 +1,15 @@
 import { Module } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
-import { TypeOrmModule } from '@nestjs/typeorm';
-import { User } from './entities/user.entity';
+import { StorageService } from 'src/storage/storage.service';
+import { UserProvider } from './users.providers';
+import { UserRepository } from './users.repository';
+import { DatabaseModule } from 'src/database/database.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User])],
+  imports: [DatabaseModule],
   controllers: [UsersController],
-  providers: [UsersService],
+  providers: [UsersService, StorageService, ...UserProvider, UserRepository],
+  exports: [UserRepository, UsersService],
 })
 export class UsersModule {}

--- a/BE/src/users/users.providers.ts
+++ b/BE/src/users/users.providers.ts
@@ -1,0 +1,10 @@
+import { User } from './entities/user.entity';
+import { DataSource } from 'typeorm';
+
+export const UserProvider = [
+  {
+    provide: 'USER_REPOSITORY',
+    useFactory: (dataSource: DataSource) => dataSource.getRepository(User),
+    inject: ['DATA_SOURCE'],
+  },
+];

--- a/BE/src/users/users.repository.ts
+++ b/BE/src/users/users.repository.ts
@@ -1,0 +1,23 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { Repository, UpdateResult } from 'typeorm';
+import { User } from './entities/user.entity';
+import { UpdateUserDto } from './dto/update-user.dto';
+
+@Injectable()
+export class UserRepository {
+  constructor(
+    @Inject('USER_REPOSITORY')
+    private userRepository: Repository<User>
+  ) {}
+
+  update(id, updateUserDto: UpdateUserDto): Promise<UpdateResult> {
+    return this.userRepository.update({ id: id }, updateUserDto);
+  }
+  findById(id: string): Promise<User> {
+    return this.userRepository.findOne({ where: { id: id } });
+  }
+
+  findByName(name: string): Promise<User> {
+    return this.userRepository.findOne({ where: { name: name } });
+  }
+}

--- a/BE/src/users/users.service.ts
+++ b/BE/src/users/users.service.ts
@@ -1,40 +1,58 @@
-import { Injectable } from '@nestjs/common';
+import { HttpException, Injectable } from '@nestjs/common';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { CreateAuthDto } from 'src/auth/dto/create-auth.dto';
-import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
 import { User } from './entities/user.entity';
+import { StorageService } from 'src/storage/storage.service';
+import { UserRepository } from './users.repository';
+import { CheckDuplicatedNameResponseDto } from './dto/check-duplicated-name-response.dto';
 
 @Injectable()
 export class UsersService {
   constructor(
-    @InjectRepository(User) private userRepository: Repository<User>
-  ) {
-    this.userRepository = userRepository;
-  }
+    private userRepository: UserRepository,
+    private readonly storageService: StorageService
+  ) {}
 
   create(createAuthDto: CreateAuthDto) {
     return 'This action adds a new user';
   }
 
-  findOne(id: string): Promise<User> {
-    //가져온 이미지 정보로 이미지 url 전달
-    return this.userRepository.findOne({ where: { id: id } });
-  }
-
-  update(id: string, updateUserDto: UpdateUserDto) {
-    //이미지 업로드 작업
-    return this.userRepository.update({ id: id }, updateUserDto);
-  }
-
-  async checkDuplicatedName(name: string) {
-    const duplicatedUser = await this.userRepository.findOne({
-      where: { name: name },
-    });
-    if (duplicatedUser === undefined) {
-      return true;
+  async findById(id: string): Promise<User> {
+    const user = await this.userRepository.findById(id);
+    if (!user) {
+      throw new HttpException('Not Found', 404);
     }
-    return false;
+    const avatarPath = user.avatar;
+    user.avatar = await this.storageService.getImageUrl(avatarPath);
+    return user;
+  }
+
+  async update(
+    id: string,
+    updateUserDto: UpdateUserDto,
+    file: Express.Multer.File
+  ) {
+    if (file) {
+      const uploadResult = await this.storageService.upload('avatar/', file);
+      const path = uploadResult.path;
+      updateUserDto.avatar = path;
+    }
+    const updateResult = await this.userRepository.update(id, updateUserDto);
+    if (updateResult.affected == 0) {
+      throw new HttpException('Bad Request', 400);
+    }
+    const url = await this.storageService.getImageUrl(updateUserDto.avatar);
+    return { imageUrl: url };
+  }
+
+  async checkDuplicatedName(
+    name: string
+  ): Promise<CheckDuplicatedNameResponseDto> {
+    const duplicatedUser = await this.userRepository.findByName(name);
+    if (!duplicatedUser) {
+      return { isDuplicated: false };
+    }
+    return { isDuplicated: true };
   }
 
   remove(id: number) {

--- a/BE/src/users/users.service.ts
+++ b/BE/src/users/users.service.ts
@@ -1,6 +1,9 @@
 import { Injectable } from '@nestjs/common';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { CreateAuthDto } from 'src/auth/dto/create-auth.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from './entities/user.entity';
 
 @Injectable()
 export class UsersService {
@@ -14,16 +17,24 @@ export class UsersService {
     return 'This action adds a new user';
   }
 
-  findAll() {
-    return `This action returns all users`;
+  findOne(id: string): Promise<User> {
+    //가져온 이미지 정보로 이미지 url 전달
+    return this.userRepository.findOne({ where: { id: id } });
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} user`;
+  update(id: string, updateUserDto: UpdateUserDto) {
+    //이미지 업로드 작업
+    return this.userRepository.update({ id: id }, updateUserDto);
   }
 
-  update(id: number, updateUserDto: UpdateUserDto) {
-    return `This action updates a #${id} user`;
+  async checkDuplicatedName(name: string) {
+    const duplicatedUser = await this.userRepository.findOne({
+      where: { name: name },
+    });
+    if (duplicatedUser === undefined) {
+      return true;
+    }
+    return false;
   }
 
   remove(id: number) {

--- a/BE/src/users/users.service.ts
+++ b/BE/src/users/users.service.ts
@@ -4,6 +4,12 @@ import { CreateAuthDto } from 'src/auth/dto/create-auth.dto';
 
 @Injectable()
 export class UsersService {
+  constructor(
+    @InjectRepository(User) private userRepository: Repository<User>
+  ) {
+    this.userRepository = userRepository;
+  }
+
   create(createAuthDto: CreateAuthDto) {
     return 'This action adds a new user';
   }


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- feature/#27

## 📚 작업한 내용
- GET `users/:id` : 사용자의 프로필 사진과 닉네임 정보를 가져온다.
- PUT `users/:id` : 사용자의 프로필 사진 또는 닉네임을 수정한다.
- GET `users/duplicate/check`: 닉네임 변경 전에 중복 여부를 검사한다.

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 원래 닉네임 중복 체크 API는 GET `users/duplicate`였으나 GET `users/:id`와 충돌하는 문제가 있어 (duplicate를 id값의 일종으로 인식해버림) 임시로 GET `users/duplicate/check`로 수정해두었습니다! 혹시 더 괜찮은 URI가 있다면 리뷰로 남겨주세요 😄 
- `Storage Module`관련해서 아침에 말씀드린 건 다른 pr로 따로 뺄까 싶어서 이 pr에는 커밋 안했어요!

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 관련 이슈
- close #27 
