### PR TITLE
[feat] 키체인 구현

### DIFF
--- a/iOS/traveline/Sources/Core/Constant/KeychainKey.swift
+++ b/iOS/traveline/Sources/Core/Constant/KeychainKey.swift
@@ -1,0 +1,14 @@
+//
+//  KeychainKey.swift
+//  traveline
+//
+//  Created by 김영인 on 2023/11/29.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+enum KeychainKey {
+    @KeychainWrapper<String>(key: "accessToken") static var accessToken
+    @KeychainWrapper<String>(key: "refreshToken") static var refreshToken
+}

--- a/iOS/traveline/Sources/Core/Util/Keychain/KeychainManager.swift
+++ b/iOS/traveline/Sources/Core/Util/Keychain/KeychainManager.swift
@@ -1,0 +1,100 @@
+//
+//  KeychainManager.swift
+//  traveline
+//
+//  Created by 김영인 on 2023/11/29.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+import OSLog
+
+enum KeychainManager {
+    
+    /// Keychain에 데이터를 저장합니다.
+    static func set(_ value: Any?, forKey key: String) {
+        guard let data = (value as AnyObject).data(using: String.Encoding.utf8.rawValue) else { return }
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: key,
+            kSecValueData: data
+        ]
+        
+        let status = SecItemAdd(query as CFDictionary, nil)
+        if status == errSecDuplicateItem {
+            update(data, forKey: key)
+        }
+        debug(forKey: key, status: status, type: .set)
+    }
+    
+    /// Keychain에서 데이터를 가져옵니다.
+    static func read(forKey key: String) -> String? {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: key,
+            kSecReturnAttributes: true,
+            kSecReturnData: true
+        ]
+        
+        var item: CFTypeRef?
+        if SecItemCopyMatching(query as CFDictionary, &item) != errSecSuccess { return nil }
+        
+        guard let exisingItems = item as? [String: Any],
+              let itemData = exisingItems[kSecValueData as String] as? Data,
+              let data = String(data: itemData, encoding: .utf8) else {
+            return nil
+        }
+        
+        return data
+    }
+    
+    /// Keychain에 있는 데이터를 삭제합니다.
+    static func delete(forKey key: String) {
+        let deleteQuery: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: key
+        ]
+        
+        let status = SecItemDelete(deleteQuery as CFDictionary)
+        debug(forKey: key, status: status, type: .delete)
+    }
+}
+
+extension KeychainManager {
+    
+    /// Keychain의 데이터를 업데이트합니다.
+    static func update(_ value: Any, forKey key: String) {
+        let previousQuery: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: key
+        ]
+        
+        let updateQuery: [CFString: Any] = [kSecValueData: value]
+        let status = SecItemUpdate(
+            previousQuery as CFDictionary,
+            updateQuery as CFDictionary
+        )
+        debug(forKey: key, status: status, type: .update)
+    }
+}
+
+extension KeychainManager {
+    
+    enum KeychainType: String {
+        case set
+        case read
+        case update
+        case delete
+    }
+    
+    static func debug(forKey key: String, status: OSStatus, type: KeychainType) {
+        switch status {
+        case errSecSuccess:
+            os_log("\(key) \(type.rawValue) success")
+        case errSecDuplicateItem:
+            os_log("\(key) \(type.rawValue) duplicate")
+        default:
+            os_log("\(key) \(type.rawValue) fail")
+        }
+    }
+}

--- a/iOS/traveline/Sources/Core/Util/Keychain/KeychainWrapper.swift
+++ b/iOS/traveline/Sources/Core/Util/Keychain/KeychainWrapper.swift
@@ -1,0 +1,31 @@
+//
+//  KeychainWrapper.swift
+//  traveline
+//
+//  Created by 김영인 on 2023/11/29.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+@propertyWrapper struct KeychainWrapper<T> {
+    
+    var wrappedValue: T? {
+        get {
+            return KeychainManager.read(forKey: key) as? T
+        }
+        set {
+            if newValue == nil {
+                KeychainManager.delete(forKey: key)
+            } else {
+                KeychainManager.set(newValue, forKey: key)
+            }
+        }
+    }
+    
+    private let key: String
+    
+    init(key: String) {
+        self.key = key
+    }
+}


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- feature/#166

## 📚 작업한 내용
- Keychain Util 구현
- KeychainKey 추가

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

### KeychainManager
KeychainManager에서 기본적인 키체인의 CRUD 작업을 수행합니다.
단순 디버깅용 enum 및 함수는 가장 아래 extension으로 빼뒀습니다 :)
추후에 혹시나 트래킹이 필요할 수도 있을 것 같아서요 !

### KeychainWrapper
PropertyWrapper를 사용해 키체인을 관리할 수 있도록 했는데요.
- 값 선언: KeychainManager.set을 호출해 값 저장
- get 접근: KeychainManager.read를 호출해 값을 가져옴
- nil 선언: KeychainManager.delete()를 호출해 값 삭제

### KeychainKey
해당 enum 내부에 사용할 키체인들 추가로 key와 함께 선언해두고 사용하면 될 것 같습니다 :)

```Swift
enum KeychainKey {
    @KeychainWrapper<String>(key: "accessToken") static var accessToken
    @KeychainWrapper<String>(key: "refreshToken") static var refreshToken
}
```

### 사용법
```Swift
KeychainKey.accessToken = "서버에서 받아온 토큰" // 저장
KeychainKey.accessToken = nil // 삭제
print(KeychainKey.accessToken) // 값 받아옴
```

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 관련 이슈
- Resolved: #166
