### PR TITLE
[feat] UserDefaults Util 구현

### DIFF
--- a/iOS/traveline/Sources/Core/Constant/KeychainList.swift
+++ b/iOS/traveline/Sources/Core/Constant/KeychainList.swift
@@ -1,5 +1,5 @@
 //
-//  KeychainKey.swift
+//  KeychainList.swift
 //  traveline
 //
 //  Created by 김영인 on 2023/11/29.
@@ -8,7 +8,7 @@
 
 import Foundation
 
-enum KeychainKey {
+enum KeychainList {
     @KeychainWrapper<String>(key: "accessToken") static var accessToken
     @KeychainWrapper<String>(key: "refreshToken") static var refreshToken
 }

--- a/iOS/traveline/Sources/Core/Constant/UserDefaultsList.swift
+++ b/iOS/traveline/Sources/Core/Constant/UserDefaultsList.swift
@@ -1,0 +1,13 @@
+//
+//  UserDefaultsList.swift
+//  traveline
+//
+//  Created by 김영인 on 2023/11/30.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+enum UserDefaultsList {
+    @UserDefaultsWrapper<Profile>(key: "profile") static var profile
+}

--- a/iOS/traveline/Sources/Core/Util/Keychain/KeychainWrapper.swift
+++ b/iOS/traveline/Sources/Core/Util/Keychain/KeychainWrapper.swift
@@ -12,7 +12,7 @@ import Foundation
     
     var wrappedValue: T? {
         get {
-            return KeychainManager.read(forKey: key) as? T
+           KeychainManager.read(forKey: key) as? T
         }
         set {
             if newValue == nil {

--- a/iOS/traveline/Sources/Core/Util/UserDefaults/UserDefaultsWrapper.swift
+++ b/iOS/traveline/Sources/Core/Util/UserDefaults/UserDefaultsWrapper.swift
@@ -1,0 +1,41 @@
+//
+//  UserDefaultsWrapper.swift
+//  traveline
+//
+//  Created by 김영인 on 2023/11/30.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+@propertyWrapper struct UserDefaultsWrapper<T: Codable> {
+    
+    var wrappedValue: T? {
+        get {
+            if let data = UserDefaults.standard.object(forKey: key) as? Data {
+                if let value = try? JSONDecoder().decode(T.self, from: data) {
+                    return value
+                }
+            }
+            
+            return defaultValue
+        }
+        set {
+            if newValue == nil {
+                UserDefaults.standard.removeObject(forKey: key)
+            } else {
+                if let encoded = try? JSONEncoder().encode(newValue) {
+                    UserDefaults.standard.setValue(encoded, forKey: key)
+                }
+            }
+        }
+    }
+    
+    private let key: String
+    private let defaultValue: T?
+    
+    init(key: String, defaultValue: T? = nil) {
+        self.key = key
+        self.defaultValue = defaultValue
+    }
+}

--- a/iOS/traveline/Sources/Domain/Model/Profile.swift
+++ b/iOS/traveline/Sources/Domain/Model/Profile.swift
@@ -8,8 +8,7 @@
 
 import Foundation
 
-struct Profile: Hashable {
-    let id: String
+struct Profile: Codable, Hashable {
     let imageURL: String
     let name: String
 }

--- a/iOS/traveline/Sources/Domain/Model/Sample/ProfileSample.swift
+++ b/iOS/traveline/Sources/Domain/Model/Sample/ProfileSample.swift
@@ -1,0 +1,15 @@
+//
+//  ProfileSample.swift
+//  traveline
+//
+//  Created by 김영인 on 2023/11/30.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+enum ProfileSample {
+    static func make() -> Profile {
+        .init(imageURL: "https://avatars.githubusercontent.com/u/74968390?v=4", name: "0inn")
+    }
+}

--- a/iOS/traveline/Sources/Domain/Model/Sample/TravelListSample.swift
+++ b/iOS/traveline/Sources/Domain/Model/Sample/TravelListSample.swift
@@ -23,7 +23,7 @@ enum TravelListSample {
             .init(id: "1",
                   imageURL: "",
                   title: "부산여행",
-                  profile: Profile(id: "1", imageURL: "", name: "영인"),
+                  profile: Profile(imageURL: "", name: "영인"),
                   like: 10,
                   isLiked: false,
                   tags: TravelListSample.makeTags()
@@ -35,7 +35,7 @@ enum TravelListSample {
             .init(id: "1",
                   imageURL: "",
                   title: "부산여행",
-                  profile: Profile(id: "1", imageURL: "", name: "영인"),
+                  profile: Profile(imageURL: "", name: "영인"),
                   like: 10,
                   isLiked: false,
                   tags: TravelListSample.makeTags()
@@ -43,7 +43,7 @@ enum TravelListSample {
             .init(id: "2",
                   imageURL: "",
                   title: "속초여행",
-                  profile: Profile(id: "2", imageURL: "", name: "0inn"),
+                  profile: Profile(imageURL: "", name: "0inn"),
                   like: 20,
                   isLiked: true,
                   tags: TravelListSample.makeTags()
@@ -51,7 +51,7 @@ enum TravelListSample {
             .init(id: "3",
                   imageURL: "",
                   title: "제주도여행",
-                  profile: Profile(id: "3", imageURL: "", name: "youngin"),
+                  profile: Profile(imageURL: "", name: "youngin"),
                   like: 30,
                   isLiked: true,
                   tags: TravelListSample.makeTags()
@@ -59,7 +59,7 @@ enum TravelListSample {
             .init(id: "4",
                   imageURL: "",
                   title: "제주도여행",
-                  profile: Profile(id: "3", imageURL: "", name: "youngin"),
+                  profile: Profile(imageURL: "", name: "youngin"),
                   like: 30,
                   isLiked: false,
                   tags: TravelListSample.makeTags()
@@ -67,7 +67,7 @@ enum TravelListSample {
             .init(id: "5",
                   imageURL: "",
                   title: "제주도여행",
-                  profile: Profile(id: "4", imageURL: "", name: "youngin"),
+                  profile: Profile(imageURL: "", name: "youngin"),
                   like: 30,
                   isLiked: true,
                   tags: TravelListSample.makeTags()
@@ -75,7 +75,7 @@ enum TravelListSample {
             .init(id: "6",
                   imageURL: "",
                   title: "제주도여행",
-                  profile: Profile(id: "5", imageURL: "", name: "youngin"),
+                  profile: Profile(imageURL: "", name: "youngin"),
                   like: 0,
                   isLiked: false,
                   tags: TravelListSample.makeTags()


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- feature/#191

## 📚 작업한 내용
- UserDefaultsWrapper 구현
- UserDefaultsList 구현
- 기존 KeychainKey -> KeychainList로 수정

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
### struct 타입 대응
일단 UserDefaults에 프로필 정보가 저장될 것 같아서 Profile 구조체 형태로 저장할 수 있도록 구현해뒀습니다.
그 과정에서 decoding, encoding이 필요하더라고요 !
그래서 Wrapper 내부에 해당 함수 추가해뒀습니다 :)

**이 때, UserDefaults에 저장할 구조체는 무조건 Codable을 채택해야 합니다.**

### KeychainList, UserDefaultsList
네이밍을 List로 통일해뒀습니다 !
사용법은 앞의 KeychainList와 동일할 것 같아요 :)

### 최근검색어
최근검색어를 UserDefaults로 구현할지, Core Data로 구현할지에 대한 얘기도 해봐야할 것 같습니다 !
UserDefaults를 쓴다면 리스트 형태로 저장할 수 있을 것 같아요.
하지만 검색을 할 때마다 리스트를 갈아끼우는 작업이 들 것 같아서 Core Data가 더 나을 수 있겠단 싶기도 합니다. .

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 관련 이슈
- Resolved: #191
