### PR TITLE
[feat] Data-Domain 플로우 구현

### DIFF
--- a/iOS/traveline/Sources/Core/Enum/VCFactory.swift
+++ b/iOS/traveline/Sources/Core/Enum/VCFactory.swift
@@ -1,0 +1,22 @@
+//
+//  VCFactory.swift
+//  traveline
+//
+//  Created by 김태현 on 11/30/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+enum VCFactory {
+    
+    static let network: NetworkType = NetworkManager(urlSession: URLSession.shared)
+    
+    static func makeTimelineVC() -> TimelineVC {
+        let repository = TimelineRepositoryImpl(network: network)
+        let useCase = FetchTravelInfoUseCaseImpl(repository: repository)
+        let viewModel = TimelineViewModel(fetchTravelInfoUseCase: useCase)
+        return TimelineVC(viewModel: viewModel)
+    }
+    
+}

--- a/iOS/traveline/Sources/Data/Network/API/PostingEndPoint.swift
+++ b/iOS/traveline/Sources/Data/Network/API/PostingEndPoint.swift
@@ -1,0 +1,31 @@
+//
+//  PostingEndPoint.swift
+//  traveline
+//
+//  Created by 김태현 on 11/30/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+enum PostingEndPoint {
+    case specificPosting
+}
+
+extension PostingEndPoint: EndPoint {
+    var path: String {
+        return "/postings"
+    }
+    
+    var httpMethod: HTTPMethod {
+        return .GET
+    }
+    
+    var body: Encodable? {
+        return nil
+    }
+    
+    var header: [String: String] {
+        return [:]
+    }
+}

--- a/iOS/traveline/Sources/Data/Network/DataMapping/LikedsDTO.swift
+++ b/iOS/traveline/Sources/Data/Network/DataMapping/LikedsDTO.swift
@@ -1,0 +1,15 @@
+//
+//  LikedsDTO.swift
+//  traveline
+//
+//  Created by 김태현 on 11/30/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+struct LikedsDTO: Decodable {
+    let user: String
+    let posting: String
+    let isDeleted: Bool
+}

--- a/iOS/traveline/Sources/Data/Network/DataMapping/PostingDetailResponseDTO.swift
+++ b/iOS/traveline/Sources/Data/Network/DataMapping/PostingDetailResponseDTO.swift
@@ -1,5 +1,5 @@
 //
-//  PostingResponseDTO.swift
+//  PostingDetailResponseDTO.swift
 //  traveline
 //
 //  Created by 김태현 on 11/30/23.
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct PostingResponseDTO: Decodable {
+struct PostingDetailResponseDTO: Decodable {
     let id: String
     let title: String
     let createdAt: String
@@ -34,7 +34,7 @@ struct PostingResponseDTO: Decodable {
 
 // MARK: - Mapping
 
-extension PostingResponseDTO {
+extension PostingDetailResponseDTO {
     func toDomain() -> TimelineTravelInfo {
         return .init(
             travelTitle: title,

--- a/iOS/traveline/Sources/Data/Network/DataMapping/PostingResponseDTO.swift
+++ b/iOS/traveline/Sources/Data/Network/DataMapping/PostingResponseDTO.swift
@@ -32,20 +32,6 @@ struct PostingResponseDTO: Decodable {
     let isOwner: Bool
 }
 
-struct LikedsDTO: Decodable {
-    let user: String
-    let posting: String
-    let isDeleted: Bool
-}
-
-struct WriterDTO: Decodable {
-    let id: String
-    let name: String
-    let avatar: String?
-    let resourceId: String
-    let socialType: Int
-}
-
 // MARK: - Mapping
 
 extension PostingResponseDTO {

--- a/iOS/traveline/Sources/Data/Network/DataMapping/PostingResponseDTO.swift
+++ b/iOS/traveline/Sources/Data/Network/DataMapping/PostingResponseDTO.swift
@@ -30,17 +30,6 @@ struct PostingResponseDTO: Decodable {
     let report: Int
     let isLiked: Bool
     let isOwner: Bool
-    
-    func toDomain() -> TimelineTravelInfo {
-        return .init(
-            travelTitle: title,
-            startDate: startDate,
-            endDate: endDate,
-            isLiked: isLiked,
-            // TODO: - 태그 합치는 작업
-            tags: []
-        )
-    }
 }
 
 struct LikedsDTO: Decodable {
@@ -55,4 +44,19 @@ struct WriterDTO: Decodable {
     let avatar: String?
     let resourceId: String
     let socialType: Int
+}
+
+// MARK: - Mapping
+
+extension PostingResponseDTO {
+    func toDomain() -> TimelineTravelInfo {
+        return .init(
+            travelTitle: title,
+            startDate: startDate,
+            endDate: endDate,
+            isLiked: isLiked,
+            // TODO: - 태그 합치는 작업
+            tags: []
+        )
+    }
 }

--- a/iOS/traveline/Sources/Data/Network/DataMapping/PostingResponseDTO.swift
+++ b/iOS/traveline/Sources/Data/Network/DataMapping/PostingResponseDTO.swift
@@ -1,0 +1,58 @@
+//
+//  PostingResponseDTO.swift
+//  traveline
+//
+//  Created by 김태현 on 11/30/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+struct PostingResponseDTO: Decodable {
+    let id: String
+    let title: String
+    let createdAt: String
+    let thumbnail: String?
+    let startDate: String
+    let endDate: String
+    let days: [String]
+    let period: String
+    let headcount: String
+    let budget: String?
+    let location: String
+    let season: String
+    let vehicle: String?
+    let theme: [String]
+    let withWho: String?
+    let likeds: [LikedsDTO]
+    let writer: WriterDTO
+    let liked: Int
+    let report: Int
+    let isLiked: Bool
+    let isOwner: Bool
+    
+    func toDomain() -> TimelineTravelInfo {
+        return .init(
+            travelTitle: title,
+            startDate: startDate,
+            endDate: endDate,
+            isLiked: isLiked,
+            // TODO: - 태그 합치는 작업
+            tags: []
+        )
+    }
+}
+
+struct LikedsDTO: Decodable {
+    let user: String
+    let posting: String
+    let isDeleted: Bool
+}
+
+struct WriterDTO: Decodable {
+    let id: String
+    let name: String
+    let avatar: String?
+    let resourceId: String
+    let socialType: Int
+}

--- a/iOS/traveline/Sources/Data/Network/DataMapping/WriterDTO.swift
+++ b/iOS/traveline/Sources/Data/Network/DataMapping/WriterDTO.swift
@@ -1,0 +1,17 @@
+//
+//  WriterDTO.swift
+//  traveline
+//
+//  Created by 김태현 on 11/30/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+struct WriterDTO: Decodable {
+    let id: String
+    let name: String
+    let avatar: String?
+    let resourceId: String
+    let socialType: Int
+}

--- a/iOS/traveline/Sources/Data/Repository/TimelineRepositoryImpl.swift
+++ b/iOS/traveline/Sources/Data/Repository/TimelineRepositoryImpl.swift
@@ -1,0 +1,30 @@
+//
+//  TimelineRepositoryImpl.swift
+//  traveline
+//
+//  Created by 김태현 on 11/29/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+final class TimelineRepositoryImpl: TimelineRepository {
+    
+    private let network: NetworkType
+    
+    init(network: NetworkType) {
+        self.network = network
+    }
+    
+    func fetchTravelInfo(id: String) async throws -> TimelineTravelInfo {
+        // EndPoint 만들어주고
+        let postingResponseDTO = try await network.request(
+            endPoint: PostingEndPoint.specificPosting,
+            type: PostingResponseDTO.self
+        )
+        
+        // 받아온 데이터 Domain으로 변경 (Data -> Domain 역할)
+        return postingResponseDTO.toDomain()
+    }
+    
+}

--- a/iOS/traveline/Sources/Data/Repository/TimelineRepositoryImpl.swift
+++ b/iOS/traveline/Sources/Data/Repository/TimelineRepositoryImpl.swift
@@ -18,13 +18,13 @@ final class TimelineRepositoryImpl: TimelineRepository {
     
     func fetchTravelInfo(id: String) async throws -> TimelineTravelInfo {
         // EndPoint 만들어주고
-        let postingResponseDTO = try await network.request(
+        let postingDetailResponseDTO = try await network.request(
             endPoint: PostingEndPoint.specificPosting,
-            type: PostingResponseDTO.self
+            type: PostingDetailResponseDTO.self
         )
         
         // 받아온 데이터 Domain으로 변경 (Data -> Domain 역할)
-        return postingResponseDTO.toDomain()
+        return postingDetailResponseDTO.toDomain()
     }
     
 }

--- a/iOS/traveline/Sources/Domain/RepositoryInterface/TimelineRepository.swift
+++ b/iOS/traveline/Sources/Domain/RepositoryInterface/TimelineRepository.swift
@@ -1,0 +1,13 @@
+//
+//  TimelineRepository.swift
+//  traveline
+//
+//  Created by 김태현 on 11/30/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+protocol TimelineRepository {
+    func fetchTravelInfo(id: String) async throws -> TimelineTravelInfo
+}

--- a/iOS/traveline/Sources/Domain/UseCase/FetchTravelInfoUseCase.swift
+++ b/iOS/traveline/Sources/Domain/UseCase/FetchTravelInfoUseCase.swift
@@ -1,0 +1,37 @@
+//
+//  FetchTravelInfoUseCase.swift
+//  traveline
+//
+//  Created by 김태현 on 11/29/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+protocol FetchTravelInfoUseCase {
+    func execute(id: String) -> AnyPublisher<TimelineTravelInfo, Error>
+}
+
+final class FetchTravelInfoUseCaseImpl: FetchTravelInfoUseCase {
+    
+    private let repository: TimelineRepository
+    
+    init(repository: TimelineRepository) {
+        self.repository = repository
+    }
+
+    func execute(id: String) -> AnyPublisher<TimelineTravelInfo, Error> {
+        return Future { promise in
+            Task {
+                do {
+                    let travelInfo = try await self.repository.fetchTravelInfo(id: id)
+                    promise(.success(travelInfo))
+                } catch {
+                    promise(.failure(error))
+                }
+            }
+        }.eraseToAnyPublisher()
+    }
+    
+}

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/VC/HomeVC.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/VC/HomeVC.swift
@@ -148,7 +148,7 @@ private extension HomeVC {
         homeListView.didSelectHomeList
             .withUnretained(self)
             .sink { owner, _  in
-                let timelineVC = TimelineVC(viewModel: TimelineViewModel())
+                let timelineVC = VCFactory.makeTimelineVC()
                 owner.navigationController?.pushViewController(
                     timelineVC,
                     animated: true

--- a/iOS/traveline/Sources/Feature/MyPageFeature/MyPostListScene/VC/MyPostListVC.swift
+++ b/iOS/traveline/Sources/Feature/MyPageFeature/MyPostListScene/VC/MyPostListVC.swift
@@ -155,7 +155,7 @@ private extension MyPostListVC {
 
 extension MyPostListVC: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let timelineVC = TimelineVC(viewModel: TimelineViewModel())
+        let timelineVC = VCFactory.makeTimelineVC()
         self.navigationController?.pushViewController(timelineVC, animated: true)
     }
 }
@@ -166,4 +166,3 @@ extension MyPostListVC: UICollectionViewDelegate {
    // vc.sampleData()
     return vc.view
 }
-

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/VC/TimelineVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/VC/TimelineVC.swift
@@ -338,5 +338,5 @@ extension TimelineVC: TimelineDateHeaderDelegate {
 
 @available(iOS 17, *)
 #Preview {
-    UINavigationController(rootViewController: TimelineVC(viewModel: TimelineViewModel()))
+    UINavigationController(rootViewController: VCFactory.makeTimelineVC())
 }


### PR DESCRIPTION
## 🌎 PR 요약
- GET Posting에 대해서 예시 플로우를 구현했습니다!

🌱 작업한 브랜치
- feature/#169

## 📚 작업한 내용
### 1. UseCase, Repository 구현
- 아침에 한 번 공유드렸었지만 흐름을 살펴보자면,
1. ViewModel에서 UseCase (Interface) 가짐
2. UseCase에서 Repository Interface 가짐
3. RepositoryImpl에서 네트워크 요청
이런 식이 될 것 같아요!
- 아침에 의견 모은대로 UseCase에서 Future-Task를 통해 async를 AnyPublisher로 흐름을 바꿔주게 해두었습니다!!

### 2. DTO 관리
- `Data - Network - DataMapping`에 DTO를 추가해뒀습니다!
- 이번에 `GET Posting` 관련해서 DTO를 추가해봤는데, 어떤 필드가 **nullable**한 지 확인이 어렵더라구요! 그래서 전체 필드를 **optional**로 가져가야할지.. 아니면 백엔드분들한테 여쭤보는게 맞을 지 고민 중입니다
- `PostingResponseDTO`에서 태그를 Domain 형식으로 바꿔주는데 **nullable** 여부에 따라 처리가 필요할 것 같아서 일단 해당 부분 비워뒀습니다.

### 3. VCFactory 추가
- 일단 `VC-ViewModel-UseCase-Repository-Network` 의 의존 관계를 한번에 만들어주기 위해서 편의를 위해 VCFactory를 추가하게 되었습니다.
- `VCFactory.makeTimelineVC()` 이렇게 호출해주시면 됩니다 :)
- 이친구 있을 위치가 애매해서 일단 `Core-Enum`에 넣어뒀어용
- 의존성 관리에 대해서 관심이 생기기 시작했습니다... 🙂

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
HomeVC, MyPostListVC에도 VCFactory 관련 코드가 수정되었으니 한 번 확인해주시면 감사드리겠슴다 🙇🏻

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 관련 이슈
- Resolved: #169 
