### PR TITLE
[feat] 타임라인 디테일 화면 뷰모델

### DIFF
--- a/iOS/traveline/Sources/Domain/Model/Timeline/TimelineSample.swift
+++ b/iOS/traveline/Sources/Domain/Model/Timeline/TimelineSample.swift
@@ -139,13 +139,13 @@ enum TimelineSample {
     static func makeDetailInfo() -> TimelineDetailInfo {
         .init(
             id: "1",
-            day: "Day 1",
             title: "광안리 최고~",
+            day: 1,
+            description: "어쩌고 저쩌고 이러쿵 저러쿵",
+            imageURL: "",
             date: "2023.11.23",
-            time: "오후 02:00",
             location: "광안리 해수욕장",
-            content: "어쩌고 저쩌고 이러쿵 저러쿵",
-            imageURL: ""
+            time: "오후 02:00"
         )
     }
 }

--- a/iOS/traveline/Sources/Domain/Model/TimelineDetailInfo.swift
+++ b/iOS/traveline/Sources/Domain/Model/TimelineDetailInfo.swift
@@ -10,13 +10,39 @@ import Foundation
 
 struct TimelineDetailInfo: Hashable {
     let id: String
-    let day: String
     let title: String
+    let day: Int
+    let description: String
+    let imageURL: String?
+    let coordX: String?
+    let coordY: String?
     let date: String
+    let location: String?
     let time: String
-    let location: String
-    let content: String
-    let imageURL: String
+    
+    init(
+        id: String,
+        title: String,
+        day: Int,
+        description: String,
+        imageURL: String? = nil,
+        coordX: String? = nil,
+        coordY: String? = nil,
+        date: String,
+        location: String? = nil,
+        time: String
+    ) {
+        self.id = id
+        self.title = title
+        self.day = day
+        self.description = description
+        self.imageURL = imageURL
+        self.coordX = coordX
+        self.coordY = coordY
+        self.date = date
+        self.location = location
+        self.time = time
+    }
     
     static func == (lhs: TimelineDetailInfo, rhs: TimelineDetailInfo) -> Bool {
         lhs.id == rhs.id

--- a/iOS/traveline/Sources/Feature/TimelineDetailFeature/TimelineDetailScene/VC/TimelineDetailVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineDetailFeature/TimelineDetailScene/VC/TimelineDetailVC.swift
@@ -107,7 +107,6 @@ final class TimelineDetailVC: UIViewController {
         }
         imageView.isHidden = false
         imageView.setImage(from: url)
-        
     }
     
 }
@@ -186,7 +185,6 @@ private extension TimelineDetailVC {
             .withUnretained(self)
             .sink { owner, info in
                 owner.updateUI(with: info)
-                print(info.imageURL)
             }
             .store(in: &cancellables)
     }

--- a/iOS/traveline/Sources/Feature/TimelineDetailFeature/TimelineDetailScene/ViewModel/TimelineDetailViewModel.swift
+++ b/iOS/traveline/Sources/Feature/TimelineDetailFeature/TimelineDetailScene/ViewModel/TimelineDetailViewModel.swift
@@ -1,0 +1,75 @@
+//
+//  TimelineDetailViewModel.swift
+//  traveline
+//
+//  Created by KiWoong Hong on 2023/11/30.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Combine
+import Foundation
+
+enum TimelineDetailAction: BaseAction {
+    case viewDidLoad
+}
+
+enum TimelineDetailSideEffect: BaseSideEffect {
+    case loadTimelineDetail(TimelineDetailInfo)
+    
+}
+
+struct TimelineDetailState: BaseState {
+    var timelineDetailInfo: TimelineDetailInfo = .init(
+        id: Literal.empty,
+        title: Literal.empty,
+        day: 1,
+        description: Literal.empty,
+        date: Literal.empty,
+        time: Literal.empty
+    )
+}
+
+final class TimelineDetailViewModel: BaseViewModel<TimelineDetailAction, TimelineDetailSideEffect, TimelineDetailState> {
+    
+    private let id: String
+    
+    init(timelineId: String) {
+        self.id = timelineId
+    }
+    
+    override func transform(action: Action) -> SideEffectPublisher {
+        switch action {
+        case .viewDidLoad:
+            return loadTimelineDetailInfo()
+        }
+    }
+
+    override func reduceState(state: State, effect: SideEffect) -> State {
+        var newState = state
+        
+        switch effect {
+        case .loadTimelineDetail(let info):
+            newState.timelineDetailInfo = info
+        }
+        
+        return newState
+    }
+}
+
+private extension TimelineDetailViewModel {
+    func loadTimelineDetailInfo() -> SideEffectPublisher {
+        // TODO: - 타임라인디테일 요청 로직 변경하기
+        let info = TimelineDetailInfo(
+            id: "ae12a997-159c-40d1-b3c6-62af7fd981d1",
+            title: "두근두근 출발 날 😍",
+            day: 1,
+            description: "서울역의 상징성은 정치적으로도 연관이 깊다. 이는 신의 한 수가 된다. 영서 지방은 ITX-청춘 용산발 춘천행, DMZ-train 서울발 백마고지행 둘뿐이었다.",
+            imageURL: "https://user-images.githubusercontent.com/51712973/280571628-e1126b86-4941-49fc-852b-9ce16f3e0c4e.jpg",
+            date: "2023-08-16",
+            location: "서울역",
+            time: "07:30"
+        )
+        
+        return .just(TimelineDetailSideEffect.loadTimelineDetail(info))
+    }
+}

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineMapScene/VC/TimelineMapVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineMapScene/VC/TimelineMapVC.swift
@@ -59,20 +59,9 @@ final class TimelineMapVC: UIViewController {
     
     @objc private func showTimelineDetail() {
         if let selected = selectedAnnotation as? TLMarkerAnnotation {
-            let info = selected.cardInfo
-            let timelineDetailVC = TimelineDetailVC(
-                info: .init(
-                    id: "1",
-                    day: "Day 1",
-                    title: info.title,
-                    date: "2023.11.23",
-                    time: "오후 02:00",
-                    location: info.subtitle,
-                    content: info.content,
-                    imageURL: ""
-                )
-            )
-            
+            let id = selected.cardInfo.detailId
+            let viewModel = TimelineDetailViewModel(timelineId: String(id))
+            let timelineDetailVC = TimelineDetailVC(viewModel: viewModel)
             navigationController?.pushViewController(timelineDetailVC, animated: true)
         }
         

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/VC/TimelineVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/VC/TimelineVC.swift
@@ -259,9 +259,8 @@ private extension TimelineVC {
 
 extension TimelineVC: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let timelineDetailVC = TimelineDetailVC(
-            info: TimelineSample.makeDetailInfo()
-        )
+        let viewModel = TimelineDetailViewModel(timelineId: "1212")
+        let timelineDetailVC = TimelineDetailVC(viewModel: viewModel)
         
         navigationController?.pushViewController(timelineDetailVC, animated: true)
     }


### PR DESCRIPTION
## 🌎 PR 요약
타임라인 상세화면 뷰모델을 작업했어요.

🌱 작업한 브랜치
- feature/#176

## 📚 작업한 내용
- 타임라인 상세화면 뷰모델

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
Swagger보고 TimelineDetailInfo도 살짝 수정했습니다.
그에 따라서 TimelineDetailInfo 사용하던 파일들도 살짝 수정했습니다.

타임라인 디테일 정보를 서버에 요청하기위해 id값이 필요한데,
id값을 뷰모델에 전달해줄지, 뷰컨에다가 전달해줄지 고민하다가 뷰모델로 주는게 맞는 것 같아서 뷰모델로 전달해줬습니다.
혹시 다른 괜찮은 의견있으시면 말씀해주세요!

## 📸 스크린샷

https://github.com/boostcampwm2023/iOS07-traveline/assets/91725382/45b14a80-2ae1-45e9-9a31-5ab3469432b5


## 관련 이슈
- Resolved: #176
