### PR TITLE
[feat] 타임라인 - 여행 정보 UI 구현

### DIFF
--- a/iOS/traveline/Sources/Core/Extension/UICollectionView+.swift
+++ b/iOS/traveline/Sources/Core/Extension/UICollectionView+.swift
@@ -1,0 +1,53 @@
+//
+//  UICollectionView+.swift
+//  traveline
+//
+//  Created by 김태현 on 11/22/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import UIKit
+
+extension UICollectionView {
+    /// UICollectionViewCell 등록
+    func register<T: UICollectionViewCell>(cell: T.Type) {
+        let identifier = String(describing: cell)
+        register(cell, forCellWithReuseIdentifier: identifier)
+    }
+    
+    /// UICollectionView Header 등록
+    func registerHeader<T: UICollectionReusableView>(view: T.Type) {
+        let identifier = String(describing: view)
+        register(
+            view,
+            forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
+            withReuseIdentifier: identifier
+        )
+    }
+    
+    /// 재사용 Cell dequeue
+    func dequeue<T: UICollectionViewCell>(cell: T.Type, for indexPath: IndexPath) -> T {
+        let identifier = String(describing: cell)
+        guard let cell = dequeueReusableCell(
+            withReuseIdentifier: identifier,
+            for: indexPath
+        ) as? T else {
+            fatalError("등록되지 않은 \(cell)입니다.")
+        }
+        return cell
+    }
+    
+    /// 재사용 Header View dequeue
+    func dequeHeader<T: UICollectionReusableView>(view: T.Type, for indexPath: IndexPath) -> T {
+        let identifier = String(describing: view)
+        guard let view = dequeueReusableSupplementaryView(
+            ofKind: UICollectionView.elementKindSectionHeader,
+            withReuseIdentifier: identifier,
+            for: indexPath
+        ) as? T else {
+            fatalError("등록되지 않은 \(view)입니다.")
+        }
+        return view
+    }
+}
+

--- a/iOS/traveline/Sources/DesignSystem/View/TLTagList/TLTagListView.swift
+++ b/iOS/traveline/Sources/DesignSystem/View/TLTagList/TLTagListView.swift
@@ -90,10 +90,10 @@ final class TLTagListView: UIView {
     }
     
     /// TLTagListView 생성 후 Tag를 추가할 때
-    func setTags(_ tags: [Tag]) {
+    func setTags(_ tags: [Tag], style: TLTagStyle) {
         tags.forEach { tag in
             let tlTag: TLTag = .init(
-                style: .normal,
+                style: style,
                 name: tag.title,
                 color: tag.type.color
             )

--- a/iOS/traveline/Sources/DesignSystem/View/TLTagList/TLTagListView.swift
+++ b/iOS/traveline/Sources/DesignSystem/View/TLTagList/TLTagListView.swift
@@ -40,7 +40,6 @@ final class TLTagListView: UIView {
     
     // MARK: - Properties
     
-    private let tagType: TagType
     private var detailTagList: [TLTag] = .init()
     private lazy var currentStackView: UIStackView = tagStackView
     
@@ -50,14 +49,22 @@ final class TLTagListView: UIView {
     // MARK: - Initializer
     
     init(tagType: TagType, width: CGFloat) {
-        self.tagType = tagType
         self.limitWidth = width
         
         super.init(frame: .zero)
         
         setupAttributes()
         setupLayout()
-        setupTags()
+        setupTags(type: tagType)
+    }
+    
+    init(width: CGFloat) {
+        self.limitWidth = width
+        
+        super.init(frame: .zero)
+        
+        setupAttributes()
+        setupLayout()
     }
     
     required init?(coder: NSCoder) {
@@ -80,6 +87,25 @@ final class TLTagListView: UIView {
     
     @objc private func selectTag(_ sender: TLTag) {
         sender.isSelected.toggle()
+    }
+    
+    /// TLTagListView 생성 후 Tag를 추가할 때
+    func setTags(_ tags: [Tag]) {
+        tags.forEach { tag in
+            let tlTag: TLTag = .init(
+                style: .normal,
+                name: tag.title,
+                color: tag.type.color
+            )
+            let neededWidth: CGFloat = tlTag.intrinsicContentSize.width + Metric.tagSpacing
+            
+            if currentWidth + neededWidth > limitWidth {
+                makeNextLine()
+            }
+            
+            currentStackView.addArrangedSubview(tlTag)
+            currentWidth += neededWidth
+        }
     }
     
 }
@@ -107,12 +133,12 @@ private extension TLTagListView {
         ])
     }
     
-    func setupTags() {
-        tagType.detailTags.forEach { detailTag in
+    func setupTags(type: TagType) {
+        type.detailTags.forEach { detailTag in
             let tlTag: TLTag = .init(
                 style: .selectable,
                 name: detailTag,
-                color: tagType.color
+                color: type.color
             )
             let neededWidth: CGFloat = tlTag.intrinsicContentSize.width + Metric.tagSpacing
             

--- a/iOS/traveline/Sources/Domain/Model/TimelineSample.swift
+++ b/iOS/traveline/Sources/Domain/Model/TimelineSample.swift
@@ -1,0 +1,30 @@
+//
+//  TimelineSample.swift
+//  traveline
+//
+//  Created by 김태현 on 11/22/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+// TODO: - 서버 연동시 지우기
+enum TimelineSample {
+    static func makeTravelInfo() -> TimelineTravelInfo {
+        return .init(
+            travelTitle: "서울 여행 ~",
+            startDate: "2023.11.21",
+            endDate: "2023.11.23",
+            isLiked: true,
+            tags: [
+                .init(title: "2박 3일", type: .period),
+                .init(title: "서울", type: .location),
+                .init(title: "가을", type: .season),
+                .init(title: "맛집", type: .theme),
+                .init(title: "힐링", type: .theme),
+                .init(title: "액티비티", type: .theme),
+                .init(title: "힐링", type: .theme)
+            ]
+        )
+    }
+}

--- a/iOS/traveline/Sources/Domain/Model/TimelineTravelInfo.swift
+++ b/iOS/traveline/Sources/Domain/Model/TimelineTravelInfo.swift
@@ -1,0 +1,17 @@
+//
+//  TimelineTravelInfo.swift
+//  traveline
+//
+//  Created by 김태현 on 11/22/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+struct TimelineTravelInfo: Hashable {
+    let travelTitle: String
+    let startDate: String
+    let endDate: String
+    let isLiked: Bool
+    let tags: [Tag]
+}

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/VC/TimelineVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/VC/TimelineVC.swift
@@ -1,0 +1,141 @@
+//
+//  TimelineVC.swift
+//  traveline
+//
+//  Created by 김태현 on 11/22/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import UIKit
+
+final class TimelineVC: UIViewController {
+    
+    // MARK: - UI Components
+    
+    private lazy var timelineCollectionView: UICollectionView = {
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: .init())
+        
+        collectionView.register(cell: TravelInfoCVC.self)
+        collectionView.showsVerticalScrollIndicator = false
+        collectionView.backgroundColor = TLColor.black
+        collectionView.delegate = self
+        collectionView.dataSource = self
+        
+        return collectionView
+    }()
+        
+    // MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setupAttributes()
+        setupLayout()
+        setupCompositionalLayout()
+    }
+    
+}
+
+// MARK: - Setup Functions
+
+private extension TimelineVC {
+    func setupAttributes() {
+        view.backgroundColor = TLColor.black
+    }
+    
+    func setupLayout() {
+        view.addSubviews(timelineCollectionView)
+        view.subviews.forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+        
+        NSLayoutConstraint.activate([
+            timelineCollectionView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            timelineCollectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            timelineCollectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            timelineCollectionView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        ])
+    }
+    
+    func setupCompositionalLayout() {
+        let layout = UICollectionViewCompositionalLayout { [weak self] section, _ in
+            switch section {
+            case 0:
+                self?.makeTravelInfoSection()
+            default:
+                self?.makeTravelInfoSection()
+            }
+        }
+        
+        timelineCollectionView.setCollectionViewLayout(layout, animated: true)
+    }
+    
+    func makeTravelInfoSection() -> NSCollectionLayoutSection {
+        let item = NSCollectionLayoutItem(
+            layoutSize: .init(
+                widthDimension: .fractionalWidth(1.0),
+                heightDimension: .estimated(170.0)
+            )
+        )
+        
+        let group = NSCollectionLayoutGroup.horizontal(
+            layoutSize: .init(
+                widthDimension: .fractionalWidth(1.0),
+                heightDimension: .estimated(170.0)
+            ),
+            repeatingSubitem: item,
+            count: 1
+        )
+        
+        let section = NSCollectionLayoutSection(group: group)
+        
+        return section
+    }
+}
+
+// MARK: - UICollectionView Delegate
+
+extension TimelineVC: UICollectionViewDelegate {
+    
+}
+
+extension TimelineVC: UICollectionViewDataSource {
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        1
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        switch section {
+        case 0:
+            return 1
+        default:
+            return 1
+        }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        switch indexPath.section {
+        case 0:
+            let cell = collectionView.dequeue(cell: TravelInfoCVC.self, for: indexPath)
+            cell.setData(from: TimelineSample.makeTravelInfo())
+            cell.delegate = self
+            return cell
+        default:
+            return UICollectionViewCell()
+        }
+    }
+}
+
+// MARK: - TravelInfo Delegate
+
+extension TimelineVC: TravelInfoDelegate {
+    func likeChanged(to isLiked: Bool) {
+        // TODO: - 좋아요 변경 처리
+        print("Like Changed")
+    }
+}
+
+@available(iOS 17, *)
+#Preview {
+    UINavigationController(rootViewController: TimelineVC())
+}

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/VC/TimelineVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/VC/TimelineVC.swift
@@ -10,6 +10,10 @@ import UIKit
 
 final class TimelineVC: UIViewController {
     
+    private enum Metric {
+        static let travelInfoEstimatedHeight: CGFloat = 170.0
+    }
+    
     // MARK: - UI Components
     
     private lazy var timelineCollectionView: UICollectionView = {
@@ -71,18 +75,15 @@ private extension TimelineVC {
     }
     
     func makeTravelInfoSection() -> NSCollectionLayoutSection {
-        let item = NSCollectionLayoutItem(
-            layoutSize: .init(
-                widthDimension: .fractionalWidth(1.0),
-                heightDimension: .estimated(170.0)
-            )
+        let size = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .estimated(Metric.travelInfoEstimatedHeight)
         )
         
+        let item = NSCollectionLayoutItem(layoutSize: size)
+        
         let group = NSCollectionLayoutGroup.horizontal(
-            layoutSize: .init(
-                widthDimension: .fractionalWidth(1.0),
-                heightDimension: .estimated(170.0)
-            ),
+            layoutSize: size,
             repeatingSubitem: item,
             count: 1
         )

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/View/TravelInfoCVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/View/TravelInfoCVC.swift
@@ -1,0 +1,124 @@
+//
+//  TravelInfoCVC.swift
+//  traveline
+//
+//  Created by 김태현 on 11/22/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import UIKit
+
+protocol TravelInfoDelegate: AnyObject {
+    func likeChanged(to isLiked: Bool)
+}
+
+final class TravelInfoCVC: UICollectionViewCell {
+    
+    private enum Metric {
+        static let verticalInset: CGFloat = 16.0
+        static let horizontalInset: CGFloat = 16.0
+        static let likeButtonWidth: CGFloat = 24.0
+        static let dateTopInset: CGFloat = 8.0
+        static let tagTopInset: CGFloat = 14.0
+    }
+    
+    // MARK: - UI Components
+    
+    private let travelTitleLabel: TLLabel = .init(
+        font: .heading1,
+        color: TLColor.white
+    )
+    
+    private let travelDateLabel: TLLabel = .init(
+        font: .body2,
+        color: TLColor.gray
+    )
+    
+    private let tagListView: TLTagListView = .init(
+        width: UIScreen.main.bounds.width - Metric.horizontalInset * 2
+    )
+    
+    private let likeButton: UIButton = {
+        let button = UIButton()
+        
+        button.setImage(TLImage.Common.likeUnselected, for: .normal)
+        button.setImage(TLImage.Common.likeSelected, for: .selected)
+        
+        return button
+    }()
+    
+    // MARK: - Properties
+    
+    weak var delegate: TravelInfoDelegate?
+    
+    // MARK: - Initializer
+    
+    override init(frame: CGRect) {
+        super.init(frame: .zero)
+        
+        setupAttributes()
+        setupLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Functions
+    
+    func setData(from data: TimelineTravelInfo) {
+        travelTitleLabel.setText(to: data.travelTitle)
+        travelDateLabel.setText(to: "\(data.startDate) ~ \(data.endDate)")
+        likeButton.isSelected = data.isLiked
+        tagListView.setTags(data.tags)
+    }
+    
+    @objc private func likeButtonPressed() {
+        likeButton.isSelected.toggle()
+        delegate?.likeChanged(to: likeButton.isSelected)
+    }
+    
+}
+
+// MARK: - Setup Functions
+
+private extension TravelInfoCVC {
+    func setupAttributes() {
+        likeButton.addTarget(
+            self,
+            action: #selector(likeButtonPressed),
+            for: .touchUpInside
+        )
+    }
+    
+    func setupLayout() {
+        addSubviews(
+            travelTitleLabel,
+            travelDateLabel,
+            tagListView,
+            likeButton
+        )
+        
+        subviews.forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+        
+        NSLayoutConstraint.activate([
+            travelTitleLabel.topAnchor.constraint(equalTo: topAnchor, constant: Metric.verticalInset),
+            travelTitleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Metric.horizontalInset),
+            
+            travelDateLabel.topAnchor.constraint(equalTo: travelTitleLabel.bottomAnchor, constant: Metric.dateTopInset),
+            travelDateLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Metric.horizontalInset),
+            
+            tagListView.topAnchor.constraint(equalTo: travelDateLabel.bottomAnchor, constant: Metric.tagTopInset),
+            tagListView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Metric.horizontalInset),
+            tagListView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Metric.horizontalInset),
+            tagListView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Metric.verticalInset),
+            
+            likeButton.topAnchor.constraint(equalTo: topAnchor, constant: Metric.verticalInset),
+            likeButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Metric.horizontalInset),
+            likeButton.widthAnchor.constraint(equalToConstant: Metric.likeButtonWidth),
+            likeButton.heightAnchor.constraint(equalTo: likeButton.widthAnchor)
+        ])
+    }
+}

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/View/TravelInfoCVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/View/TravelInfoCVC.swift
@@ -70,7 +70,7 @@ final class TravelInfoCVC: UICollectionViewCell {
         travelTitleLabel.setText(to: data.travelTitle)
         travelDateLabel.setText(to: "\(data.startDate) ~ \(data.endDate)")
         likeButton.isSelected = data.isLiked
-        tagListView.setTags(data.tags)
+        tagListView.setTags(data.tags, style: .normal)
     }
     
     @objc private func likeButtonPressed() {


### PR DESCRIPTION
## 🌎 PR 요약
- 타임라인 화면 중 여행 정보 UI를 먼저 구현해 적용했습니다!

🌱 작업한 브랜치
- feature/#87

## 📚 작업한 내용
### 1. UICollectionView+
- UICollectionView Extension에 셀과 헤더를 좀 더 편하게 register하고 dequeue할 수 있는 함수를 추가해뒀습니다!
아래와 같이 사용하시면 됩니당 🙂

~~~swift
collectionView.register(cell: TravelInfoCVC.self)
let cell = collectionView.dequeue(cell: TravelInfoCVC.self, for: indexPath)
~~~

### 2. TLTagListView 수정
- 어제 만들었던 TLTagListView에서 태그를 나중에 추가할 수 있도록 변경했습니다!
- `setTags(_:style:)` 메서드를 통해 추가할 수 있습니당

### 3. TimelineVC 생성
- 타임라인 화면 VC를 생성하고 여행 정보 cell을 적용해봤습니다.
- Compositional Layout을 적용했고, Diffable DataSource도 함께 적용하려고 했는데 둘 다 잘 모르는 상태에서 함께 적용하려니 너무 잘 안되더라구요 ^^,, 그래서 DataSource는 나중에 변경하도록 하겠슴다
- 태그가 늘어날 수록 여행 정보 영역이 같이 늘어날 수 있도록 dynamic height를 적용했습니당

<img src="https://github.com/boostcampwm2023/iOS07-traveline/assets/51712973/3d456ef0-79c1-4cb6-8e3b-78a9a02e7271" width="300">
<img src="https://github.com/boostcampwm2023/iOS07-traveline/assets/51712973/3b76f295-8642-46f6-9528-d61f18907e11" width="300">

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
Compositional Layout에서 section의 layout을 만들어주는 메서드를 따로 빼서 사용했는데, (`makeTravelInfoSection`)
section이 많아질수록 이 코드도 자연스럽게 많아질 것 같은데.... 어떻게 관리해야할지 고민중임다

## 📸 스크린샷
https://github.com/boostcampwm2023/iOS07-traveline/assets/51712973/0e7571a0-7dfa-46ab-9525-d4eda0234354


## 관련 이슈
- Resolved: #87 
