### PR TITLE
[feat] TLImageCache 구현

### DIFF
--- a/iOS/traveline/Sources/Core/Cache/ImageCacheRepository.swift
+++ b/iOS/traveline/Sources/Core/Cache/ImageCacheRepository.swift
@@ -37,6 +37,7 @@ final class ImageCacheRepositoryImpl: ImageCacheRepository {
         }
         
         if let diskCachedData = fetchFromDiskData(cacheKey) {
+            storeToMemoryCache(diskCachedData, cacheKey: cacheKey)
             return diskCachedData
         }
         return nil

--- a/iOS/traveline/Sources/Core/Cache/ImageCacheRepository.swift
+++ b/iOS/traveline/Sources/Core/Cache/ImageCacheRepository.swift
@@ -54,7 +54,7 @@ final class ImageCacheRepositoryImpl: ImageCacheRepository {
     }
     
     private func storeToMemoryCache(_ data: Data, cacheKey: String) {
-        memoryCache.setObject(data as NSData, forKey: cacheKey as NSString)
+        return memoryCache.setObject(data as NSData, forKey: cacheKey as NSString)
     }
     
     // MARK: - Disk

--- a/iOS/traveline/Sources/Core/Cache/ImageCacheRepository.swift
+++ b/iOS/traveline/Sources/Core/Cache/ImageCacheRepository.swift
@@ -1,0 +1,84 @@
+//
+//  ImageCacheRepository.swift
+//  traveline
+//
+//  Created by 김태현 on 11/26/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+protocol ImageCacheRepository {
+    func fetch(_ cacheKey: String) -> Data?
+    func store(_ data: Data, cacheKey: String)
+}
+
+final class ImageCacheRepositoryImpl: ImageCacheRepository {
+    
+    private enum Constants {
+        static let cacheDataName: String = "cacheImageData"
+    }
+    
+    private let memoryCache: NSCache<NSString, NSData> = .init()
+    private let fileManager: FileManager
+    
+    init(fileManager: FileManager) {
+        self.fileManager = fileManager
+        
+        // TODO: - 캐시 정책
+        memoryCache.countLimit = 50
+    }
+    
+    // MARK: - Functions
+    
+    func fetch(_ cacheKey: String) -> Data? {
+        if let memoryCachedData = fetchFromMemoryData(cacheKey) {
+            return memoryCachedData
+        }
+        
+        if let diskCachedData = fetchFromDiskData(cacheKey) {
+            return diskCachedData
+        }
+        return nil
+    }
+    
+    func store(_ data: Data, cacheKey: String) {
+        storeToMemoryCache(data, cacheKey: cacheKey)
+        storeToDiskCache(data, cacheKey: cacheKey)
+    }
+    
+    // MARK: - Memory
+    
+    private func fetchFromMemoryData(_ cacheKey: String) -> Data? {
+        return memoryCache.object(forKey: cacheKey as NSString) as? Data
+    }
+    
+    private func storeToMemoryCache(_ data: Data, cacheKey: String) {
+        memoryCache.setObject(data as NSData, forKey: cacheKey as NSString)
+    }
+    
+    // MARK: - Disk
+    
+    private func fetchFromDiskData(_ cacheKey: String) -> Data? {
+        guard let cacheDirectoryURL = makeCacheDirectoryURL(cacheKey: cacheKey) else { return nil }
+        let cacheDataURL = cacheDirectoryURL.appending(path: Constants.cacheDataName)
+        return try? Data(contentsOf: cacheDataURL)
+    }
+    
+    private func storeToDiskCache(_ data: Data, cacheKey: String) {
+        guard let cacheDirectoryURL = makeCacheDirectoryURL(cacheKey: cacheKey) else { return }
+        let cacheDataURL = cacheDirectoryURL.appending(path: Constants.cacheDataName)
+        try? fileManager.createDirectory(atPath: cacheDirectoryURL.path(), withIntermediateDirectories: true)
+        fileManager.createFile(atPath: cacheDataURL.path(), contents: data)
+    }
+    
+    // MARK: - File URL
+    
+    private func makeCacheDirectoryURL(cacheKey: String) -> URL? {
+        return fileManager
+            .urls(for: .cachesDirectory, in: .userDomainMask)
+            .first?
+            .appending(path: cacheKey)
+    }
+    
+}

--- a/iOS/traveline/Sources/Core/Cache/TLImageCache.swift
+++ b/iOS/traveline/Sources/Core/Cache/TLImageCache.swift
@@ -1,0 +1,29 @@
+//
+//  TLImageCache.swift
+//  traveline
+//
+//  Created by 김태현 on 11/26/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+final class TLImageCache {
+    
+    static let shared = TLImageCache()
+    
+    private let imageCacheRepository: ImageCacheRepository = ImageCacheRepositoryImpl(fileManager: FileManager.default)
+    
+    private init() {}
+    
+    // MARK: - Functions
+    
+    func fetch(_ urlString: String) -> Data? {
+        imageCacheRepository.fetch(urlString)
+    }
+    
+    func store(_ data: Data, urlString: String) {
+        imageCacheRepository.store(data, cacheKey: urlString)
+    }
+    
+}

--- a/iOS/traveline/Sources/Core/Cache/TLImageDownloader.swift
+++ b/iOS/traveline/Sources/Core/Cache/TLImageDownloader.swift
@@ -24,7 +24,7 @@ final class TLImageDownloader {
     func cancelDownload(key: AnyHashable) {
         downloadTaskQueue.async { [weak self] in
             self?.downloadTasks[key]?.cancel()
-            self?.downloadTasks[key] = nil
+            self?.downloadTasks.removeValue(forKey: key)
         }
     }
     

--- a/iOS/traveline/Sources/Core/Cache/TLImageDownloader.swift
+++ b/iOS/traveline/Sources/Core/Cache/TLImageDownloader.swift
@@ -1,0 +1,50 @@
+//
+//  TLImageDownloader.swift
+//  traveline
+//
+//  Created by 김태현 on 11/26/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+final class TLImageDownloader {
+    
+    static let shared = TLImageDownloader()
+    
+    private let downloadTaskQueue = DispatchQueue(label: "TLImageDownloader")
+    private var downloadTasks: [AnyHashable: Task<Data, Error>] = .init()
+    
+    private init() {}
+    
+    // MARK: - Functions
+    
+    /// 기존의 Download Task를 취소합니다.
+    /// - Parameter key: 취소할 UIImageView
+    func cancelDownload(key: AnyHashable) {
+        downloadTaskQueue.async { [weak self] in
+            self?.downloadTasks[key]?.cancel()
+            self?.downloadTasks[key] = nil
+        }
+    }
+    
+    /// URL에서 이미지를 다운로드합니다.
+    /// - Parameters:
+    ///   - key: 다운로드할 UIImageView
+    ///   - urlString: 다운로드할 URL 문자열
+    /// - Returns: 다운로드 받은 이미지 데이터
+    func download(key: AnyHashable, urlString: String) async -> Data? {
+        guard let url = URL(string: urlString) else { return nil }
+        let downloadTask = Task {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            return data
+        }
+        
+        downloadTaskQueue.async { [weak self] in
+            self?.downloadTasks[key] = downloadTask
+        }
+        
+        return try? await downloadTask.value
+    }
+    
+}

--- a/iOS/traveline/Sources/Core/Extension/UIImageView+.swift
+++ b/iOS/traveline/Sources/Core/Extension/UIImageView+.swift
@@ -1,0 +1,34 @@
+//
+//  UIImageView+.swift
+//  traveline
+//
+//  Created by 김태현 on 11/26/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import UIKit
+
+extension UIImageView {
+    
+    /// urlString으로부터 이미지를 Load 합니다.
+    /// 캐시에 존재한다면 캐시에서 가져오고, 없으면 다운로드합니다.
+    /// - Parameter urlString: 이미지 URL 문자열
+    func setImage(from urlString: String) {
+        if let cachedImageData = TLImageCache.shared.fetch(urlString) {
+            image = UIImage(data: cachedImageData)
+            return
+        }
+        
+        Task {
+            guard let downloadImageData = await TLImageDownloader.shared.download(key: self, urlString: urlString) else { return }
+            TLImageCache.shared.store(downloadImageData, urlString: urlString)
+            image = UIImage(data: downloadImageData) 
+        }
+    }
+    
+    /// 재사용 시 기존 UIImageView의 Download Task를 취소합니다.
+    func cancel() {
+        TLImageDownloader.shared.cancelDownload(key: self)
+    }
+    
+}

--- a/iOS/traveline/Sources/Domain/Model/Timeline/TimelineSample.swift
+++ b/iOS/traveline/Sources/Domain/Model/Timeline/TimelineSample.swift
@@ -32,7 +32,7 @@ enum TimelineSample {
         return [
             .init(
                 detailId: 1,
-                thumbnailURL: "",
+                thumbnailURL: "https://picsum.photos/600/400",
                 title: "광안리 최고~",
                 subtitle: "광안리 해수욕장",
                 content: "어쩌고 저쩌고 이러쿵 저러쿵",
@@ -42,7 +42,7 @@ enum TimelineSample {
             ),
             .init(
                 detailId: 1,
-                thumbnailURL: "",
+                thumbnailURL: "https://picsum.photos/600/300",
                 title: "호텔 오션뷰 최고",
                 subtitle: "호텔 센트럴베이",
                 content: "너무 깔끔하고 좋네요",
@@ -52,7 +52,7 @@ enum TimelineSample {
             ),
             .init(
                 detailId: 1,
-                thumbnailURL: "",
+                thumbnailURL: "https://picsum.photos/500/400",
                 title: "맛있는게 많네요",
                 subtitle: "민락더마켓",
                 content: "주차장도 넓고 바로 앞에 바다가 있어요",
@@ -62,7 +62,7 @@ enum TimelineSample {
             ),
             .init(
                 detailId: 1,
-                thumbnailURL: "",
+                thumbnailURL: "https://picsum.photos/500/300",
                 title: "산책하기 좋아요",
                 subtitle: "해운대 해수욕장",
                 content: "어쩌고 저쩌고 이러쿵 저러쿵",
@@ -72,7 +72,47 @@ enum TimelineSample {
             ),
             .init(
                 detailId: 1,
-                thumbnailURL: "",
+                thumbnailURL: "https://picsum.photos/600/400",
+                title: "곱창전골이 맛있어요",
+                subtitle: "해성막창집 본점",
+                content: "웨이팅이 길고 주차가 어렵고 어쩌고",
+                time: "21:00",
+                latitude: 35.163869,
+                longitude: 129.163293
+            ),
+            .init(
+                detailId: 1,
+                thumbnailURL: "https://picsum.photos/700/400",
+                title: "곱창전골이 맛있어요",
+                subtitle: "해성막창집 본점",
+                content: "웨이팅이 길고 주차가 어렵고 어쩌고",
+                time: "21:00",
+                latitude: 35.163869,
+                longitude: 129.163293
+            ),
+            .init(
+                detailId: 1,
+                thumbnailURL: "https://picsum.photos/700/500",
+                title: "곱창전골이 맛있어요",
+                subtitle: "해성막창집 본점",
+                content: "웨이팅이 길고 주차가 어렵고 어쩌고",
+                time: "21:00",
+                latitude: 35.163869,
+                longitude: 129.163293
+            ),
+            .init(
+                detailId: 1,
+                thumbnailURL: "https://picsum.photos/700/600",
+                title: "곱창전골이 맛있어요",
+                subtitle: "해성막창집 본점",
+                content: "웨이팅이 길고 주차가 어렵고 어쩌고",
+                time: "21:00",
+                latitude: 35.163869,
+                longitude: 129.163293
+            ),
+            .init(
+                detailId: 1,
+                thumbnailURL: "https://picsum.photos/700/700",
                 title: "곱창전골이 맛있어요",
                 subtitle: "해성막창집 본점",
                 content: "웨이팅이 길고 주차가 어렵고 어쩌고",

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/View/TimelineCardCVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/View/TimelineCardCVC.swift
@@ -48,6 +48,7 @@ final class TimelineCardCVC: UICollectionViewCell {
     // MARK: - Properties
     
     private lazy var lineHeightConstraint: NSLayoutConstraint = lineView.bottomAnchor.constraint(equalTo: bottomAnchor)
+    private lazy var lastLineHeightConstraint: NSLayoutConstraint = lineView.bottomAnchor.constraint(equalTo: cardView.centerYAnchor)
     
     // MARK: - Initializer
     
@@ -61,6 +62,14 @@ final class TimelineCardCVC: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        cardView.reset()
+        lastLineHeightConstraint.isActive = false
+        lineHeightConstraint.isActive = true
+    }
+    
     // MARK: - Functions
     
     func setData(by cardInfo: TimelineCardInfo) {
@@ -71,7 +80,7 @@ final class TimelineCardCVC: UICollectionViewCell {
     /// 마지막 셀일 때 line 길이 수정
     func changeToLast() {
         lineHeightConstraint.isActive = false
-        lineView.bottomAnchor.constraint(equalTo: cardView.centerYAnchor).isActive = true
+        lastLineHeightConstraint.isActive = true
     }
 }
 

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/View/TimelineCardView.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/View/TimelineCardView.swift
@@ -55,7 +55,15 @@ final class TimelineCardView: UIView {
         titleLabel.setText(to: cardInfo.title)
         subtitleLabel.setText(to: cardInfo.subtitle)
         contentLabel.setText(to: cardInfo.content)
+        thumbnailImageView.setImage(from: cardInfo.thumbnailURL)
     }
+    
+    /// 셀 재사용 시 이미지 reset
+    func reset() {
+        thumbnailImageView.cancel()
+        thumbnailImageView.image = nil
+    }
+    
 }
 
 // MARK: - Setup Functions
@@ -66,8 +74,6 @@ private extension TimelineCardView {
         layer.cornerRadius = Metric.radius
         thumbnailImageView.backgroundColor = TLColor.disabledGray
         thumbnailImageView.layer.cornerRadius = 12.0
-        // TODO: - 서버 연동 후 수정
-        thumbnailImageView.image = TravelineAsset.Images.travelImage.image
         thumbnailImageView.clipsToBounds = true
     }
     


### PR DESCRIPTION
## 🌎 PR 요약
> 이미지 캐싱 구현

🌱 작업한 브랜치
- feature/#129

## 📚 작업한 내용
### 1. ImageCacheRepository 구현
- 이미지 캐싱 또한 저장소로 볼 수 있지 않을까..? 라는 생각에 Repository를 통하도록 구현해봤습니다.
- `ImageCacheRepository`에서 `memoryCache`와 `fileManager`를 가지고 있습니다!

### 2. 전체적인 흐름
1. `UIImageView` -> `setImage`
2. `TLImageCache`에서 메모리 캐시, 디스크 캐시를 확인하고 있으면 가져옵니다.
3. 없으면 `TLImageDownloader`에서 `downloadTask`를 통해 이미지를 다운로드하고 `TLImageCache`에 저장합니다.

### 3. UIImageView 재사용 시 downloadTask 밀림(?) 현상
- cell 안에 UIImageView가 있고 재사용될 때, 이전 셀에서 요청한 downloadTask의 응답이 뒤늦게 도착해서 이미지가 여러번 변경되는 현상이 있었습니다.
- cancel 로직 구현을 위해 `TLImageDownloader`에서 downloadTask를 딕셔너리로 들고 있다가, cancelDownload 시에 해당 downloadTask를 cancel 해주었습니다!
- 이때 딕셔너리가 thread safe하지 않기 때문에 `downloadTaskQueue`를 만들고 해당 DispatchQueue에서 딕셔너리에 write 하도록 했슴다

### 4. 캐시 정책?
- 현재는 단순하게 `memoryCache`의 `countLimit`을 50개로 정해두었는데, 어떤 방식으로 정책을 정하면 좋을지.. 고민해봐야 할 것 같습니닷
- 아래 영상은 countLimit을 2개로 두고 diskCache에서 가져오는 걸 테스트해본 영상입니다~!
<br/>

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

아래와 같이 사용하시면 됩니다!!
~~~swift
thumbnailImageView.setImage(from: "이미지 URL")

// prepareForReuse..
thumbnailImageView.cancel()
~~~

`ImageCacheRepository` 같은 경우에 Interface는 Domain layer에, 구현체는 Data layer에 있어야 하나 싶은데 일단 지금은 기웅님 작업 (Data, Domain 플로우)이랑 겹칠 수 있을 것 같아서 `Core - Cache`에 모아뒀습니당 🙂

## 📸 스크린샷
https://github.com/boostcampwm2023/iOS07-traveline/assets/51712973/bbed20fe-6461-4bf6-aa27-a24752745c71

## 관련 이슈
- Closes #129 
