### PR TITLE
[refactor] Posting 엔티티에서 @RelationId 제거 (기능 변화X)

### DIFF
--- a/BE/src/postings/entities/posting.entity.ts
+++ b/BE/src/postings/entities/posting.entity.ts
@@ -6,7 +6,6 @@ import {
   ManyToOne,
   OneToMany,
   PrimaryGeneratedColumn,
-  RelationId,
 } from 'typeorm';
 import { Liked } from './liked.entity';
 import { Report } from './report.entity';
@@ -43,9 +42,6 @@ export class Posting {
   @Column({ length: 255, nullable: true, default: null })
   thumbnail: string;
 
-  @RelationId((posting: Posting) => posting.likeds)
-  liked: { user: string; posting: string }[];
-
   @Column({ name: 'start_date', type: 'date' })
   startDate: Date;
 
@@ -78,9 +74,6 @@ export class Posting {
 
   @Column({ type: 'json', nullable: true })
   withWho: WithWho[];
-
-  @RelationId((posting: Posting) => posting.reports)
-  report: { reporter: string; posting: string }[];
 
   @OneToMany(() => Timeline, (timeline) => timeline.postings)
   timelines: Timeline[];

--- a/BE/src/postings/posting.swagger.ts
+++ b/BE/src/postings/posting.swagger.ts
@@ -14,18 +14,6 @@ export const findOne_OK = {
   vehicle: '대중교통',
   theme: ['힐링', '쇼핑', '감성'],
   withWho: null,
-  likeds: [
-    {
-      user: '000056789012345678901234567890123456',
-      posting: '22550a18-fe73-42d7-9c64-6e7da27660e7',
-      isDeleted: false,
-    },
-    {
-      user: '123456789012345678901234567890123456',
-      posting: '22550a18-fe73-42d7-9c64-6e7da27660e7',
-      isDeleted: true,
-    },
-  ],
   writer: {
     id: '000056789012345678901234567890123456',
     name: 'pong',
@@ -33,8 +21,8 @@ export const findOne_OK = {
     resourceId: 'km',
     socialType: 1,
   },
-  liked: 2,
-  report: 0,
+  likeds: 2,
+  reports: 0,
   isLiked: true,
   isOwner: false,
 };
@@ -69,8 +57,8 @@ export const search_OK = [
       resourceId: 'temp',
       socialType: 1,
     },
-    liked: [],
-    report: [
+    likeds: [],
+    reports: [
       {
         reporter: '000056789012345678901234567890123456',
         posting: 'c0fc7b89-97fc-4e02-99b4-80a958c98172',
@@ -100,13 +88,13 @@ export const search_OK = [
       resourceId: 'km',
       socialType: 1,
     },
-    liked: [
+    likeds: [
       {
         user: '123456789012345678901234567890123456',
         posting: '51336ad1-3769-4827-bfb1-1080df368532',
       },
     ],
-    report: [],
+    reports: [],
   },
   {
     id: 'e9c76262-cb37-45a4-b713-a08a625b79d7',
@@ -131,7 +119,7 @@ export const search_OK = [
       resourceId: 'km',
       socialType: 1,
     },
-    liked: [
+    likeds: [
       {
         user: '000056789012345678901234567890123456',
         posting: 'e9c76262-cb37-45a4-b713-a08a625b79d7',
@@ -141,7 +129,7 @@ export const search_OK = [
         posting: 'e9c76262-cb37-45a4-b713-a08a625b79d7',
       },
     ],
-    report: [],
+    reports: [],
   },
 ];
 
@@ -198,8 +186,8 @@ export const remove_OK = {
     resourceId: 'temp',
     socialType: 1,
   },
-  liked: [],
-  report: [],
+  likeds: [],
+  reports: [],
 };
 
 export const like_OK = {

--- a/BE/src/postings/postings.controller.ts
+++ b/BE/src/postings/postings.controller.ts
@@ -123,13 +123,13 @@ export class PostingsController {
   async findOne(@Req() request, @Param('id', ParseUUIDPipe) id: string) {
     const userId = request['user'].id;
     const posting = await this.postingsService.findOne(id);
-    console.log(posting);
+
     return {
       ...posting,
       days: this.createDaysList(posting.startDate, posting.days),
-      liked: posting.liked.length,
-      report: posting.report.length,
-      isLiked: posting.liked.some((liked) => liked.user === userId),
+      reports: posting.reports.length,
+      likeds: posting.likeds.length,
+      isLiked: posting.likeds.some((liked) => liked.user === userId),
       isOwner: posting.writer.id === userId,
     };
   }

--- a/BE/src/postings/postings.service.ts
+++ b/BE/src/postings/postings.service.ts
@@ -65,7 +65,7 @@ export class PostingsService {
     return [
       ...new Set(
         titles
-          .filter((e) => e.report.length <= BLOCKING_LIMIT)
+          .filter((e) => e.reports.length <= BLOCKING_LIMIT)
           .map((e) => e.title)
       ),
     ];
@@ -78,7 +78,7 @@ export class PostingsService {
       throw new NotFoundException('게시글이 존재하지 않습니다.');
     }
 
-    if (posting.report.length > BLOCKING_LIMIT) {
+    if (posting.reports.length > BLOCKING_LIMIT) {
       throw new ForbiddenException('차단된 게시글입니다.');
     }
 

--- a/BE/src/postings/repositories/postings.repository.ts
+++ b/BE/src/postings/repositories/postings.repository.ts
@@ -13,6 +13,8 @@ import {
   Theme,
   WithWho,
 } from '../postings.types';
+import { Liked } from '../entities/liked.entity';
+import { Report } from '../entities/report.entity';
 
 @Injectable()
 export class PostingsRepository {
@@ -26,12 +28,13 @@ export class PostingsRepository {
   }
 
   async findOne(id: string) {
-    return this.postingsRepository.findOne({
-      where: { id },
-      relations: {
-        writer: true,
-      },
-    });
+    return this.postingsRepository
+      .createQueryBuilder('p')
+      .leftJoinAndSelect('p.writer', 'w')
+      .leftJoinAndSelect('p.reports', 'r')
+      .leftJoinAndSelect('p.likeds', 'l', 'l.isDeleted = false')
+      .where('p.id = :id', { id })
+      .getOne();
   }
 
   async findAll(

--- a/BE/src/postings/repositories/postings.repository.ts
+++ b/BE/src/postings/repositories/postings.repository.ts
@@ -65,20 +65,25 @@ export class PostingsRepository {
     if (location) {
       qb.andWhere('p.location = :location', { location });
     }
+
     if (period) {
       qb.andWhere('p.period = :period', { period });
     }
+
     if (season) {
       qb.andWhere('p.season = :season', { season });
     }
+
     if (vehicle) {
       qb.andWhere('p.vehicle = :vehicle', { vehicle });
     }
+
     if (theme) {
       qb.andWhere('JSON_CONTAINS(p.theme, :theme)', {
         theme: JSON.stringify(theme),
       });
     }
+
     if (withWho) {
       qb.andWhere('JSON_CONTAINS(p.withWho, :withWho)', {
         withWho: JSON.stringify(withWho),

--- a/BE/src/postings/repositories/postings.repository.ts
+++ b/BE/src/postings/repositories/postings.repository.ts
@@ -13,8 +13,6 @@ import {
   Theme,
   WithWho,
 } from '../postings.types';
-import { Liked } from '../entities/liked.entity';
-import { Report } from '../entities/report.entity';
 
 @Injectable()
 export class PostingsRepository {


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- be-feature/#43-new-search

## 📚 작업한 내용
- Posting 엔티티에 liked와 report 필드에 @RelationId 데코레이터가 달려 있었는데, 지웠습니다! (외래키 관계는 그대로 유지돼요!)
    - 반환되는 내용 자체는 그대로고, liked → likeds, report → reports처럼 필드 이름만 복수형으로 바뀌었어요!

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- @RelationId 데코레이터를 사용하면 조회할 때 굳이 liked/report 테이블을 JOIN하지 않아도, 게시글 id를 posting 필드 값으로 가지는 liked/report의 레코드를 반환해주는데요.
- 그런데 이때 반환해주는 liked/report 레코드는 TypeORM이 자동으로 반환해주는 것이기 때문에 제가 liked.isDeleted = false인 레코드만 뽑으라고 설정할 수가 없어요 ㅠㅠ
- 그래서 동일한 기능을 구현하되 제가 원하는 조건을 추가하기 위해 @RelationId를 지우고, 직접 JOIN하는 방식으로 변경했습니다.
- 만약 @RelationId 안 지우고, JOIN으로 liked.isDeleted = false 조건 추가하면 이러 식으로 반환돼요.

```
Posting {
  id: '9093b3bd-2730-49fd-a783-f4fd055e3f93',
  title: 'bread ❤️❤️',
  ...
  // @RelationId로 인해 자동으로 모두 반환되는 레코드
  like: [
    {
      user: '111',
      posting: 'aaa'
    },
    {
      user: '111',
      posting: 'bbb'
    },
  ],
  // JOIN으로 직접 조건 추가하여 isDeleted = false만 반환되는 레코드
  likeds: [
    Like {
      user: '111',
      posting: 'aaa'
      isDeleted: false
    }
 ]
}
```


<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 관련 이슈
- close #43
