### PR TITLE
[feat] TravelViewModel 구현

### DIFF
--- a/iOS/traveline/Sources/Core/Enum/TagType.swift
+++ b/iOS/traveline/Sources/Core/Enum/TagType.swift
@@ -89,4 +89,11 @@ enum TagType: CaseIterable {
             SeasonFilter.allCases.map { $0.title }
         }
     }
+    
+    var isMultiple: Bool {
+        switch self {
+        case .theme, .with: true
+        default: false
+        }
+    }
 }

--- a/iOS/traveline/Sources/DesignSystem/Component/TLTag/TLTag.swift
+++ b/iOS/traveline/Sources/DesignSystem/Component/TLTag/TLTag.swift
@@ -80,6 +80,7 @@ final class TLTag: UIButton {
     private var style: TLTagStyle
     private let tagColor: UIColor
     private let defaultColor: UIColor = TLColor.mediumGray
+    let name: String
 
     // MARK: - Initialize
     
@@ -91,6 +92,7 @@ final class TLTag: UIButton {
     ) {
         self.style = style
         self.tagColor = color
+        self.name = name
         tagTitleLabel.setText(to: name)
         tagTitleLabel.setFont(to: style.font)
         

--- a/iOS/traveline/Sources/DesignSystem/View/TLTagList/TLTagListView.swift
+++ b/iOS/traveline/Sources/DesignSystem/View/TLTagList/TLTagListView.swift
@@ -42,20 +42,27 @@ final class TLTagListView: UIView {
     
     private var detailTagList: [TLTag] = .init()
     private lazy var currentStackView: UIStackView = tagStackView
-    
+    private var tagType: TagType?
+    private var selectedTag: TLTag?
+
     private var currentWidth: CGFloat = 0
     private let limitWidth: CGFloat
+    
+    var selectedTags: [String] {
+        detailTagList.filter({ $0.isSelected }).map { $0.name }
+    }
     
     // MARK: - Initializer
     
     init(tagType: TagType, width: CGFloat) {
         self.limitWidth = width
+        self.tagType = tagType
         
         super.init(frame: .zero)
         
         setupAttributes()
         setupLayout()
-        setupTags(type: tagType)
+        setupTags()
     }
     
     init(width: CGFloat) {
@@ -86,6 +93,10 @@ final class TLTagListView: UIView {
     }
     
     @objc private func selectTag(_ sender: TLTag) {
+        if let tagType, !tagType.isMultiple {
+            selectedTag?.isSelected = false
+            selectedTag = sender
+        }
         sender.isSelected.toggle()
     }
     
@@ -150,12 +161,13 @@ private extension TLTagListView {
         ])
     }
     
-    func setupTags(type: TagType) {
-        type.detailTags.forEach { detailTag in
+    func setupTags() {
+        guard let tagType else { return }
+        tagType.detailTags.forEach { detailTag in
             let tlTag: TLTag = .init(
                 style: .selectable,
                 name: detailTag,
-                color: type.color
+                color: tagType.color
             )
             let neededWidth: CGFloat = tlTag.intrinsicContentSize.width + Metric.tagSpacing
             

--- a/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/VC/TravelVC.swift
+++ b/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/VC/TravelVC.swift
@@ -67,6 +67,22 @@ final class TravelVC: UIViewController {
     private let withTagView: SelectTagView = .init(tagType: .with, width: Metric.width)
     private let costTagView: SelectTagView = .init(tagType: .cost, width: Metric.width)
     
+    // MARK: - Properties
+    
+    private var cancellables: Set<AnyCancellable> = .init()
+    private let viewModel: TravelViewModel
+    
+    // MARK: - Initializer
+    
+    init(viewModel: TravelViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     // MARK: - Life Cycle
     
     override func viewDidLoad() {
@@ -75,6 +91,7 @@ final class TravelVC: UIViewController {
         setupAttributes()
         setupLayout()
         setupKeyboard()
+        bind()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -84,10 +101,6 @@ final class TravelVC: UIViewController {
     }
 
     // MARK: - Functions
-    
-    @objc private func doneButtonPressed() {
-        // TODO: - 완료 버튼 처리
-    }
     
     @objc private func dismissKeyboard() {
         view.endEditing(true)
@@ -102,6 +115,28 @@ final class TravelVC: UIViewController {
         regionBottomSheetVC.delegate = self
         present(regionBottomSheetVC, animated: true)
     }
+    
+    @objc private func selectStartDate(_ sender: UIDatePicker) {
+        let startDate = sender.date
+        viewModel.sendAction(.startDateSelected(startDate))
+        
+        if selectPeriodView.endDatePicker.date < startDate {
+            selectPeriodView.endDatePicker.date = startDate
+            viewModel.sendAction(.endDateSelected(startDate))
+        }
+        
+        selectPeriodView.endDatePicker.minimumDate = startDate
+        
+        dismiss(animated: false)
+    }
+    
+    @objc private func selectEndDate(_ sender: UIDatePicker) {
+        let endDate = sender.date
+        viewModel.sendAction(.endDateSelected(endDate))
+        
+        dismiss(animated: false)
+    }
+    
 }
 
 // MARK: - Setup Functions
@@ -111,7 +146,10 @@ private extension TravelVC {
         view.backgroundColor = TLColor.black
         titleTextField.placeholder = Constants.textFieldPlaceholder
         baseScrollView.delegate = self
+        titleTextField.delegate = self
         selectRegionButton.addTarget(self, action: #selector(selectRegion), for: .touchUpInside)
+        selectPeriodView.startDatePicker.addTarget(self, action: #selector(selectStartDate(_:)), for: .primaryActionTriggered)
+        selectPeriodView.endDatePicker.addTarget(self, action: #selector(selectEndDate(_:)), for: .valueChanged)
         
         tlNavigationBar.delegate = self
     }
@@ -188,6 +226,16 @@ private extension TravelVC {
         )
         baseScrollView.addGestureRecognizer(tapGesture)
     }
+    
+    func bind() {
+        viewModel.$state
+            .map(\.canPost)
+            .sink { [weak owner = self] canPost in
+                guard let owner else { return }
+                owner.tlNavigationBar.isRightButtonEnabled(canPost)
+            }
+            .store(in: &cancellables)
+    }
 }
 
 // MARK: - UIScrollView Delegate
@@ -198,12 +246,27 @@ extension TravelVC: UIScrollViewDelegate {
     }
 }
 
+// MARK: - UITextField Delegate
+
+extension TravelVC: UITextFieldDelegate {
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        guard let text = textField.text else { return }
+        viewModel.sendAction(.titleEdited(text))
+    }
+    
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        dismissKeyboard()
+        return true
+    }
+}
+
 // MARK: - TLBottomSheetDelegate
 
 extension TravelVC: TLBottomSheetDelegate {
     func bottomSheetDidDisappear(data: Any) {
         guard let region = data as? String else { return }
         selectRegionButton.setSelectedTitle(region)
+        viewModel.sendAction(.regionSelected(region))
     }
 }
 
@@ -211,11 +274,19 @@ extension TravelVC: TLBottomSheetDelegate {
 
 extension TravelVC: TLNavigationBarDelegate {
     func rightButtonDidTapped() {
-        // TODO: 네비게이션 바 완료 버튼 선택
+        let selectedTags = [
+            peopleTagView.selectedTags.map { Tag(title: $0, type: .people) },
+            transportationTagView.selectedTags.map { Tag(title: $0, type: .transportation) },
+            themeTagView.selectedTags.map { Tag(title: $0, type: .theme) },
+            withTagView.selectedTags.map { Tag(title: $0, type: .with) },
+            costTagView.selectedTags.map { Tag(title: $0, type: .cost) }
+        ].flatMap({ $0 })
+        
+        viewModel.sendAction(.donePressed(selectedTags))
     }
 }
 
 @available(iOS 17, *)
 #Preview {
-    return UINavigationController(rootViewController: TravelVC())
+    return UINavigationController(rootViewController: TravelVC(viewModel: TravelViewModel()))
 }

--- a/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/VC/TravelVC.swift
+++ b/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/VC/TravelVC.swift
@@ -119,14 +119,7 @@ final class TravelVC: UIViewController {
     @objc private func selectStartDate(_ sender: UIDatePicker) {
         let startDate = sender.date
         viewModel.sendAction(.startDateSelected(startDate))
-        
-        if selectPeriodView.endDatePicker.date < startDate {
-            selectPeriodView.endDatePicker.date = startDate
-            viewModel.sendAction(.endDateSelected(startDate))
-        }
-        
-        selectPeriodView.endDatePicker.minimumDate = startDate
-        
+
         dismiss(animated: false)
     }
     
@@ -230,9 +223,27 @@ private extension TravelVC {
     func bind() {
         viewModel.$state
             .map(\.canPost)
+            .removeDuplicates()
             .sink { [weak owner = self] canPost in
                 guard let owner else { return }
                 owner.tlNavigationBar.isRightButtonEnabled(canPost)
+            }
+            .store(in: &cancellables)
+        
+        viewModel.$state
+            .map(\.startDate)
+            .sink { [weak owner = self] startDate in
+                guard let owner else { return }
+                owner.selectPeriodView.endDatePicker.minimumDate = startDate
+            }
+            .store(in: &cancellables)
+        
+        viewModel.$state
+            .map(\.endDate)
+            .removeDuplicates()
+            .sink { [weak owner = self] endDate in
+                guard let owner else { return }
+                owner.selectPeriodView.endDatePicker.date = endDate
             }
             .store(in: &cancellables)
     }

--- a/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/View/SelectTagView.swift
+++ b/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/View/SelectTagView.swift
@@ -55,6 +55,10 @@ final class SelectTagView: UIView {
     private let tagType: TagType
     private let limitWidth: CGFloat
     
+    var selectedTags: [String] {
+        tagListView.selectedTags
+    }
+    
     // MARK: - Initializer
     
     init(tagType: TagType, width: CGFloat) {

--- a/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/ViewModel/TravelViewModel.swift
+++ b/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/ViewModel/TravelViewModel.swift
@@ -77,6 +77,7 @@ final class TravelViewModel: BaseViewModel<TravelAction, TravelSideEffect, Trave
             
         case let .saveStartDate(startDate):
             newState.startDate = startDate
+            if !newState.isValidDate { newState.endDate = startDate }
             
         case let .saveEndDate(endDate):
             newState.endDate = endDate

--- a/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/ViewModel/TravelViewModel.swift
+++ b/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/ViewModel/TravelViewModel.swift
@@ -1,0 +1,108 @@
+//
+//  TravelViewModel.swift
+//  traveline
+//
+//  Created by 김태현 on 11/27/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Combine
+import Foundation
+
+enum TravelAction: BaseAction {
+    case titleEdited(String)
+    case regionSelected(String)
+    case startDateSelected(Date)
+    case endDateSelected(Date)
+    case donePressed([Tag])
+}
+
+enum TravelSideEffect: BaseSideEffect {
+    case saveTitle(String)
+    case saveRegion(String)
+    case saveStartDate(Date)
+    case saveEndDate(Date)
+    case postTravel([Tag])
+    case invalidTitle
+}
+
+struct TravelState: BaseState {
+    var titleText: String = Literal.empty
+    var region: String = Literal.empty
+    var startDate: Date = .now
+    var endDate: Date = .now
+    var isValidTitle: Bool = false
+    
+    var isValidDate: Bool {
+        startDate <= endDate
+    }
+    
+    var canPost: Bool {
+        isValidTitle && !region.isEmpty && isValidDate
+    }
+}
+
+final class TravelViewModel: BaseViewModel<TravelAction, TravelSideEffect, TravelState> {
+    
+    override func transform(action: TravelAction) -> SideEffectPublisher {
+        switch action {
+        case let .titleEdited(title):
+            validate(title: title)
+            
+        case let .regionSelected(region):
+            Just(TravelSideEffect.saveRegion(region)).eraseToAnyPublisher()
+            
+        case let .startDateSelected(startDate):
+            Just(TravelSideEffect.saveStartDate(startDate)).eraseToAnyPublisher()
+            
+        case let .endDateSelected(endDate):
+            Just(TravelSideEffect.saveEndDate(endDate)).eraseToAnyPublisher()
+            
+        case let .donePressed(tags):
+            // TODO: - Posting API
+            Just(TravelSideEffect.postTravel(tags)).eraseToAnyPublisher()
+        }
+    }
+    
+    override func reduceState(state: TravelState, effect: TravelSideEffect) -> TravelState {
+        var newState = state
+        
+        switch effect {
+        case let .saveTitle(title):
+            newState.titleText = title
+            newState.isValidTitle = true
+            
+        case let .saveRegion(region):
+            newState.region = region
+            
+        case let .saveStartDate(startDate):
+            newState.startDate = startDate
+            
+        case let .saveEndDate(endDate):
+            newState.endDate = endDate
+            
+        case let .postTravel(tags):
+            // TODO: - Posting 성공 이후 State (타임라인 화면으로 이동?)
+            break
+            
+        case .invalidTitle:
+            newState.isValidTitle = false
+        }
+        
+        return newState
+    }
+    
+}
+
+// MARK: - Validation
+
+private extension TravelViewModel {
+    // TODO: - 정규식을 통한 제목 유효성 검사
+    func validate(title: String) -> SideEffectPublisher {
+        if 1...14 ~= title.count {
+            Just(TravelSideEffect.saveTitle(title)).eraseToAnyPublisher()
+        } else {
+            Just(TravelSideEffect.invalidTitle).eraseToAnyPublisher()
+        }
+    }
+}


### PR DESCRIPTION
## 🌎 PR 요약
> 여행 생성 화면 View Model 구현, 연결

🌱 작업한 브랜치
- feature/#136

## 📚 작업한 내용
### 1. TagType, TLTagListView에 다중 선택 여부 처리
- "테마"와 "함께" 태그만 다중 선택이 가능한 것을 확인하고 `TagType`에 `isMultiple` 프로퍼티를 추가했습니다.
- `TLTagListView`에서 태그를 선택할 때도 `TagType`에 따라 다중 선택을 구현했습니다!

### 2. TravelViewModel 구현, 연결
- TravelViewModel을 구현하고 TravelVC에 연결했습니다.
- 현재 제목이 입력됐을 때, 지역이 선택됐을 때, 출발/도착 날짜가 선택됐을 때 Action을 보내주고 있습니다!
- 완료 버튼의 활성화 여부를 제목, 지역, 날짜의 올바른 입력 여부에 바인딩 해두었습니다.
- 완료 버튼을 눌렀을 때 선택된 Tag들을 전달하게 됩니다!

### 3. Date Picker
- "출발 날짜가 도착 날짜보다 빠르거나 같아야 한다"라는 조건을 위해 ViewModel에도 isValidDate라는 값을 검사하고 있지만, Date Picker의 minimumDate를 설정해 도착 날짜 선택 Date Picker는 출발 날짜 이전의 날짜를 선택할 수 없도록 해두었습니다!

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
선택된 태그들의 관리에 대해 고민이 있었는데요!
태그가 선택될 때마다 이걸 ViewModel로 넘겨주어 관리해야하나? 하는 고민이 있었습니다.

하지만 현재 입력받는 태그가 필수 태그가 아니고, 태그의 선택 여부에 따라 화면의 상태 (`State`)가 변하지 않는다,, 라고 느껴져서
완료 버튼을 누르게 되었을 때 선택된 태그들을 `donePressed` action과 함께 보내주게 해놨는데,
이렇게 되면 네트워크 요청을 보낼 때 어떤 데이터는 `State`에서 가져와서 쓰고, 어떤 데이터(태그)는 `action`에서 받아와서 쓰는게 어색할까? 하는 고민이 또 있네용,, 다른분들 생각은 어떠신가요??

## 📸 스크린샷
https://github.com/boostcampwm2023/iOS07-traveline/assets/51712973/3005b7d3-b39e-4c2b-892c-fa856a335a42


## 관련 이슈
- Resolved: #136
