### PR TITLE
[feat] 지역 선택 바텀시트 구현

### DIFF
--- a/iOS/traveline/Sources/Core/Enum/TravelRegion.swift
+++ b/iOS/traveline/Sources/Core/Enum/TravelRegion.swift
@@ -1,0 +1,51 @@
+//
+//  TravelRegion.swift
+//  traveline
+//
+//  Created by 김태현 on 11/26/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+enum TravelRegion: CaseIterable {
+    case seoul
+    case busan
+    case daegu
+    case incheon
+    case gwangju
+    case daejeon
+    case ulsan
+    case sejong
+    case gyeonggi
+    case gangwon
+    case chungbuk
+    case chungnam
+    case jeonbuk
+    case jeonnam
+    case gyeongbuk
+    case gyeongnam
+    case jeju
+    
+    var name: String {
+        switch self {
+        case .seoul: "서울특별시"
+        case .busan: "부산광역시"
+        case .daegu: "대구광역시"
+        case .incheon: "인천광역시"
+        case .gwangju: "광주광역시"
+        case .daejeon: "대전광역시"
+        case .ulsan: "울산광역시"
+        case .sejong: "세종특별자치시"
+        case .gyeonggi: "경기도"
+        case .gangwon: "강원도"
+        case .chungbuk: "충청북도"
+        case .chungnam: "충청남도"
+        case .jeonbuk: "전라북도"
+        case .jeonnam: "전라남도"
+        case .gyeongbuk: "경상북도"
+        case .gyeongnam: "경상남도"
+        case .jeju: "제주도"
+        }
+    }
+}

--- a/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/VC/TravelVC.swift
+++ b/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/VC/TravelVC.swift
@@ -16,11 +16,13 @@ final class TravelVC: UIViewController {
         static let spacing: CGFloat = 20.0
         static let width: CGFloat = UIScreen.main.bounds.width - 32.0
         static let borderWidth: CGFloat = 1.0
+        static let bottomSheetHeight: CGFloat = 595.0
     }
     
     private enum Constants {
         static let textFieldPlaceholder: String = "제목 *"
         static let done: String = "완료"
+        static let bottomSheetTitle: String = "지역"
     }
     
     // MARK: - UI Components
@@ -48,7 +50,7 @@ final class TravelVC: UIViewController {
         let stackView = UIStackView()
         
         stackView.axis = .vertical
-        stackView.spacing = 20.0
+        stackView.spacing = Metric.spacing
         stackView.distribution = .fill
         stackView.alignment = .leading
         
@@ -81,6 +83,15 @@ final class TravelVC: UIViewController {
         view.endEditing(true)
     }
     
+    @objc private func selectRegion() {
+        let regionBottomSheetVC = RegionBottomSheetVC(
+            title: Constants.bottomSheetTitle,
+            hasCompleteButton: false,
+            detentHeight: Metric.bottomSheetHeight
+        )
+        regionBottomSheetVC.delegate = self
+        present(regionBottomSheetVC, animated: true)
+    }
 }
 
 // MARK: - Setup Functions
@@ -90,6 +101,7 @@ private extension TravelVC {
         view.backgroundColor = TLColor.black
         titleTextField.placeholder = Constants.textFieldPlaceholder
         baseScrollView.delegate = self
+        selectRegionButton.addTarget(self, action: #selector(selectRegion), for: .touchUpInside)
         
         navigationItem.title = "여행 생성"
         navigationController?.navigationBar.titleTextAttributes = [
@@ -193,6 +205,15 @@ private extension TravelVC {
 extension TravelVC: UIScrollViewDelegate {
     func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
         dismissKeyboard()
+    }
+}
+
+// MARK: - TLBottomSheetDelegate
+
+extension TravelVC: TLBottomSheetDelegate {
+    func bottomSheetDidDisappear(data: Any) {
+        guard let region = data as? String else { return }
+        selectRegionButton.setSelectedTitle(region)
     }
 }
 

--- a/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/VC/TravelVC.swift
+++ b/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/VC/TravelVC.swift
@@ -16,7 +16,7 @@ final class TravelVC: UIViewController {
         static let spacing: CGFloat = 20.0
         static let width: CGFloat = UIScreen.main.bounds.width - 32.0
         static let borderWidth: CGFloat = 1.0
-        static let bottomSheetHeight: CGFloat = 595.0
+        static let bottomSheetHeight: CGFloat = UIScreen.main.bounds.height * 0.7
     }
     
     private enum Constants {

--- a/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/View/Cell/RegionCVC.swift
+++ b/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/View/Cell/RegionCVC.swift
@@ -1,0 +1,58 @@
+//
+//  RegionCVC.swift
+//  traveline
+//
+//  Created by 김태현 on 11/25/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import UIKit
+
+final class RegionCVC: UICollectionViewCell {
+    
+    // MARK: - UI Components
+    
+    private let regionLabel: TLLabel = .init(font: .body1, color: TLColor.white)
+    
+    // MARK: - Properties
+    
+    override var isHighlighted: Bool {
+        didSet {
+            backgroundColor = isHighlighted ? TLColor.pressedMain.withAlphaComponent(0.2) : TLColor.black
+        }
+    }
+    
+    // MARK: - Initializer
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setupLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Functions
+    
+    func setRegion(_ region: String) {
+        regionLabel.setText(to: region)
+    }
+}
+
+// MARK: - Setup Functions
+
+private extension RegionCVC {
+    func setupLayout() {
+        addSubview(regionLabel)
+        regionLabel.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            regionLabel.topAnchor.constraint(equalTo: topAnchor, constant: 14.0),
+            regionLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16.0),
+            regionLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16.0),
+            regionLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -14.0)
+        ])
+    }
+}

--- a/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/View/Cell/RegionCVC.swift
+++ b/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/View/Cell/RegionCVC.swift
@@ -10,6 +10,11 @@ import UIKit
 
 final class RegionCVC: UICollectionViewCell {
     
+    private enum Metric {
+        static let verticalInset: CGFloat = 14.0
+        static let horizontalInset: CGFloat = 16.0
+    }
+    
     // MARK: - UI Components
     
     private let regionLabel: TLLabel = .init(font: .body1, color: TLColor.white)
@@ -49,10 +54,10 @@ private extension RegionCVC {
         regionLabel.translatesAutoresizingMaskIntoConstraints = false
         
         NSLayoutConstraint.activate([
-            regionLabel.topAnchor.constraint(equalTo: topAnchor, constant: 14.0),
-            regionLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16.0),
-            regionLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16.0),
-            regionLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -14.0)
+            regionLabel.topAnchor.constraint(equalTo: topAnchor, constant: Metric.verticalInset),
+            regionLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Metric.horizontalInset),
+            regionLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Metric.horizontalInset),
+            regionLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Metric.verticalInset)
         ])
     }
 }

--- a/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/View/RegionBottomSheetVC.swift
+++ b/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/View/RegionBottomSheetVC.swift
@@ -1,0 +1,88 @@
+//
+//  RegionBottomSheetVC.swift
+//  traveline
+//
+//  Created by 김태현 on 11/25/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import UIKit
+
+final class RegionBottomSheetVC: TLBottomSheetVC {
+    
+    // MARK: - UI Components
+    
+    private lazy var regionCollectionView: UICollectionView = {
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: makeLayout())
+        
+        collectionView.backgroundColor = TLColor.black
+        collectionView.delegate = self
+        collectionView.dataSource = self
+        collectionView.register(cell: RegionCVC.self)
+        
+        return collectionView
+    }()
+    
+    // MARK: - Properties
+    
+    private let travelRegions: [String] = TravelRegion.allCases.map { $0.name }
+    
+    // MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setupLayout()
+    }
+    
+}
+
+// MARK: - Setup Functions
+
+private extension RegionBottomSheetVC {
+    func setupLayout() {
+        main.addSubview(regionCollectionView)
+        main.isUserInteractionEnabled = true
+        regionCollectionView.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            regionCollectionView.topAnchor.constraint(equalTo: main.topAnchor),
+            regionCollectionView.leadingAnchor.constraint(equalTo: main.leadingAnchor),
+            regionCollectionView.trailingAnchor.constraint(equalTo: main.trailingAnchor),
+            regionCollectionView.bottomAnchor.constraint(equalTo: main.bottomAnchor)
+        ])
+    }
+    
+    func makeLayout() -> UICollectionViewCompositionalLayout {
+        let size = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .estimated(47.0)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: size)
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: size, subitems: [item])
+        let section = NSCollectionLayoutSection(group: group)
+        return UICollectionViewCompositionalLayout(section: section)
+    }
+}
+
+// MARK: - UICollectionView Delegate, DataSource
+
+extension RegionBottomSheetVC: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        let selectedRegion = travelRegions[indexPath.row]
+        delegate?.bottomSheetDidDisappear(data: selectedRegion)
+        dismiss(animated: true)
+    }
+}
+
+extension RegionBottomSheetVC: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        travelRegions.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeue(cell: RegionCVC.self, for: indexPath)
+        cell.setRegion(travelRegions[indexPath.row])
+        return cell
+    }
+}


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- feature/#127

## 📚 작업한 내용
### 여행 생성 화면 - 지역 선택 연결
- 여행 생성 화면에서 지역 선택 -> 바텀시트 부분을 구현했습니다.
- 지역 목록은 일단 Enum에 추가해두었습니다!

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
셀 선택 시에 Highlight 색상을 임의로 줘봤는데 괜찮은가용? 🤔

![스크린샷 2023-11-26 오전 11 12 41](https://github.com/boostcampwm2023/iOS07-traveline/assets/51712973/1f2d2ca7-f945-4550-8d37-0cc225e2ed92)


## 📸 스크린샷
https://github.com/boostcampwm2023/iOS07-traveline/assets/51712973/9c7ead5d-45f8-4f7c-a828-a2447909379b

## 관련 이슈
- Resolved: #127 
