### PR TITLE
[feat] 타임라인 상세 뷰 UI

### DIFF
--- a/iOS/traveline/Sources/DesignSystem/Component/TLImageLabel.swift
+++ b/iOS/traveline/Sources/DesignSystem/Component/TLImageLabel.swift
@@ -1,0 +1,90 @@
+//
+//  TLImageLabel.swift
+//  traveline
+//
+//  Created by KiWoong Hong on 2023/11/22.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import UIKit
+
+final class TLImageLabel: UIView {
+    
+    private enum Constants {
+        static let spacing: CGFloat = 4.0
+    }
+    
+    // MARK: - UI Components
+    
+    private let imageView: UIImageView = {
+        let imageView = UIImageView()
+        
+        return imageView
+    }()
+    
+    private let label: TLLabel = {
+        let label = TLLabel(font: TLFont.subtitle2, color: TLColor.white)
+        
+        return label
+    }()
+
+    // MARK: - Initialize
+    
+    init(image: UIImage? = nil, text: String = "") {
+        super.init(frame: .zero)
+        
+        label.setText(to: text)
+        imageView.image = image
+        setupAttributes()
+        setupLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Functions
+    
+    func setText(to text: String) {
+        label.setText(to: text)
+    }
+    
+    func setImage(to image: UIImage) {
+        imageView.image = image
+    }
+    
+}
+
+// MARK: - Setup Functions
+
+private extension TLImageLabel {
+    func setupAttributes() {
+        backgroundColor = .clear
+    }
+    
+    func setupLayout() {
+        addSubviews(
+            imageView,
+            label
+        )
+        
+        subviews.forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+        
+        NSLayoutConstraint.activate([
+            imageView.topAnchor.constraint(equalTo: topAnchor),
+            imageView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            imageView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            imageView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            
+            label.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: Constants.spacing),
+            label.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ])
+    }
+}
+
+@available(iOS 17, *)
+#Preview {
+    TLImageLabel(image: TLImage.Travel.time, text: "오후 02:00")
+}

--- a/iOS/traveline/Sources/DesignSystem/Component/TLImageLabel.swift
+++ b/iOS/traveline/Sources/DesignSystem/Component/TLImageLabel.swift
@@ -16,18 +16,13 @@ final class TLImageLabel: UIView {
     
     // MARK: - UI Components
     
-    private let imageView: UIImageView = {
-        let imageView = UIImageView()
-        
-        return imageView
-    }()
+    private let imageView: UIImageView = .init()
     
-    private let label: TLLabel = {
-        let label = TLLabel(font: TLFont.subtitle2, color: TLColor.white)
-        
-        return label
-    }()
-
+    private let label: TLLabel = .init(
+        font: TLFont.subtitle2,
+        color: TLColor.white
+    )
+    
     // MARK: - Initialize
     
     init(image: UIImage? = nil, text: String = "") {

--- a/iOS/traveline/Sources/Domain/Model/TimelineDetailInfo.swift
+++ b/iOS/traveline/Sources/Domain/Model/TimelineDetailInfo.swift
@@ -1,0 +1,24 @@
+//
+//  TimelineDetail.swift
+//  traveline
+//
+//  Created by KiWoong Hong on 2023/11/22.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+struct TimelineDetailInfo: Hashable {
+    let id: String
+    let day: String
+    let title: String
+    let date: String
+    let time: String
+    let location: String
+    let content: String
+    let imageURL: String
+    
+    static func == (lhs: TimelineDetailInfo, rhs: TimelineDetailInfo) -> Bool {
+        lhs.id == rhs.id
+    }
+}

--- a/iOS/traveline/Sources/Feature/TimelineDetailFeature/TimelineDtailScene/VC/TimelineDetailVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineDetailFeature/TimelineDtailScene/VC/TimelineDetailVC.swift
@@ -48,8 +48,6 @@ final class TimelineDetailVC: UIViewController {
     private let contentView: TLLabel = {
         let view = TLLabel(font: TLFont.body1, color: TLColor.white)
         view.numberOfLines = 0
-        view.tintColor = TLColor.white
-        view.font = TLFont.body1.font
         
         return view
     }()
@@ -91,7 +89,7 @@ final class TimelineDetailVC: UIViewController {
     
     // MARK: - Functions
     
-    private func ascpectRatio(from image: UIImage) -> CGFloat {
+    private func aspectRatio(from image: UIImage) -> CGFloat {
         return image.size.width / image.size.height
     }
     
@@ -141,7 +139,7 @@ private extension TimelineDetailVC {
             imageView.trailingAnchor.constraint(equalTo: stackView.trailingAnchor),
             imageView.heightAnchor.constraint(
                 equalTo: imageView.widthAnchor,
-                multiplier: 1.0 / ascpectRatio(from: imageView.image ?? UIImage())
+                multiplier: 1.0 / aspectRatio(from: imageView.image ?? UIImage())
             )
         ])
         

--- a/iOS/traveline/Sources/Feature/TimelineDetailFeature/TimelineDtailScene/VC/TimelineDetailVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineDetailFeature/TimelineDtailScene/VC/TimelineDetailVC.swift
@@ -1,0 +1,181 @@
+//
+//  TimelineDetailVC.swift
+//  traveline
+//
+//  Created by KiWoong Hong on 2023/11/21.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import UIKit
+
+final class TimelineDetailVC: UIViewController {
+    
+    private enum Metric {
+        static let topInset: CGFloat = 24
+        static let margin: CGFloat = 16
+        static let spacing: CGFloat = 20
+        static let aboveLine: CGFloat = 12
+        static let belowLine: CGFloat = 4
+    }
+    
+    // MARK: - UI Components
+    
+    private let scrollView: UIScrollView = {
+        let view = UIScrollView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        
+        return view
+    }()
+    
+    private let stackView: UIStackView = {
+        let view = UIStackView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.axis = .vertical
+        view.spacing = Metric.spacing
+        
+        return view
+    }()
+    
+    private let titleLabel: TLLabel = {
+        let label = TLLabel(font: TLFont.heading1, color: TLColor.white)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.setText(to: "광안리 짱")
+        
+        return label
+    }()
+    
+    private let line: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = TLColor.lineGray
+        return view
+    }()
+    
+    private let dateLabel: TLLabel = {
+        let label = TLLabel(font: TLFont.body2, color: TLColor.gray)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.setText(to: "2023년 11월 9일")
+        
+        return label
+    }()
+    
+    private let timeLabel: TLImageLabel = {
+        let label = TLImageLabel(image: TLImage.Travel.time, text: "오전 02:00")
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        return label
+    }()
+    
+    private let locationLabel: TLImageLabel = {
+        let label = TLImageLabel(image: TLImage.Travel.location, text: "부산 광안리 해수욕장")
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        return label
+    }()
+    
+    private let imageView: UIImageView = {
+        let view = UIImageView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.contentMode = .scaleAspectFill
+        view.image = UIImage(systemName: "leaf")
+        
+        return view
+    }()
+    
+    private let contentView: TLLabel = {
+        let view = TLLabel(font: TLFont.body1, color: TLColor.white)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.numberOfLines = 0
+        view.tintColor = TLColor.white
+        view.font = TLFont.body1.font
+        view.text = "광안리 짱짱맨"
+        
+        return view
+    }()
+    
+    // MARK: - Properties
+    
+    // MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setupAttributes()
+        setupLayout()
+    }
+    
+    // MARK: - Functions
+    
+    private func ascpectRatio(from image: UIImage) -> CGFloat {
+        return image.size.width / image.size.height
+    }
+    
+}
+
+// MARK: - Setup Functions
+
+private extension TimelineDetailVC {
+    
+    private func setupAttributes() {
+        self.navigationItem.title = "Day01"
+        view.backgroundColor = TLColor.black
+    }
+    
+    private func setupLayout() {
+        view.addSubview(scrollView)
+        scrollView.addSubview(stackView)
+        stackView.addArrangedSubviews(
+            titleLabel,
+            line,
+            dateLabel,
+            timeLabel,
+            locationLabel,
+            imageView,
+            contentView
+        )
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.arrangedSubviews.forEach { 
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+        
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.layoutMarginsGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.layoutMarginsGuide.bottomAnchor),
+            
+            stackView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+            stackView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
+            stackView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
+            stackView.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor),
+            
+            titleLabel.topAnchor.constraint(equalTo: stackView.topAnchor, constant: Metric.topInset),
+            line.heightAnchor.constraint(equalToConstant: 1),
+            imageView.leadingAnchor.constraint(equalTo: stackView.leadingAnchor),
+            imageView.trailingAnchor.constraint(equalTo: stackView.trailingAnchor),
+            imageView.heightAnchor.constraint(
+                equalTo: imageView.widthAnchor,
+                multiplier: 1.0 / ascpectRatio(from: imageView.image ?? UIImage())
+            )
+        ])
+        
+        stackView.arrangedSubviews.forEach {
+            guard $0 != imageView else { return }
+            $0.leadingAnchor.constraint(equalTo: stackView.leadingAnchor, constant: Metric.margin).isActive = true
+            $0.trailingAnchor.constraint(equalTo: stackView.trailingAnchor, constant: -Metric.margin).isActive = true
+        }
+        
+        stackView.setCustomSpacing(Metric.aboveLine, after: titleLabel)
+        stackView.setCustomSpacing(Metric.belowLine, after: line)
+        
+    }
+}
+
+@available(iOS 17, *)
+#Preview("TimelineDetailVC") {
+    let timelineDetailVC = TimelineDetailVC()
+    let homeNV = UINavigationController(rootViewController: timelineDetailVC)
+    return homeNV
+}

--- a/iOS/traveline/Sources/Feature/TimelineDetailFeature/TimelineDtailScene/VC/TimelineDetailVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineDetailFeature/TimelineDtailScene/VC/TimelineDetailVC.swift
@@ -20,16 +20,10 @@ final class TimelineDetailVC: UIViewController {
     
     // MARK: - UI Components
     
-    private let scrollView: UIScrollView = {
-        let view = UIScrollView()
-        view.translatesAutoresizingMaskIntoConstraints = false
-        
-        return view
-    }()
+    private let scrollView: UIScrollView = .init()
     
     private let stackView: UIStackView = {
         let view = UIStackView()
-        view.translatesAutoresizingMaskIntoConstraints = false
         view.axis = .vertical
         view.spacing = Metric.spacing
         
@@ -38,7 +32,6 @@ final class TimelineDetailVC: UIViewController {
     
     private let titleLabel: TLLabel = {
         let label = TLLabel(font: TLFont.heading1, color: TLColor.white)
-        label.translatesAutoresizingMaskIntoConstraints = false
         label.setText(to: "광안리 짱")
         
         return label
@@ -46,14 +39,13 @@ final class TimelineDetailVC: UIViewController {
     
     private let line: UIView = {
         let view = UIView()
-        view.translatesAutoresizingMaskIntoConstraints = false
         view.backgroundColor = TLColor.lineGray
+        
         return view
     }()
     
     private let dateLabel: TLLabel = {
         let label = TLLabel(font: TLFont.body2, color: TLColor.gray)
-        label.translatesAutoresizingMaskIntoConstraints = false
         label.setText(to: "2023년 11월 9일")
         
         return label
@@ -61,21 +53,18 @@ final class TimelineDetailVC: UIViewController {
     
     private let timeLabel: TLImageLabel = {
         let label = TLImageLabel(image: TLImage.Travel.time, text: "오전 02:00")
-        label.translatesAutoresizingMaskIntoConstraints = false
         
         return label
     }()
     
     private let locationLabel: TLImageLabel = {
         let label = TLImageLabel(image: TLImage.Travel.location, text: "부산 광안리 해수욕장")
-        label.translatesAutoresizingMaskIntoConstraints = false
         
         return label
     }()
     
     private let imageView: UIImageView = {
         let view = UIImageView()
-        view.translatesAutoresizingMaskIntoConstraints = false
         view.contentMode = .scaleAspectFill
         view.image = UIImage(systemName: "leaf")
         
@@ -84,7 +73,6 @@ final class TimelineDetailVC: UIViewController {
     
     private let contentView: TLLabel = {
         let view = TLLabel(font: TLFont.body1, color: TLColor.white)
-        view.translatesAutoresizingMaskIntoConstraints = false
         view.numberOfLines = 0
         view.tintColor = TLColor.white
         view.font = TLFont.body1.font
@@ -116,12 +104,12 @@ final class TimelineDetailVC: UIViewController {
 
 private extension TimelineDetailVC {
     
-    private func setupAttributes() {
+    func setupAttributes() {
         self.navigationItem.title = "Day01"
         view.backgroundColor = TLColor.black
     }
     
-    private func setupLayout() {
+    func setupLayout() {
         view.addSubview(scrollView)
         scrollView.addSubview(stackView)
         stackView.addArrangedSubviews(

--- a/iOS/traveline/Sources/Feature/TimelineDetailFeature/TimelineDtailScene/VC/TimelineDetailVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineDetailFeature/TimelineDtailScene/VC/TimelineDetailVC.swift
@@ -30,12 +30,6 @@ final class TimelineDetailVC: UIViewController {
         return view
     }()
     
-    private let titleLabel: TLLabel = {
-        let label = TLLabel(font: TLFont.heading1, color: TLColor.white)
-        label.setText(to: "광안리 짱")
-        
-        return label
-    }()
     
     private let line: UIView = {
         let view = UIView()
@@ -44,29 +38,9 @@ final class TimelineDetailVC: UIViewController {
         return view
     }()
     
-    private let dateLabel: TLLabel = {
-        let label = TLLabel(font: TLFont.body2, color: TLColor.gray)
-        label.setText(to: "2023년 11월 9일")
-        
-        return label
-    }()
-    
-    private let timeLabel: TLImageLabel = {
-        let label = TLImageLabel(image: TLImage.Travel.time, text: "오전 02:00")
-        
-        return label
-    }()
-    
-    private let locationLabel: TLImageLabel = {
-        let label = TLImageLabel(image: TLImage.Travel.location, text: "부산 광안리 해수욕장")
-        
-        return label
-    }()
-    
     private let imageView: UIImageView = {
         let view = UIImageView()
         view.contentMode = .scaleAspectFill
-        view.image = UIImage(systemName: "leaf")
         
         return view
     }()
@@ -76,20 +50,43 @@ final class TimelineDetailVC: UIViewController {
         view.numberOfLines = 0
         view.tintColor = TLColor.white
         view.font = TLFont.body1.font
-        view.text = "광안리 짱짱맨"
         
         return view
     }()
     
-    // MARK: - Properties
+    private let titleLabel: TLLabel = .init(font: TLFont.heading1, color: TLColor.white)
+    private let dateLabel: TLLabel = .init(font: TLFont.body2, color: TLColor.gray)
+    private let timeLabel: TLImageLabel = .init(image: TLImage.Travel.time)
+    private let locationLabel: TLImageLabel = .init(image: TLImage.Travel.location)
+    
+    // MARK: - Initialize
+    
+    init(info: TimelineDetailInfo) {
+        super.init(nibName: nil, bundle: nil)
+        
+        initInfo(from: info)
+        setupAttributes()
+        setupLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func initInfo(from info: TimelineDetailInfo) {
+        self.navigationItem.title = info.day
+        titleLabel.setText(to: info.title)
+        dateLabel.setText(to: info.date)
+        timeLabel.setText(to: info.time)
+        locationLabel.setText(to: info.location)
+        imageView.image = UIImage(systemName: "leaf")
+        contentView.setText(to: info.content)
+    }
     
     // MARK: - Life Cycle
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        setupAttributes()
-        setupLayout()
     }
     
     // MARK: - Functions
@@ -105,7 +102,6 @@ final class TimelineDetailVC: UIViewController {
 private extension TimelineDetailVC {
     
     func setupAttributes() {
-        self.navigationItem.title = "Day01"
         view.backgroundColor = TLColor.black
     }
     
@@ -163,7 +159,17 @@ private extension TimelineDetailVC {
 
 @available(iOS 17, *)
 #Preview("TimelineDetailVC") {
-    let timelineDetailVC = TimelineDetailVC()
+    let info = TimelineDetailInfo(
+        id: "a1b2c3d4",
+        day: "day02",
+        title: "광안리 짱",
+        date: "2023년 12월 15일",
+        time: "오후 02:00",
+        location: "부산 광안리 해수욕장",
+        content: "광안리 짱짱맨",
+        imageURL: "http://sigan.nermoo.bballa"
+    )
+    let timelineDetailVC = TimelineDetailVC(info: info)
     let homeNV = UINavigationController(rootViewController: timelineDetailVC)
     return homeNV
 }

--- a/iOS/traveline/Sources/Feature/TimelineDetailFeature/TimelineDtailScene/VC/TimelineDetailVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineDetailFeature/TimelineDtailScene/VC/TimelineDetailVC.swift
@@ -81,12 +81,6 @@ final class TimelineDetailVC: UIViewController {
         contentView.setText(to: info.content)
     }
     
-    // MARK: - Life Cycle
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
-    }
-    
     // MARK: - Functions
     
     private func aspectRatio(from image: UIImage) -> CGFloat {


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- feature/#79

## 📚 작업한 내용
- 재사용 이미지라벨 작성
- 타임라인 상세 뷰 UI 작성

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 재사용 이미지라벨을 만들었어요. 제가 만들 다른 뷰에서도 재사용을 여러번할 것 같아서 따로 TLImageLabel로 만들었습니다.
  - 스크린샷은 아래 첨부하였고, 들어가는 이미지와 텍스트를 변경할 수 있습니다.
- 타임라인 상세 뷰의 사진 이미지를 원본 비율에 맞춰서 보여지도록 했습니다. 정방형에서 크롭할껀지 정확히 확정이 안됐어서 우선 이렇게 진행했습니다. 변동 사항있으면 리뷰 남겨주세요 :)
- 타임라인 내용이 길어지면 스크롤이 가능하게 스크롤뷰로 작업했습니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|재사용 이미지라벨|<image src="https://github.com/boostcampwm2023/iOS07-traveline/assets/91725382/5053ace2-730f-493e-831e-40d107c716a7" width = 100>|
|타임라인 상세 뷰 UI|<image src=https://github.com/boostcampwm2023/iOS07-traveline/assets/91725382/26ef9878-1409-4dd3-89a5-a3b963886666 width = 300>|

## 관련 이슈
- Resolved: #79 
