### PR TITLE
[feat] 애플 로그인 구현

### DIFF
--- a/iOS/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/iOS/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -36,6 +36,7 @@ extension Project {
             infoPlist: .extendingDefault(with: infoPlist),
             sources: ["\(name)/Sources/**"],
             resources: ["\(name)/Resources/**"],
+            entitlements: "\(name)/\(name).entitlements",
             scripts: [.swiftLintShell],
             dependencies: dependencies,
             settings: .settings(

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeViewModel.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeViewModel.swift
@@ -14,19 +14,25 @@ final class HomeViewModel: BaseViewModel<HomeAction, HomeSideEffect, HomeState> 
     override func transform(action: Action) -> SideEffectPublisher {
         switch action {
         case .viewDidLoad, .cancelSearch:
-                .just(HomeSideEffect.showList)
+            return .just(HomeSideEffect.showList)
+            
         case .startSearch:
-                .just(HomeSideEffect.showRecent)
+            return .just(HomeSideEffect.showRecent)
+            
         case let .searching(text):
-                .just(HomeSideEffect.showRelated(text))
+            return .just(HomeSideEffect.showRelated(text))
+            
         case let .searchDone(text):
-                .just(HomeSideEffect.showResult(text))
+            return .just(HomeSideEffect.showResult(text))
+            
         case let .startFilter(type):
-                .just(HomeSideEffect.showFilter(type))
+            return .just(HomeSideEffect.showFilter(type))
+            
         case let .addFilter(filterList):
-                .just(HomeSideEffect.saveFilter(filterList))
+            return .just(HomeSideEffect.saveFilter(filterList))
+            
         case .createTravel:
-                .just(HomeSideEffect.showTravelWriting)
+            return .just(HomeSideEffect.showTravelWriting)
         }
     }
     
@@ -40,12 +46,14 @@ final class HomeViewModel: BaseViewModel<HomeAction, HomeSideEffect, HomeState> 
             newState.homeViewType = .recent
             newState.curFilter = nil
             newState.isSearching = true
+            
         case let .showRelated(text):
             // TODO: - 서버 연동 후 수정
             newState.searchList = SearchKeywordSample.makeRelatedList()
             newState.homeViewType = (text.isEmpty) ? .recent : .related
             newState.searchText = text
             newState.isSearching = true
+            
         case let .showResult(text):
             // TODO: - 서버 연동 후 수정
             newState.travelList = TravelListSample.make()
@@ -53,13 +61,16 @@ final class HomeViewModel: BaseViewModel<HomeAction, HomeSideEffect, HomeState> 
             newState.searchText = text
             newState.isSearching = false
             newState.resultFilters = .make()
+            
         case .showList:
             // TODO: - 서버 연동 후 수정
             newState.travelList = TravelListSample.make()
             newState.homeViewType = .home
             newState.isSearching = false
+            
         case let .showFilter(type):
             newState.curFilter = (state.homeViewType == .home) ? state.homeFilters[type] : state.resultFilters[type]
+            
         case let .saveFilter(filterList):
             if state.homeViewType == .home {
                 filterList.forEach { newState.homeFilters[$0.type] = $0 }
@@ -67,6 +78,7 @@ final class HomeViewModel: BaseViewModel<HomeAction, HomeSideEffect, HomeState> 
                 filterList.forEach { newState.resultFilters[$0.type] = $0 }
             }
             newState.curFilter = nil
+            
         case .showTravelWriting:
             newState.moveToTravelWriting = true
         }

--- a/iOS/traveline/Sources/Feature/LoginFeature/ViewModel/LoginViewModel.swift
+++ b/iOS/traveline/Sources/Feature/LoginFeature/ViewModel/LoginViewModel.swift
@@ -1,0 +1,79 @@
+//
+//  LoginViewModel.swift
+//  traveline
+//
+//  Created by 김영인 on 2023/11/29.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import AuthenticationServices
+import Foundation
+
+typealias AppleIDRequest = ASAuthorizationAppleIDRequest
+typealias Auth = ASAuthorization
+
+enum LoginAction: BaseAction {
+    case startAppleLogin
+    case successAppleLogin(Auth)
+    case failAppleLogin
+}
+
+enum LoginSideEffect: BaseSideEffect {
+    case requestAppleLogin(AppleIDRequest)
+    case completeAppleLogin(Bool)
+}
+
+struct LoginState: BaseState {
+    var appleIDRequests: [AppleIDRequest]?
+    var isSuccessLogin: Bool = false
+}
+
+final class LoginViewModel: BaseViewModel<LoginAction, LoginSideEffect, LoginState> {
+    
+    override func transform(action: LoginAction) -> SideEffectPublisher {
+        switch action {
+        case .startAppleLogin:
+            requestAppleLogin()
+        case let .successAppleLogin(auth):
+            handleAppleAuth(auth)
+        case .failAppleLogin:
+                .just(LoginSideEffect.completeAppleLogin(false))
+        }
+    }
+    
+    override func reduceState(state: LoginState, effect: LoginSideEffect) -> LoginState {
+        var newState = state
+        
+        switch effect {
+        case let .requestAppleLogin(request):
+            newState.appleIDRequests = [request]
+        case let .completeAppleLogin(isSuccess):
+            newState.isSuccessLogin = isSuccess
+        }
+        
+        return newState
+    }
+}
+
+private extension LoginViewModel {
+    func requestAppleLogin() -> SideEffectPublisher {
+        let appleIDProvider = ASAuthorizationAppleIDProvider()
+        let request = appleIDProvider.createRequest()
+        
+        return .just(LoginSideEffect.requestAppleLogin(request))
+    }
+    
+    func handleAppleAuth(_ auth: Auth) -> SideEffectPublisher {
+        guard let appleIDCredential = auth.credential as? ASAuthorizationAppleIDCredential else {
+            return .just(LoginSideEffect.completeAppleLogin(false))
+        }
+        
+        let userIdentifier = appleIDCredential.user
+        if let identityToken = appleIDCredential.identityToken,
+           let identityTokenString = String(data: identityToken, encoding: .utf8) {
+            // TODO: 로그인 API에 identityTokenString 담아서 로그인하기
+        }
+        
+        return .just(LoginSideEffect.completeAppleLogin(true))
+    }
+}

--- a/iOS/traveline/Sources/Feature/LoginFeature/ViewModel/LoginViewModel.swift
+++ b/iOS/traveline/Sources/Feature/LoginFeature/ViewModel/LoginViewModel.swift
@@ -33,11 +33,13 @@ final class LoginViewModel: BaseViewModel<LoginAction, LoginSideEffect, LoginSta
     override func transform(action: LoginAction) -> SideEffectPublisher {
         switch action {
         case .startAppleLogin:
-            requestAppleLogin()
+            return requestAppleLogin()
+            
         case let .successAppleLogin(auth):
-            handleAppleAuth(auth)
+            return handleAppleAuth(auth)
+            
         case .failAppleLogin:
-                .just(LoginSideEffect.completeAppleLogin(false))
+            return .just(LoginSideEffect.completeAppleLogin(false))
         }
     }
     
@@ -47,6 +49,7 @@ final class LoginViewModel: BaseViewModel<LoginAction, LoginSideEffect, LoginSta
         switch effect {
         case let .requestAppleLogin(request):
             newState.appleIDRequests = [request]
+            
         case let .completeAppleLogin(isSuccess):
             newState.isSuccessLogin = isSuccess
         }
@@ -68,7 +71,6 @@ private extension LoginViewModel {
             return .just(LoginSideEffect.completeAppleLogin(false))
         }
         
-        let userIdentifier = appleIDCredential.user
         if let identityToken = appleIDCredential.identityToken,
            let identityTokenString = String(data: identityToken, encoding: .utf8) {
             // TODO: 로그인 API에 identityTokenString 담아서 로그인하기

--- a/iOS/traveline/traveline.entitlements
+++ b/iOS/traveline/traveline.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- feature/#165

## 📚 작업한 내용
- sign with apple 설정 추가 (cc. tuist)
- 애플 로그인 구현 (cc. vc + viewmodel)

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
### 애플 로그인 구현
- start [애플 로그인 버튼 클릭 시]
- success [delegate로 complete 받아올 시]
- fail [delegate로 error 받아올 시]

시점을 기준으로 ViewModel을 생성했습니다 :)

### tuist에 entitlements 추가
sign with apple을 추가하면 entitlements가 추가되는데
Target에 해당 옵션을 추가해줘야 tuist generate할 때 같이 생성돼서 사용할 수 있습니다 :)

~~### userIdentifier, identitytoken
일단 애플 로그인을 통해 위의 두 가지를 받아오도록 했습니다.
identitytoken은 무조건 서버에 넘겨줘야하고, userIdentifier도 저번에 얘기가 나왔어서 일단은 추가했는데
추후에 서버랑 협의하고 필요없으면 제외해도 좋을 것 같습니다 !~~
→ 협의 완! userIdentifier 제외하겠습니다 !

### 로그인 실패 케이스
로그인 실패하는 경우에 대한 alert창이나 toast가 필요하지 않을까 싶네요 , ,
구현하면서 서버 에러 등의 케이스가 발생할텐데 alert이나 toast로 통일하고 message만 다르게 가져가도 좋을 것 같아요 :)

## 📸 스크린샷
https://github.com/boostcampwm2023/iOS07-traveline/assets/74968390/020aad6d-6598-4c18-b0ea-a9cc1d8068a2

## 관련 이슈
- Resolved: #165 
