### PR TITLE
[hotfix] HomeVC에서 TravelViewModel 주입

### DIFF
--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/VC/HomeVC.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/VC/HomeVC.swift
@@ -226,7 +226,7 @@ private extension HomeVC {
             .filter { $0 }
             .withUnretained(self)
             .sink { owner, _ in
-                let travelVC = TravelVC()
+                let travelVC = TravelVC(viewModel: TravelViewModel())
                 owner.navigationController?.pushViewController(travelVC, animated: true)
             }
             .store(in: &cancellables)


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- feature/#157

## 📚 작업한 내용
### HomeVC에서 TravelViewModel 주입
- TravelViewModel 구현 이후 develop으로 merge 되었는데, 기존 develop에 존재하던 HomeVC에서 TravelVC 생성 시 viewModel 주입이 되지 않아서 에러가 발생하고 있었습니다.
- 일단 viewModel 생성자를 추가해주었는데, 어떻게 이렇게 된건지..? 파악중입니다..

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
TravelViewModel을 수정된 develop으로 fetch-rebase한 과정에서 해당 에러를 처리하지 않고 merge된 것 같습니다 ^^;;
죄송함니다!!! 🙇🏻

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 관련 이슈
- Resolved: #157
