### PR TITLE
[feat] 타임라인 마지막 셀 처리

### DIFF
--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/VC/TimelineVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/VC/TimelineVC.swift
@@ -191,11 +191,9 @@ private extension TimelineVC {
     
 }
 
-// MARK: - UICollectionView Delegate
+// MARK: - UICollectionView Delegate, DataSource
 
 extension TimelineVC: UICollectionViewDelegate {
-    // TODO: - 상세 뷰 연결
-    
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let timelineDetailVC = TimelineDetailVC(
             info: TimelineSample.makeDetailInfo()
@@ -242,7 +240,11 @@ extension TimelineVC: UICollectionViewDataSource {
         }
     }
     
-    func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+    func collectionView(
+        _ collectionView: UICollectionView,
+        viewForSupplementaryElementOfKind kind: String,
+        at indexPath: IndexPath
+    ) -> UICollectionReusableView {
         let header = collectionView.dequeHeader(view: TimelineDateHeaderView.self, for: indexPath)
         header.delegate = self
         return header

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/VC/TimelineVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/VC/TimelineVC.swift
@@ -229,10 +229,14 @@ extension TimelineVC: UICollectionViewDataSource {
             cell.setData(from: TimelineSample.makeTravelInfo())
             cell.delegate = self
             return cell
+            
         case 1:
             let cell = collectionView.dequeue(cell: TimelineCardCVC.self, for: indexPath)
             cell.setData(by: dummyCardList[indexPath.row])
+            let lastRow = collectionView.numberOfItems(inSection: indexPath.section) - 1
+            if indexPath.row == lastRow { cell.changeToLast() }
             return cell
+                
         default:
             return UICollectionViewCell()
         }

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/View/TimelineCardCVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/View/TimelineCardCVC.swift
@@ -69,7 +69,7 @@ final class TimelineCardCVC: UICollectionViewCell {
     }
     
     /// 마지막 셀일 때 line 길이 수정
-    private func changeToLast() {
+    func changeToLast() {
         lineHeightConstraint.isActive = false
         lineView.bottomAnchor.constraint(equalTo: cardView.centerYAnchor).isActive = true
     }


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- feature/#125

## 📚 작업한 내용
### 타임라인 마지막 셀 선 안보이게 처리
- 타임라인에서 마지막 셀에 선이 보이지 않도록 처리했습니당
- 아래 사진처럼 밑에 선이 보이는 부분까지 한 셀로 처리해서, 마지막 셀일때는 해당 선의 길이를 조절해줬어용
<img width="500" alt="스크린샷 2023-11-25 오후 6 41 46" src="https://github.com/boostcampwm2023/iOS07-traveline/assets/51712973/185ccf63-cb58-42da-94af-84d91aaddb1d">

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
<img width="455" alt="스크린샷 2023-11-25 오후 6 29 51" src="https://github.com/boostcampwm2023/iOS07-traveline/assets/51712973/d4d99929-97bc-40a1-947a-c83547624e83">

## 관련 이슈
- Resolved: #125 
