### PR TITLE
[refactor] 좋아요에 is_deleted 필드 추가, on delete/update 정책 수정

### DIFF
--- a/BE/src/postings/entities/liked.entity.ts
+++ b/BE/src/postings/entities/liked.entity.ts
@@ -1,6 +1,6 @@
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
 import { User } from 'src/users/entities/user.entity';
 import { Posting } from './posting.entity';
-import { Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
 
 @Entity()
 export class Liked {
@@ -10,16 +10,17 @@ export class Liked {
   @PrimaryColumn({ type: 'char', length: 36 })
   posting: string;
 
+  @Column({ name: 'is_deleted', type: 'bool', default: false })
+  isDeleted: boolean;
+
   @ManyToOne(() => User, (user) => user.likeds, {
     onDelete: 'CASCADE',
-    onUpdate: 'CASCADE',
   })
   @JoinColumn({ name: 'user', referencedColumnName: 'id' })
   users: User;
 
   @ManyToOne(() => Posting, (posting) => posting.likeds, {
     onDelete: 'CASCADE',
-    onUpdate: 'CASCADE',
   })
   @JoinColumn({ name: 'posting', referencedColumnName: 'id' })
   postings: Posting;

--- a/BE/src/postings/entities/posting.entity.ts
+++ b/BE/src/postings/entities/posting.entity.ts
@@ -70,7 +70,7 @@ export class Posting {
   report: { reporter: string; posting: string }[];
 
   @ManyToOne(() => User, (user) => user.postings, {
-    onDelete: 'SET NULL',
+    onDelete: 'CASCADE',
     onUpdate: 'CASCADE',
   })
   @JoinColumn({ name: 'writer', referencedColumnName: 'id' })

--- a/BE/src/postings/entities/report.entity.ts
+++ b/BE/src/postings/entities/report.entity.ts
@@ -1,5 +1,5 @@
-import { User } from 'src/users/entities/user.entity';
 import { Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
+import { User } from 'src/users/entities/user.entity';
 import { Posting } from './posting.entity';
 
 @Entity()
@@ -12,14 +12,12 @@ export class Report {
 
   @ManyToOne(() => User, (user) => user.reports, {
     onDelete: 'CASCADE',
-    onUpdate: 'CASCADE',
   })
   @JoinColumn({ name: 'reporter', referencedColumnName: 'id' })
   reporters: User;
 
   @ManyToOne(() => Posting, (posting) => posting.reports, {
     onDelete: 'CASCADE',
-    onUpdate: 'CASCADE',
   })
   @JoinColumn({ name: 'posting', referencedColumnName: 'id' })
   postings: Posting;


### PR DESCRIPTION
좋아요 직접 삭제 시엔 soft delete로, 회원 탈퇴나 게시글 삭제 시엔 좋아요 hard delete로 설정했다.

## 🌎 PR 요약

🌱 작업한 브랜치
- be-feature/#56-add-column

## 📚 작업한 내용
- 좋아요에 is_deleted 필드 추가 (좋아요 취소 시 soft delete)
- 회원/게시글 삭제 시 좋아요/신고 기록도 삭제되도록 설정

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- MySQL에서 onUpdate의 디폴트가 `CASCADE`라서 그냥 지워버렸어요 ㅎㅎ 괜한 코드가 1줄 느는 것 같아서요!

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 관련 이슈
- close #56
