### PR TITLE
[feat] 세팅 뷰 UI 작성

### DIFF
--- a/iOS/traveline/Sources/Feature/MyPageFeature/SettingScene/VC/SettingVC.swift
+++ b/iOS/traveline/Sources/Feature/MyPageFeature/SettingScene/VC/SettingVC.swift
@@ -1,0 +1,179 @@
+//
+//  SettingVC.swift
+//  traveline
+//
+//  Created by KiWoong Hong on 2023/11/20.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import SafariServices
+import UIKit
+
+enum ServiceGuideType: String, CaseIterable {
+    case license = "라이센스"
+    case termsOfUse = "이용약관"
+    case privacyPolicy = "개인정보 처리방침"
+    
+    var link: String {
+        switch self {
+        case .license: return "https://www.apple.com"
+        case .termsOfUse: return "https://www.naver.com"
+        case .privacyPolicy: return "https://www.daum.net"
+        }
+    }
+    
+    func button() -> UIButton {
+        let button = UIButton()
+        button.setTitle(self.rawValue, for: .normal)
+        button.setTitleColor(TLColor.white, for: .normal)
+        
+        return button
+    }
+    
+}
+
+// MARK: - Setting VC
+
+final class SettingVC: UIViewController {
+    // MARK: - UI Components
+    private let lineWidth: CGFloat = 1
+    
+    let stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        stackView.distribution = .fill
+        stackView.alignment = .leading
+        stackView.spacing = 12
+        return stackView
+    }()
+    
+    let serviceGuides: [ServiceGuideType: UIButton] = {
+        return ServiceGuideType.allCases.reduce(into: [:]) { result, key in
+            result[key] = key.button()
+        }
+    }()
+    
+    let line: UIView = {
+        let line = UIView()
+        line.backgroundColor = TLColor.lineGray
+        return line
+    }()
+    
+    let logoutButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("로그아웃", for: .normal)
+        button.setTitleColor(TLColor.white, for: .normal)
+        return button
+    }()
+    
+    let withdrawalButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("탈퇴하기", for: .normal)
+        button.setTitleColor(TLColor.white, for: .normal)
+        return button
+    }()
+    
+    // MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setupAttributes()
+        setupLayout()
+    }
+    
+    // MARK: - Functions
+    
+    @objc private func logoutButtonTapped() {
+        showLogoutAlert()
+    }
+    
+    @objc private func withdrawalButtonTapped() {
+        showWithdrawalAlert()
+    }
+    
+    private func showLogoutAlert() {
+        let alert = TLAlertController(
+            title: "로그아웃",
+            message: "정말 로그아웃하시겠습니까?",
+            preferredStyle: .alert
+        )
+        let cancel = UIAlertAction(title: "취소", style: .cancel)
+        let logout = UIAlertAction(title: "로그아웃", style: .destructive) { _ in
+            // logout action
+        }
+        
+        alert.addActions([cancel, logout])
+        
+        present(alert, animated: true, completion: nil)
+    }
+    
+    private func showWithdrawalAlert() {
+        let alert = TLAlertController(
+            title: "정말 탈퇴하시겠습니까?",
+            message: "작성한 글들을 다시 볼 수 없습니다.",
+            preferredStyle: .alert
+        )
+        let cancel = UIAlertAction(title: "취소", style: .default)
+        let withdrawal = UIAlertAction(title: "탈퇴하기", style: .destructive) { _ in
+            // withdrawal action
+        }
+        
+        alert.addActions([withdrawal, cancel])
+        cancel.setValue(TLColor.gray, forKey: "titleTextColor")
+        
+        present(alert, animated: true, completion: nil)
+    }
+}
+
+// MARK: - Setup Functions
+
+extension SettingVC {
+    
+    private func setupAttributes() {
+        self.navigationItem.title = "설정"
+        logoutButton.addTarget(self, action: #selector(logoutButtonTapped), for: .touchUpInside)
+        withdrawalButton.addTarget(self, action: #selector(withdrawalButtonTapped), for: .touchUpInside)
+        setupServiceGuideButton()
+    }
+    
+    private func setupServiceGuideButton() {
+        serviceGuides.forEach { type, button in
+            let action = UIAction(handler: { _ in
+                guard let url = URL(string: type.link) else { return }
+                guard UIApplication.shared.canOpenURL(url) else { return }
+                
+                let safariVC = SFSafariViewController(url: url)
+                self.present(safariVC, animated: true)
+            })
+            button.addAction(action, for: .touchUpInside)
+        }
+    }
+    
+    private func setupLayout() {
+        view.addSubview(stackView)
+        [
+            serviceGuides[.license] ?? UIButton(),
+            serviceGuides[.termsOfUse] ?? UIButton(),
+            serviceGuides[.privacyPolicy] ?? UIButton(),
+            line,
+            logoutButton,
+            withdrawalButton
+        ].forEach {
+            stackView.addArrangedSubview($0)
+        }
+        
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 32),
+            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
+            stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            
+            line.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            line.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            line.heightAnchor.constraint(equalToConstant: lineWidth)
+        ])
+    }
+    
+}
+

--- a/iOS/traveline/Sources/Feature/MyPageFeature/SettingScene/VC/SettingVC.swift
+++ b/iOS/traveline/Sources/Feature/MyPageFeature/SettingScene/VC/SettingVC.swift
@@ -26,6 +26,7 @@ enum ServiceGuideType: String, CaseIterable {
         let button = UIButton()
         button.setTitle(self.rawValue, for: .normal)
         button.setTitleColor(TLColor.white, for: .normal)
+        button.titleLabel?.font = TLFont.subtitle2.font
         
         return button
     }
@@ -35,10 +36,12 @@ enum ServiceGuideType: String, CaseIterable {
 // MARK: - Setting VC
 
 final class SettingVC: UIViewController {
+    
     // MARK: - UI Components
+    
     private let lineWidth: CGFloat = 1
     
-    let stackView: UIStackView = {
+    private let stackView: UIStackView = {
         let stackView = UIStackView()
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .vertical
@@ -48,29 +51,31 @@ final class SettingVC: UIViewController {
         return stackView
     }()
     
-    let serviceGuides: [ServiceGuideType: UIButton] = {
+    private let serviceGuides: [ServiceGuideType: UIButton] = {
         return ServiceGuideType.allCases.reduce(into: [:]) { result, key in
             result[key] = key.button()
         }
     }()
     
-    let line: UIView = {
+    private let line: UIView = {
         let line = UIView()
         line.backgroundColor = TLColor.lineGray
         return line
     }()
     
-    let logoutButton: UIButton = {
+    private let logoutButton: UIButton = {
         let button = UIButton()
         button.setTitle("로그아웃", for: .normal)
         button.setTitleColor(TLColor.white, for: .normal)
+        button.titleLabel?.font = TLFont.subtitle2.font
         return button
     }()
     
-    let withdrawalButton: UIButton = {
+    private let withdrawalButton: UIButton = {
         let button = UIButton()
         button.setTitle("탈퇴하기", for: .normal)
         button.setTitleColor(TLColor.white, for: .normal)
+        button.titleLabel?.font = TLFont.subtitle2.font
         return button
     }()
     
@@ -140,9 +145,10 @@ extension SettingVC {
     
     private func setupServiceGuideButton() {
         serviceGuides.forEach { type, button in
-            let action = UIAction(handler: { _ in
-                guard let url = URL(string: type.link) else { return }
-                guard UIApplication.shared.canOpenURL(url) else { return }
+            let action = UIAction(handler: { [weak self] _ in
+                guard let url = URL(string: type.link),
+                      UIApplication.shared.canOpenURL(url),
+                      let self = self else { return }
                 
                 let safariVC = SFSafariViewController(url: url)
                 self.present(safariVC, animated: true)


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- feature/#49

## 📚 작업한 내용
세팅 뷰 UI를 구현.
서비스 지침 관련 웹뷰 링크 연결.
로그아웃이나 탈퇴 시 알람창 UI 연결.

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
서비스 지침 관련은 추후에 작성이 되면 노션이나 다른 링크를 통해 웹뷰로 연결할 예정이라 지금은 임시로 다른 웹페이지를 넣어두었습니다.
접근할 수 없는 url은 런타임에러가 발생해서 웹뷰 연결을 막아두었습니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|세팅 뷰 UI|<image src=https://github.com/boostcampwm2023/iOS07-traveline/assets/91725382/bae49c54-fa57-4130-9b6c-e8a51618e2fd width=300>| 

## 관련 이슈
- Resolved: #49
