### PR TITLE
[refactor] users API 리뷰 및 요청사항 반영

### DIFF
--- a/BE/src/app.module.ts
+++ b/BE/src/app.module.ts
@@ -19,7 +19,7 @@ import { JwtModule } from '@nestjs/jwt';
     JwtModule.register({
       global: true,
       secret: process.env.JWT_SECRET,
-      signOptions: { expiresIn: '900s' },
+      signOptions: { expiresIn: '6h' },
     }),
     StorageModule,
     UsersModule,

--- a/BE/src/auth/auth.service.ts
+++ b/BE/src/auth/auth.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { CreateAuthDto } from './dto/create-auth.dto';
-import { UpdateUserDto } from '../users/dto/update-user.dto';
+import { UserInfoDto } from '../users/dto/user-info.dto';
 import { JwtService } from '@nestjs/jwt';
 
 @Injectable()
@@ -38,7 +38,7 @@ export class AuthService {
     return `This action returns a #${id} auth`;
   }
 
-  update(id: number, updateUserDto: UpdateUserDto) {
+  update(id: number, updateUserDto: UserInfoDto) {
     return `This action updates a #${id} auth`;
   }
 

--- a/BE/src/storage/storage.service.ts
+++ b/BE/src/storage/storage.service.ts
@@ -21,7 +21,7 @@ export class StorageService {
   }
 
   async upload(path: string, file: Express.Multer.File) {
-    const uploadParams = {
+    const uploadParams: AWS.S3.PutObjectRequest = {
       Bucket: this.bucketName,
       Key: path + this.generateFilename(file.originalname),
       Body: file.buffer,
@@ -44,5 +44,14 @@ export class StorageService {
 
     const signedUrl = await this.s3.getSignedUrlPromise('getObject', params);
     return signedUrl;
+  }
+
+  async delete(path: string) {
+    const deleteParams: AWS.S3.DeleteObjectRequest = {
+      Bucket: this.bucketName,
+      Key: path,
+    };
+
+    return await this.s3.deleteObject(deleteParams).promise();
   }
 }

--- a/BE/src/users/dto/user-info.dto.ts
+++ b/BE/src/users/dto/user-info.dto.ts
@@ -2,7 +2,7 @@ import { ApiProperty, PartialType } from '@nestjs/swagger';
 import { IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
 import { CreateAuthDto } from 'src/auth/dto/create-auth.dto';
 
-export class UpdateUserDto extends PartialType(CreateAuthDto) {
+export class UserInfoDto extends PartialType(CreateAuthDto) {
   @IsOptional()
   @IsString()
   @MinLength(1)

--- a/BE/src/users/users.constants.ts
+++ b/BE/src/users/users.constants.ts
@@ -1,0 +1,2 @@
+export const DATA_SOURCE = 'DATA_SOURCE';
+export const USERS_REPOSITORY = 'USERS_REPOSITORY';

--- a/BE/src/users/users.controller.ts
+++ b/BE/src/users/users.controller.ts
@@ -30,7 +30,7 @@ export class UsersController {
   })
   @ApiOkResponse({
     description: 'OK',
-    type: User,
+    type: UserInfoDto,
   })
   async findOne(@Req() request) {
     return this.usersService.getUserInfo(request['user'].id);

--- a/BE/src/users/users.controller.ts
+++ b/BE/src/users/users.controller.ts
@@ -2,16 +2,16 @@ import {
   Controller,
   Get,
   Body,
-  Param,
   Put,
   Query,
   UseInterceptors,
   UploadedFile,
   UseGuards,
+  Req,
 } from '@nestjs/common';
 import { User } from './entities/user.entity';
 import { UsersService } from './users.service';
-import { UpdateUserDto } from './dto/update-user.dto';
+import { UserInfoDto } from './dto/user-info.dto';
 import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { CheckDuplicatedNameResponseDto } from './dto/check-duplicated-name-response.dto';
 import { FileInterceptor } from '@nestjs/platform-express';
@@ -23,7 +23,7 @@ import { AuthGuard } from 'src/auth/auth.guard';
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
-  @Get(':id')
+  @Get()
   @ApiOperation({
     summary: 'id에 해당하는 User 정보 반환',
     description: 'id에 해당하는 User 정보를 반환한다.',
@@ -32,31 +32,33 @@ export class UsersController {
     description: 'OK',
     type: User,
   })
-  findOne(@Param('id') id: string) {
-    console.log(id);
-    return this.usersService.findById(id);
+  async findOne(@Req() request) {
+    return this.usersService.getUserInfo(request['user'].id);
   }
-  //테스트 완료
 
-  @Put(':id')
+  @Put()
   @ApiOperation({
     summary: 'id에 해당하는 User 정보 수정',
     description: 'id에 해당하는 User 정보를 수정한다.',
   })
   @ApiOkResponse({
     description: 'OK',
+    type: UserInfoDto,
   })
   @UseInterceptors(FileInterceptor('file'))
   update(
-    @Param('id') id: string,
-    @Body() updateUserDto: UpdateUserDto,
+    @Req() request,
+    @Body() updateUserDto: UserInfoDto,
     @UploadedFile() file: Express.Multer.File
   ) {
-    return this.usersService.update(id, updateUserDto, file);
+    return this.usersService.updateUserInfo(
+      request['user'].id,
+      updateUserDto,
+      file
+    );
   }
-  //클라이언트 측에서 프로필사진/이름 중 하나라도 변경사항이 있을 때만 요청을 보내야 한다.
 
-  @Get('duplicate/check')
+  @Get('duplicate')
   @ApiOperation({
     summary: 'name 중복 검사',
     description: 'name과 동일한 이름이 DB에 존재하는지 확인한다.',

--- a/BE/src/users/users.providers.ts
+++ b/BE/src/users/users.providers.ts
@@ -1,10 +1,11 @@
 import { User } from './entities/user.entity';
 import { DataSource } from 'typeorm';
+import { DATA_SOURCE, USERS_REPOSITORY } from './users.constants';
 
 export const usersProvider = [
   {
-    provide: 'USERS_REPOSITORY',
+    provide: USERS_REPOSITORY,
     useFactory: (dataSource: DataSource) => dataSource.getRepository(User),
-    inject: ['DATA_SOURCE'],
+    inject: [DATA_SOURCE],
   },
 ];

--- a/BE/src/users/users.repository.ts
+++ b/BE/src/users/users.repository.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { Repository, UpdateResult } from 'typeorm';
 import { User } from './entities/user.entity';
-import { UpdateUserDto } from './dto/update-user.dto';
+import { UserInfoDto } from './dto/user-info.dto';
 
 @Injectable()
 export class UserRepository {
@@ -10,8 +10,8 @@ export class UserRepository {
     private userRepository: Repository<User>
   ) {}
 
-  update(id, updateUserDto: UpdateUserDto): Promise<UpdateResult> {
-    return this.userRepository.update({ id: id }, updateUserDto);
+  update(id, updateUserDto: UserInfoDto): Promise<UpdateResult> {
+    return this.userRepository.update(id, updateUserDto);
   }
   findById(id: string): Promise<User> {
     return this.userRepository.findOne({ where: { id: id } });

--- a/BE/src/users/users.repository.ts
+++ b/BE/src/users/users.repository.ts
@@ -2,11 +2,12 @@ import { Inject, Injectable } from '@nestjs/common';
 import { Repository, UpdateResult } from 'typeorm';
 import { User } from './entities/user.entity';
 import { UserInfoDto } from './dto/user-info.dto';
+import { USERS_REPOSITORY } from './users.constants';
 
 @Injectable()
 export class UserRepository {
   constructor(
-    @Inject('USERS_REPOSITORY')
+    @Inject(USERS_REPOSITORY)
     private userRepository: Repository<User>
   ) {}
 


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- feature/#59

## 📚 작업한 내용
- users API 엔드포인트 수정

  **iOS 요청사항 반영**
  - 엔드포인트에서 사용자 식별자 제거 -> jwt 안에 식별자 저장하여 사용
 
  **BE 리뷰 반영**
  - `/:id` 핸들러가 `/duplicate` 핸들러와 충돌했던 문제는 iOS 요청사항을 해결하며 함께 해결
  - 프로필 사진 업로드 전 사용자 식별자를 이용한 유효성 검사 과정은 jwt 가드를 적용하였기 때문에 따로 추가하지 않음
  - 프로필 사진 변경 시 기존 프로필 사진 삭제
  - 변수명 저장용 `users.constants.ts` 파일 분리
  - 예외 처리 방식 변경
- `storage` 모듈 수정
  - users API에서 프로필 사진 변경 시 기존 프로필 사진을 삭제하기 위해 delete 함수 추가
- 기타
  - DTO 이름 변경
  - 개발 시 번거로움을 줄이기 위해 JWT 유효기간 9시간으로 연장

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- `chore` 커밋들은 단순 이름 변경(?) 급의 간단한 커밋이니 건너뛰셔도 괜찮습니당 ㅎㅎ
- 리뷰&머지 천천히 해주셔도 괜찮습니당 ㅎㅎ
- `users.service.ts`에 예외처리 목적으로 `try catch`를 엄청 때려박았는데... 괜찮으려나요 ㅠㅠ
- DTO 이름에도 따로 컨벤션이 있나용? 같은 형태의 DTO를 여러 핸들러에서 사용해서... 하나로 통일해서 쓰고 싶어서 네이밍을 좀 더 범용성 있게(?) 바꿔봤는데 괜찮은지 궁금합니다...

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 관련 이슈
- Closes #59 
