### PR TITLE
[refactor] DB 구조 변경에 따른 기존 게시글 조회/수정/삭제 및 좋아요, 신고 API 수정

### DIFF
--- a/BE/src/database/database.providers.ts
+++ b/BE/src/database/database.providers.ts
@@ -12,7 +12,7 @@ export const databaseProviders = [
         password: process.env.DB_PASSWORD,
         database: process.env.DB_DATABASE,
         entities: [__dirname + '/../**/*.entity{.ts,.js}'],
-        synchronize: true,
+        synchronize: false,
       });
       return dataSource.initialize();
     },

--- a/BE/src/postings/entities/mappings/posting-mapping.entity.ts
+++ b/BE/src/postings/entities/mappings/posting-mapping.entity.ts
@@ -1,0 +1,6 @@
+import { PrimaryGeneratedColumn } from 'typeorm';
+
+export class PostingMapping {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+}

--- a/BE/src/postings/entities/mappings/posting-theme.entity.ts
+++ b/BE/src/postings/entities/mappings/posting-theme.entity.ts
@@ -1,12 +1,10 @@
-import { Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
-import { Posting } from '../posting.entity';
+import { PostingMapping } from './posting-mapping.entity';
+import { Entity, JoinColumn, ManyToOne } from 'typeorm';
 import { Theme } from '../tags/theme.entity';
+import { Posting } from '../posting.entity';
 
 @Entity('posting_theme')
-export class PostingTheme {
-  @PrimaryGeneratedColumn('uuid')
-  id: string;
-
+export class PostingTheme extends PostingMapping {
   @ManyToOne(() => Posting, (posting) => posting.postingThemes, {
     onDelete: 'CASCADE',
   })
@@ -16,6 +14,6 @@ export class PostingTheme {
   @ManyToOne(() => Theme, (theme) => theme.postingTheme, {
     onDelete: 'CASCADE',
   })
-  @JoinColumn({ name: 'theme' })
-  theme: Theme;
+  @JoinColumn({ name: 'tag' })
+  tag: Theme;
 }

--- a/BE/src/postings/entities/mappings/posting-with-who.entity.ts
+++ b/BE/src/postings/entities/mappings/posting-with-who.entity.ts
@@ -1,12 +1,10 @@
-import { Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { PostingMapping } from './posting-mapping.entity';
+import { Entity, JoinColumn, ManyToOne } from 'typeorm';
 import { WithWho } from '../tags/with-who.entity';
 import { Posting } from '../posting.entity';
 
 @Entity('posting_with_who')
-export class PostingWithWho {
-  @PrimaryGeneratedColumn('uuid')
-  id: string;
-
+export class PostingWithWho extends PostingMapping {
   @ManyToOne(() => Posting, (posting) => posting.postingWithWhos, {
     onDelete: 'CASCADE',
   })
@@ -16,6 +14,6 @@ export class PostingWithWho {
   @ManyToOne(() => WithWho, (withWho) => withWho.postingWithWho, {
     onDelete: 'CASCADE',
   })
-  @JoinColumn({ name: 'with_who' })
-  withWho: WithWho;
+  @JoinColumn({ name: 'tag' })
+  tag: WithWho;
 }

--- a/BE/src/postings/entities/tags/theme.entity.ts
+++ b/BE/src/postings/entities/tags/theme.entity.ts
@@ -4,6 +4,6 @@ import { Entity, OneToMany } from 'typeorm';
 
 @Entity()
 export class Theme extends Tag {
-  @OneToMany(() => PostingTheme, (postingTheme) => postingTheme.theme)
+  @OneToMany(() => PostingTheme, (postingTheme) => postingTheme.tag)
   postingTheme: PostingTheme[];
 }

--- a/BE/src/postings/entities/tags/with-who.entity.ts
+++ b/BE/src/postings/entities/tags/with-who.entity.ts
@@ -4,6 +4,6 @@ import { Tag } from './tag.entity';
 
 @Entity('with_who')
 export class WithWho extends Tag {
-  @OneToMany(() => PostingWithWho, (postingWithWho) => postingWithWho.withWho)
+  @OneToMany(() => PostingWithWho, (postingWithWho) => postingWithWho.tag)
   postingWithWho: PostingWithWho[];
 }

--- a/BE/src/postings/postings.controller.ts
+++ b/BE/src/postings/postings.controller.ts
@@ -112,17 +112,17 @@ export class PostingsController {
   //   //return this.postingsService.searchByKeyWord(keyword);
   // }
 
-  // @Post(':id/like')
-  // @ApiOperation({
-  //   summary: '포스팅 좋아요 API',
-  //   description:
-  //     'id 값에 해당되는 포스팅에 좋아요가 추가되거나 삭제된다. (토글)',
-  // })
-  // @ApiOkResponse({ description: 'OK' })
-  // toggleLike(@Param('id') id: string) {
-  //   // TODO: JWT에서 사용자 ID 가져오기
-  //   return this.postingsService.toggleLike(id, '');
-  // }
+  @Post(':id/like')
+  @ApiOperation({
+    summary: '포스팅 좋아요 API',
+    description:
+      'id 값에 해당되는 포스팅에 좋아요가 추가되거나 삭제된다. (토글)',
+  })
+  @ApiOkResponse({ description: 'OK' })
+  toggleLike(@Param('id') id: string) {
+    const userId = ''; // TODO: request['user'].id; (현재 id 필드 값은 닉네임)
+    return this.postingsService.toggleLike(id, userId);
+  }
 
   // @Post(':id/report')
   // @ApiOperation({

--- a/BE/src/postings/postings.controller.ts
+++ b/BE/src/postings/postings.controller.ts
@@ -69,43 +69,25 @@ export class PostingsController {
   //   //return this.postingsService.search(searchPostingDto);
   // }
 
-  // @Get(':id')
-  // @ApiOperation({
-  //   summary: '포스팅 로드 API',
-  //   description: 'id 값에 해당되는 포스팅을 반환한다.',
-  // })
-  // @ApiOkResponse({ description: 'OK', type: Posting })
-  // async findOne(@Param('id') id: string) {
-  //   const posting = await this.postingsService.findOne(id);
-  //   const userId = ''; // TODO: JWT에서 userID 가져오기
-  //   return {
-  //     id: posting.id,
-  //     writer: posting.writer,
-  //     title: posting.title,
-  //     createdAt: posting.created_at,
-  //     thumbnail: posting.thumbnail,
-  //     startDate: posting.start_date,
-  //     endDate: posting.end_date,
-  //     days: this.postingsService.createDaysList(
-  //       posting.start_date,
-  //       posting.days
-  //     ),
-  //     period: periods[posting.period] || null,
-  //     headcount: headcounts[posting.headcount] || null,
-  //     budget: budgets[posting.budget] || null,
-  //     location: locations[posting.location],
-  //     season: seasons[posting.season],
-  //     vehicle: vehicles[posting.vehicle] || null,
-  //     theme: posting.theme ? posting.theme.map((e) => themes[e]) : null,
-  //     withWho: posting.with_who
-  //       ? posting.with_who.map((e) => withWhos[e])
-  //       : null,
-  //     report: posting.report.length,
-  //     liked: posting.liked.length,
-  //     isLiked: posting.liked.some((liked) => liked.user === userId),
-  //     isOwner: posting.writer === userId,
-  //   };
-  // }
+  @Get(':id')
+  @ApiOperation({
+    summary: '포스팅 로드 API',
+    description: 'id 값에 해당되는 포스팅을 반환한다.',
+  })
+  @ApiOkResponse({ description: 'OK', type: Posting })
+  async findOne(@Param('id') id: string) {
+    const userId = ''; // TODO: request['user'].id; (현재 id 필드 값은 닉네임)
+    const posting = await this.postingsService.findPosting(id);
+
+    return {
+      ...posting,
+      days: this.createDaysList(posting.startDate, posting.days),
+      liked: posting.liked.length,
+      report: posting.report.length,
+      isLiked: posting.liked.some((liked) => liked.user === userId),
+      isOwner: posting.writer.id === userId,
+    };
+  }
 
   // @Put(':id')
   // @ApiOperation({
@@ -164,4 +146,15 @@ export class PostingsController {
   //   // TODO: JWT에서 사용자 ID 가져오기
   //   return this.postingsService.report(id, '');
   // }
+
+  private createDaysList(startDate: Date, days: number) {
+    const weekdays = ['일', '월', '화', '수', '목', '금', '토'];
+    const standardDate = new Date(startDate);
+
+    return Array.from({ length: days }, (_, index) => {
+      const date = new Date(startDate);
+      date.setDate(standardDate.getDate() + index);
+      return `${date.getDate()}${weekdays[date.getDay()]}`;
+    });
+  }
 }

--- a/BE/src/postings/postings.controller.ts
+++ b/BE/src/postings/postings.controller.ts
@@ -7,7 +7,6 @@ import {
   Delete,
   Query,
   Put,
-  BadRequestException,
   UseGuards,
   Req,
 } from '@nestjs/common';
@@ -37,14 +36,6 @@ export class PostingsController {
   })
   @ApiCreatedResponse({ description: 'Created', type: Posting })
   async create(@Req() request, @Body() createPostingDto: CreatePostingDto) {
-    if (
-      new Date(createPostingDto.endDate) < new Date(createPostingDto.startDate)
-    ) {
-      throw new BadRequestException(
-        'endDate는 startDate와 같거나 더 나중의 날짜여야 합니다.'
-      );
-    }
-
     const userId = ''; // TODO: request['user'].id; (현재 id 필드 값은 닉네임)
     return this.postingsService.createPosting(userId, createPostingDto);
   }

--- a/BE/src/postings/postings.controller.ts
+++ b/BE/src/postings/postings.controller.ts
@@ -22,16 +22,6 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { Posting } from './entities/posting.entity';
-import {
-  budgets,
-  headcounts,
-  locations,
-  periods,
-  seasons,
-  themes,
-  vehicles,
-  withWhos,
-} from './postings.types';
 import { AuthGuard } from '../auth/auth.guard';
 
 @UseGuards(AuthGuard)
@@ -45,7 +35,7 @@ export class PostingsController {
     summary: '포스팅 생성 API',
     description: '새로운 포스팅을 작성한다.',
   })
-  @ApiOkResponse({ description: 'OK', type: Posting })
+  @ApiCreatedResponse({ description: 'Created', type: Posting })
   async create(@Req() request, @Body() createPostingDto: CreatePostingDto) {
     if (
       new Date(createPostingDto.endDate) < new Date(createPostingDto.startDate)

--- a/BE/src/postings/postings.controller.ts
+++ b/BE/src/postings/postings.controller.ts
@@ -100,16 +100,16 @@ export class PostingsController {
     return this.postingsService.updatePosting(id, userId, updatePostingDto);
   }
 
-  // @Delete(':id')
-  // @ApiOperation({
-  //   summary: '포스팅 삭제 API',
-  //   description: 'id 값에 해당되는 포스팅을 삭제한다.',
-  // })
-  // @ApiOkResponse({ description: 'OK' })
-  // remove(@Param('id') id: string) {
-  //   // TODO: JWT에서 user id 가져오기
-  //   return this.postingsService.remove(id, '');
-  // }
+  @Delete(':id')
+  @ApiOperation({
+    summary: '포스팅 삭제 API',
+    description: 'id 값에 해당되는 포스팅을 삭제한다.',
+  })
+  @ApiOkResponse({ description: 'OK' })
+  remove(@Param('id') id: string) {
+    const userId = ''; // TODO: request['user'].id; (현재 id 필드 값은 닉네임)
+    return this.postingsService.removePosting(id, userId);
+  }
 
   // @Get('/titles')
   // @ApiOperation({

--- a/BE/src/postings/postings.controller.ts
+++ b/BE/src/postings/postings.controller.ts
@@ -124,18 +124,18 @@ export class PostingsController {
     return this.postingsService.toggleLike(id, userId);
   }
 
-  // @Post(':id/report')
-  // @ApiOperation({
-  //   summary: '게시글 신고',
-  //   description: 'id에 해당하는 게시글을 신고한다.',
-  // })
-  // @ApiCreatedResponse({
-  //   description: 'OK',
-  // })
-  // report(@Param('id') id: string) {
-  //   // TODO: JWT에서 사용자 ID 가져오기
-  //   return this.postingsService.report(id, '');
-  // }
+  @Post(':id/report')
+  @ApiOperation({
+    summary: '게시글 신고',
+    description: 'id에 해당하는 게시글을 신고한다.',
+  })
+  @ApiCreatedResponse({
+    description: 'OK',
+  })
+  report(@Param('id') id: string) {
+    const userId = ''; // TODO: request['user'].id; (현재 id 필드 값은 닉네임)
+    return this.postingsService.report(id, userId);
+  }
 
   private createDaysList(startDate: Date, days: number) {
     const weekdays = ['일', '월', '화', '수', '목', '금', '토'];

--- a/BE/src/postings/postings.controller.ts
+++ b/BE/src/postings/postings.controller.ts
@@ -9,6 +9,7 @@ import {
   Put,
   BadRequestException,
   UseGuards,
+  Req,
 } from '@nestjs/common';
 import { PostingsService } from './postings.service';
 import { CreatePostingDto } from './dto/create-posting.dto';
@@ -32,16 +33,12 @@ import {
   withWhos,
 } from './postings.types';
 import { AuthGuard } from '../auth/auth.guard';
-import { UsersService } from '../users/users.service';
 
 @UseGuards(AuthGuard)
 @Controller('postings')
 @ApiTags('Postings API')
 export class PostingsController {
-  constructor(
-    private readonly postingsService: PostingsService,
-    private readonly usersService: UsersService
-  ) {}
+  constructor(private readonly postingsService: PostingsService) {}
 
   @Post()
   @ApiOperation({
@@ -49,7 +46,7 @@ export class PostingsController {
     description: '새로운 포스팅을 작성한다.',
   })
   @ApiOkResponse({ description: 'OK', type: Posting })
-  async create(@Body() createPostingDto: CreatePostingDto) {
+  async create(@Req() request, @Body() createPostingDto: CreatePostingDto) {
     if (
       new Date(createPostingDto.endDate) < new Date(createPostingDto.startDate)
     ) {
@@ -58,23 +55,8 @@ export class PostingsController {
       );
     }
 
-    const user = await this.usersService.findById(''); // TODO: JWT 토큰에서 user의 id 꺼내기
-    const posting = await this.postingsService.createPosting(
-      user,
-      createPostingDto
-    );
-
-    await this.postingsService.createPostingTheme(
-      posting,
-      createPostingDto.theme
-    );
-
-    await this.postingsService.createPostingWithWho(
-      posting,
-      createPostingDto.withWho
-    );
-
-    return posting;
+    const userId = ''; // TODO: request['user'].id; (현재 id 필드 값은 닉네임)
+    return this.postingsService.createPosting(userId, createPostingDto);
   }
 
   // @Get()

--- a/BE/src/postings/postings.controller.ts
+++ b/BE/src/postings/postings.controller.ts
@@ -89,16 +89,16 @@ export class PostingsController {
     };
   }
 
-  // @Put(':id')
-  // @ApiOperation({
-  //   summary: '포스팅 수정 API',
-  //   description: 'id 값에 해당되는 포스팅을 수정한다.',
-  // })
-  // @ApiOkResponse({ description: 'OK' })
-  // update(@Param('id') id: string, @Body() updatePostingDto: UpdatePostingDto) {
-  //   // TODO: JWT에서 user id 가져오기
-  //   return this.postingsService.update(id, '', updatePostingDto);
-  // }
+  @Put(':id')
+  @ApiOperation({
+    summary: '포스팅 수정 API',
+    description: 'id 값에 해당되는 포스팅을 수정한다.',
+  })
+  @ApiOkResponse({ description: 'OK' })
+  update(@Param('id') id: string, @Body() updatePostingDto: UpdatePostingDto) {
+    const userId = ''; // TODO: request['user'].id; (현재 id 필드 값은 닉네임)
+    return this.postingsService.updatePosting(id, userId, updatePostingDto);
+  }
 
   // @Delete(':id')
   // @ApiOperation({

--- a/BE/src/postings/postings.module.ts
+++ b/BE/src/postings/postings.module.ts
@@ -16,16 +16,12 @@ import { VehiclesRepository } from './repositories/tags/vehicles.repository';
 import { WithWhosRepository } from './repositories/tags/with-whos.repository';
 import { PostingThemesRepository } from './repositories/mappings/posting-themes.repository';
 import { PostingWithWhosRepository } from './repositories/mappings/posting-with-whos.repository';
-import { UsersService } from '../users/users.service';
 import { UsersModule } from '../users/users.module';
-import { StorageService } from '../storage/storage.service';
 
 @Module({
   imports: [DatabaseModule, UsersModule],
   controllers: [PostingsController],
   providers: [
-    UsersService,
-    StorageService,
     ...postingsProviders,
     PostingsService,
     PostingsRepository,

--- a/BE/src/postings/postings.service.ts
+++ b/BE/src/postings/postings.service.ts
@@ -154,17 +154,21 @@ export class PostingsService {
     return this.createPostingWithWho(posting, withWhos);
   }
 
-  // async remove(postingId: string, userId: string) {
-  //   const posting = await this.postingsRepository.findOneBy({ id: postingId });
+  async removePosting(postingId: string, userId: string) {
+    const posting = await this.postingsRepository.findOne(postingId);
 
-  //   if (posting && posting.writer !== userId) {
-  //     throw new ForbiddenException(
-  //       '본인이 작성한 게시글만 삭제할 수 있습니다.'
-  //     );
-  //   }
+    if (!posting) {
+      throw new NotFoundException('게시글이 존재하지 않습니다.');
+    }
 
-  //   return this.postingsRepository.delete({ id: postingId });
-  // }
+    if (posting.writer.id !== userId) {
+      throw new ForbiddenException(
+        '본인이 작성한 게시글만 삭제할 수 있습니다.'
+      );
+    }
+
+    return this.postingsRepository.remove(posting);
+  }
 
   async removePostingTheme(postingThemes: PostingTheme[]) {
     return this.postingThemesRepository.remove(postingThemes);

--- a/BE/src/postings/postings.service.ts
+++ b/BE/src/postings/postings.service.ts
@@ -103,6 +103,10 @@ export class PostingsService {
       this.postingWithWhosRepository.findAllByPosting(id),
     ]);
 
+    if (posting.report.length > 5) {
+      throw new ForbiddenException('차단된 게시글입니다.');
+    }
+
     return { ...posting, theme, withWho };
   }
 

--- a/BE/src/postings/postings.service.ts
+++ b/BE/src/postings/postings.service.ts
@@ -117,9 +117,15 @@ export class PostingsService {
   //   return `This action returns all postings`;
   // }
 
-  // async findOne(id: string) {
-  //   return this.postingsRepository.findOneBy({ id });
-  // }
+  async findPosting(id: string) {
+    const [posting, theme, withWho] = await Promise.all([
+      this.postingsRepository.findOne(id),
+      this.postingThemesRepository.findAllByPosting(id),
+      this.postingWithWhosRepository.findAllByPosting(id),
+    ]);
+
+    return { ...posting, theme, withWho };
+  }
 
   // async update(
   //   postingId: string,
@@ -206,16 +212,5 @@ export class PostingsService {
 
   private calculateDays(startDate: Date, endDate: Date): number {
     return (endDate.getTime() - startDate.getTime()) / (1000 * 3600 * 24) + 1;
-  }
-
-  createDaysList(startDate: Date, days: number) {
-    const weekdays = ['일', '월', '화', '수', '목', '금', '토'];
-    const standardDate = new Date(startDate);
-
-    return Array.from({ length: days }, (_, index) => {
-      const date = new Date(startDate);
-      date.setDate(standardDate.getDate() + index);
-      return `${date.getDate()}${weekdays[date.getDay()]}`;
-    });
   }
 }

--- a/BE/src/postings/postings.service.ts
+++ b/BE/src/postings/postings.service.ts
@@ -70,30 +70,26 @@ export class PostingsService {
     return { ...savedPosting, postingTheme, postingWithWho };
   }
 
-  async createPostingTheme(posting: Posting, themes: string[]) {
-    return !!themes
-      ? Promise.all(
-          themes.map(async (e) => {
-            const postingTheme = new PostingTheme();
-            postingTheme.posting = posting;
-            postingTheme.tag = await this.themesRepository.findByName(e);
-            return this.postingThemesRepository.save(postingTheme);
-          })
-        )
-      : undefined;
+  async createPostingTheme(posting: Posting, themes: string[] = []) {
+    return Promise.all(
+      themes.map(async (e) => {
+        const postingTheme = new PostingTheme();
+        postingTheme.posting = posting;
+        postingTheme.tag = await this.themesRepository.findByName(e);
+        return this.postingThemesRepository.save(postingTheme);
+      })
+    );
   }
 
-  async createPostingWithWho(posting: Posting, withWhos: string[]) {
-    return !!withWhos
-      ? Promise.all(
-          withWhos.map(async (e) => {
-            const postingWithWho = new PostingWithWho();
-            postingWithWho.posting = posting;
-            postingWithWho.tag = await this.withWhosRepository.findByName(e);
-            return this.postingWithWhosRepository.save(postingWithWho);
-          })
-        )
-      : undefined;
+  async createPostingWithWho(posting: Posting, withWhos: string[] = []) {
+    return Promise.all(
+      withWhos.map(async (e) => {
+        const postingWithWho = new PostingWithWho();
+        postingWithWho.posting = posting;
+        postingWithWho.tag = await this.withWhosRepository.findByName(e);
+        return this.postingWithWhosRepository.save(postingWithWho);
+      })
+    );
   }
 
   // findAll() {

--- a/BE/src/postings/postings.service.ts
+++ b/BE/src/postings/postings.service.ts
@@ -32,6 +32,7 @@ import { WithWhosRepository } from './repositories/tags/with-whos.repository';
 import { PostingTheme } from './entities/mappings/posting-theme.entity';
 import { PostingWithWho } from './entities/mappings/posting-with-who.entity';
 import { UserRepository } from 'src/users/users.repository';
+import { Liked } from './entities/liked.entity';
 
 @Injectable()
 export class PostingsService {
@@ -178,22 +179,24 @@ export class PostingsService {
     return this.postingWithWhosRepository.remove(postingWithWhos);
   }
 
-  // async toggleLike(postingId: string, userId: string) {
-  //   const liked = await this.likedsRepository.findOneBy({
-  //     posting: postingId,
-  //     user: userId,
-  //   });
+  async toggleLike(postingId: string, userId: string) {
+    const posting = await this.postingsRepository.findOne(postingId);
 
-  //   if (liked) {
-  //     return this.likedsRepository.delete({ posting: postingId, user: userId });
-  //   }
+    if (!posting) {
+      throw new NotFoundException('게시글이 존재하지 않습니다.');
+    }
 
-  //   const newLiked = new Liked();
-  //   newLiked.posting = postingId;
-  //   newLiked.user = userId;
+    const liked = await this.likedsRepository.findOne(postingId, userId);
 
-  //   return this.likedsRepository.save(newLiked);
-  // }
+    if (liked) {
+      const newLiked = new Liked();
+      newLiked.posting = postingId;
+      newLiked.user = userId;
+      return this.likedsRepository.save(newLiked);
+    }
+
+    return this.likedsRepository.toggle(liked);
+  }
 
   // async report(postingId: string, userId: string) {
   //   const report = await this.reportsRepository.findOneBy({

--- a/BE/src/postings/postings.service.ts
+++ b/BE/src/postings/postings.service.ts
@@ -96,7 +96,7 @@ export class PostingsService {
       themes.map(async (e) => {
         const postingTheme = new PostingTheme();
         postingTheme.posting = posting;
-        postingTheme.theme = await this.themesRepository.findByName(e);
+        postingTheme.tag = await this.themesRepository.findByName(e);
         return this.postingThemesRepository.save(postingTheme);
       })
     );
@@ -107,7 +107,7 @@ export class PostingsService {
       withWhos.map(async (e) => {
         const postingWithWho = new PostingWithWho();
         postingWithWho.posting = posting;
-        postingWithWho.withWho = await this.withWhosRepository.findByName(e);
+        postingWithWho.tag = await this.withWhosRepository.findByName(e);
         return this.postingWithWhosRepository.save(postingWithWho);
       })
     );

--- a/BE/src/postings/postings.service.ts
+++ b/BE/src/postings/postings.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   ConflictException,
   ForbiddenException,
   Injectable,
@@ -54,6 +55,14 @@ export class PostingsService {
   ) {}
 
   async createPosting(userId: string, createPostingDto: CreatePostingDto) {
+    if (
+      new Date(createPostingDto.endDate) < new Date(createPostingDto.startDate)
+    ) {
+      throw new BadRequestException(
+        'endDate는 startDate와 같거나 더 나중의 날짜여야 합니다.'
+      );
+    }
+
     const posting = await this.initializePosting(createPostingDto);
     posting.writer = await this.userRepository.findById(userId);
 

--- a/BE/src/postings/repositories/likeds.repository.ts
+++ b/BE/src/postings/repositories/likeds.repository.ts
@@ -9,4 +9,18 @@ export class LikedsRepository {
     @Inject(LIKEDS_REPOSITORY)
     private likesRepository: Repository<Liked>
   ) {}
+
+  findOne(postingId: string, userId: string) {
+    return this.likesRepository.findOne({
+      where: { posting: postingId, user: userId },
+    });
+  }
+
+  save(liked: Liked) {
+    return this.likesRepository.save(liked);
+  }
+
+  toggle(liked: Liked) {
+    return this.likesRepository.update(liked, { isDeleted: !liked.isDeleted });
+  }
 }

--- a/BE/src/postings/repositories/mappings/posting-mapping.repository.ts
+++ b/BE/src/postings/repositories/mappings/posting-mapping.repository.ts
@@ -1,0 +1,9 @@
+import { Repository } from 'typeorm';
+
+export class PostingMappingRepository<T> {
+  constructor(private postingMappingRepository: Repository<T>) {}
+
+  async save(entity: T) {
+    return this.postingMappingRepository.save(entity);
+  }
+}

--- a/BE/src/postings/repositories/mappings/posting-mapping.repository.ts
+++ b/BE/src/postings/repositories/mappings/posting-mapping.repository.ts
@@ -7,6 +7,17 @@ export class PostingMappingRepository<T> {
     return this.postingMappingRepository.save(entity);
   }
 
+  async findAllEntitiesByPosting(postingId: string) {
+    return this.postingMappingRepository
+      .createQueryBuilder('pm')
+      .where('pm.posting = :postingId', { postingId: postingId })
+      .getMany();
+  }
+
+  async remove(entities: T[]) {
+    return this.postingMappingRepository.remove(entities);
+  }
+
   async findAllByPosting(postingId: string) {
     const results = await this.postingMappingRepository
       .createQueryBuilder('pm')

--- a/BE/src/postings/repositories/mappings/posting-mapping.repository.ts
+++ b/BE/src/postings/repositories/mappings/posting-mapping.repository.ts
@@ -6,4 +6,14 @@ export class PostingMappingRepository<T> {
   async save(entity: T) {
     return this.postingMappingRepository.save(entity);
   }
+
+  async findAllByPosting(postingId: string) {
+    const results = await this.postingMappingRepository
+      .createQueryBuilder('pm')
+      .leftJoinAndSelect('pm.tag', 't')
+      .where('pm.posting = :postingId', { postingId: postingId })
+      .getMany();
+
+    return results.map((e) => e['tag'].name);
+  }
 }

--- a/BE/src/postings/repositories/mappings/posting-themes.repository.ts
+++ b/BE/src/postings/repositories/mappings/posting-themes.repository.ts
@@ -1,16 +1,15 @@
 import { PostingTheme } from 'src/postings/entities/mappings/posting-theme.entity';
 import { POSTING_THEMES_REPOSITORY } from '../../postings.constants';
+import { PostingMappingRepository } from './posting-mapping.repository';
 import { Inject, Injectable } from '@nestjs/common';
 import { Repository } from 'typeorm';
 
 @Injectable()
-export class PostingThemesRepository {
+export class PostingThemesRepository extends PostingMappingRepository<PostingTheme> {
   constructor(
     @Inject(POSTING_THEMES_REPOSITORY)
     private postingThemesRepository: Repository<PostingTheme>
-  ) {}
-
-  async save(postingTheme: PostingTheme) {
-    return this.postingThemesRepository.save(postingTheme);
+  ) {
+    super(postingThemesRepository);
   }
 }

--- a/BE/src/postings/repositories/mappings/posting-with-whos.repository.ts
+++ b/BE/src/postings/repositories/mappings/posting-with-whos.repository.ts
@@ -1,16 +1,15 @@
 import { PostingWithWho } from 'src/postings/entities/mappings/posting-with-who.entity';
 import { POSTING_WITH_WHOS_REPOSITORY } from '../../postings.constants';
+import { PostingMappingRepository } from './posting-mapping.repository';
 import { Inject, Injectable } from '@nestjs/common';
 import { Repository } from 'typeorm';
 
 @Injectable()
-export class PostingWithWhosRepository {
+export class PostingWithWhosRepository extends PostingMappingRepository<PostingWithWho> {
   constructor(
     @Inject(POSTING_WITH_WHOS_REPOSITORY)
     private postingWithWhosRepository: Repository<PostingWithWho>
-  ) {}
-
-  async save(postingWithWho: PostingWithWho) {
-    return this.postingWithWhosRepository.save(postingWithWho);
+  ) {
+    super(postingWithWhosRepository);
   }
 }

--- a/BE/src/postings/repositories/postings.repository.ts
+++ b/BE/src/postings/repositories/postings.repository.ts
@@ -28,4 +28,8 @@ export class PostingsRepository {
       },
     });
   }
+
+  async update(id: string, posting: Posting) {
+    return this.postingsRepository.update(id, posting);
+  }
 }

--- a/BE/src/postings/repositories/postings.repository.ts
+++ b/BE/src/postings/repositories/postings.repository.ts
@@ -13,4 +13,19 @@ export class PostingsRepository {
   async save(posting: Posting) {
     return this.postingsRepository.save(posting);
   }
+
+  async findOne(id: string) {
+    return this.postingsRepository.findOne({
+      where: { id },
+      relations: {
+        writer: true,
+        budget: true,
+        headcount: true,
+        location: true,
+        period: true,
+        season: true,
+        vehicle: true,
+      },
+    });
+  }
 }

--- a/BE/src/postings/repositories/postings.repository.ts
+++ b/BE/src/postings/repositories/postings.repository.ts
@@ -32,4 +32,8 @@ export class PostingsRepository {
   async update(id: string, posting: Posting) {
     return this.postingsRepository.update(id, posting);
   }
+
+  async remove(posting: Posting) {
+    return this.postingsRepository.remove(posting);
+  }
 }

--- a/BE/src/postings/repositories/reports.repository.ts
+++ b/BE/src/postings/repositories/reports.repository.ts
@@ -9,4 +9,14 @@ export class ReportsRepository {
     @Inject(REPORTS_REPOSITORY)
     private reportsRepository: Repository<Report>
   ) {}
+
+  findOne(postingId: string, userId: string) {
+    return this.reportsRepository.findOne({
+      where: { posting: postingId, reporter: userId },
+    });
+  }
+
+  save(report: Report) {
+    return this.reportsRepository.save(report);
+  }
 }

--- a/BE/src/postings/repositories/tags/tag.repository.ts
+++ b/BE/src/postings/repositories/tags/tag.repository.ts
@@ -6,7 +6,6 @@ export class TagRepository<T> {
   async findByName(name: string) {
     return this.tagRepository
       .createQueryBuilder('r')
-      .select('r.id')
       .where('r.name = :name', { name })
       .getOne();
   }


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- be-feature/#85-update-posting

## 📚 작업한 내용
- 태그처럼 게시글과 테마/누구랑 매핑 엔티티/레포지터리도 부모 클래스를 상속 받도록 수정했습니다.
- id에 해당하는 게시글 조회/수정/삭제 API를 수정했습니다.
- 좋아요 토글 API와 신고 API를 수정했습니다.

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 엔티티 파일이 수정됐습니다! database 모듈의 synchronize 속성을 false로 만들었기 때문에 서버에서 직접 DB를 생성하든가 해야 할 것 같습니다!!
- 게시글의 누적 신고 수가 5를 초과하면 차단되도록 했는데요. 일단 임시로 넣은 수라서 더 적절한 기준 값이 있으면 편하게 말씀해주세요 😊

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 관련 이슈
- Close #85
