### PR TITLE
[feat] 홈 화면 - Use Case 추가

### DIFF
--- a/iOS/traveline/Sources/App/RootContainerVC.swift
+++ b/iOS/traveline/Sources/App/RootContainerVC.swift
@@ -18,7 +18,7 @@ final class RootContainerVC: UIViewController {
     // MARK: - UI Components
     
     private let sideMenuVC: SideMenuVC = .init(viewModel: SideMenuViewModel())
-    private let homeVC: HomeVC = .init(viewModel: HomeViewModel())
+    private let homeVC: HomeVC = VCFactory.makeHomeVC()
     private let shadowView: UIView = .init()
     private var navigationVC: UINavigationController?
     private var selectedVC: UIViewController?

--- a/iOS/traveline/Sources/App/RootContainerVC.swift
+++ b/iOS/traveline/Sources/App/RootContainerVC.swift
@@ -155,7 +155,6 @@ extension RootContainerVC: SideMenuDelegate {
         switch menuItem {
         case .profileEdit:
             let profile = Profile(
-                id: "1234",
                 imageURL: "leaf",
                 name: "hongki"
             )

--- a/iOS/traveline/Sources/Core/Enum/VCFactory.swift
+++ b/iOS/traveline/Sources/Core/Enum/VCFactory.swift
@@ -19,4 +19,12 @@ enum VCFactory {
         return TimelineVC(viewModel: viewModel)
     }
     
+    static func makeHomeVC() -> HomeVC {
+        // TODO: - 서버 연결 후 Repository 변경
+        let repository = PostingRepositoryMock()
+        let useCase = HomeUseCaseImpl(repository: repository)
+        let viewModel = HomeViewModel(homeUseCase: useCase)
+        return HomeVC(viewModel: viewModel)
+    }
+    
 }

--- a/iOS/traveline/Sources/Data/Network/API/PostingEndPoint.swift
+++ b/iOS/traveline/Sources/Data/Network/API/PostingEndPoint.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 enum PostingEndPoint {
+    case postingList
     case specificPosting
 }
 

--- a/iOS/traveline/Sources/Data/Network/DataMapping/PostingDetailResponseDTO.swift
+++ b/iOS/traveline/Sources/Data/Network/DataMapping/PostingDetailResponseDTO.swift
@@ -17,12 +17,12 @@ struct PostingDetailResponseDTO: Decodable {
     let endDate: String
     let days: [String]
     let period: String
-    let headcount: String
+    let headcount: String?
     let budget: String?
     let location: String
     let season: String
     let vehicle: String?
-    let theme: [String]
+    let theme: [String]?
     let withWho: String?
     let likeds: [LikedsDTO]
     let writer: WriterDTO

--- a/iOS/traveline/Sources/Data/Network/DataMapping/PostingResponseDTO.swift
+++ b/iOS/traveline/Sources/Data/Network/DataMapping/PostingResponseDTO.swift
@@ -19,12 +19,12 @@ struct PostingResponseDTO: Decodable {
     let endDate: String
     let days: [String]
     let period: String
-    let headcount: String
+    let headcount: String?
     let budget: String?
     let location: String
     let season: String
     let vehicle: String?
-    let theme: [String]
+    let theme: [String]?
     let withWho: String?
     let writer: WriterDTO
     let likeds: [LikedsDTO]

--- a/iOS/traveline/Sources/Data/Network/DataMapping/PostingResponseDTO.swift
+++ b/iOS/traveline/Sources/Data/Network/DataMapping/PostingResponseDTO.swift
@@ -39,7 +39,6 @@ extension PostingResponseDTO {
             imageURL: thumbnail ?? Literal.empty,
             title: title,
             profile: .init(
-                id: writer.id,
                 imageURL: writer.avatar ?? Literal.empty,
                 name: writer.name
             ),

--- a/iOS/traveline/Sources/Data/Network/DataMapping/PostingResponseDTO.swift
+++ b/iOS/traveline/Sources/Data/Network/DataMapping/PostingResponseDTO.swift
@@ -1,0 +1,55 @@
+//
+//  PostingResponseDTO.swift
+//  traveline
+//
+//  Created by 김태현 on 11/30/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+typealias PostingListResponseDTO = [PostingResponseDTO]
+
+struct PostingResponseDTO: Decodable {
+    let id: String
+    let title: String
+    let createdAt: String
+    let thumbnail: String?
+    let startDate: String
+    let endDate: String
+    let days: [String]
+    let period: String
+    let headcount: String
+    let budget: String?
+    let location: String
+    let season: String
+    let vehicle: String?
+    let theme: [String]
+    let withWho: String?
+    let writer: WriterDTO
+    let likeds: [LikedsDTO]
+}
+
+// MARK: - Mapping
+
+extension PostingResponseDTO {
+    func toDomain() -> TravelListInfo {
+        return .init(
+            id: id,
+            imageURL: thumbnail ?? Literal.empty,
+            title: title,
+            profile: .init(
+                id: writer.id,
+                imageURL: writer.avatar ?? Literal.empty,
+                name: writer.name
+            ),
+            like: likeds.count,
+            isLiked: true,
+            tags: [
+                .init(title: location, type: .region),
+                .init(title: period, type: .people),
+                .init(title: season, type: .season)
+            ]
+        )
+    }
+}

--- a/iOS/traveline/Sources/Data/Repository/Mock/PostingRepositoryMock.swift
+++ b/iOS/traveline/Sources/Data/Repository/Mock/PostingRepositoryMock.swift
@@ -1,0 +1,20 @@
+//
+//  PostingRepositoryMock.swift
+//  traveline
+//
+//  Created by 김태현 on 11/30/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+final class PostingRepositoryMock: PostingRepository {
+    
+    func fetchPostingList() async throws -> TravelList {
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+        
+        let mockData = TravelListSample.make()
+        return mockData
+    }
+    
+}

--- a/iOS/traveline/Sources/Data/Repository/PostingRepositoryImpl.swift
+++ b/iOS/traveline/Sources/Data/Repository/PostingRepositoryImpl.swift
@@ -1,0 +1,28 @@
+//
+//  PostingRepositoryImpl.swift
+//  traveline
+//
+//  Created by 김태현 on 11/30/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+final class PostingRepositoryImpl: PostingRepository {
+    
+    private let network: NetworkType
+    
+    init(network: NetworkType) {
+        self.network = network
+    }
+    
+    func fetchPostingList() async throws -> TravelList {
+        let postingListResponseDTO = try await network.request(
+            endPoint: PostingEndPoint.postingList,
+            type: PostingListResponseDTO.self
+        )
+        
+        return postingListResponseDTO.map { $0.toDomain() }
+    }
+    
+}

--- a/iOS/traveline/Sources/Domain/Model/Profile.swift
+++ b/iOS/traveline/Sources/Domain/Model/Profile.swift
@@ -13,7 +13,6 @@ struct Profile: Codable, Hashable {
     let name: String
     
     static let empty: Profile = .init(
-        id: Literal.empty,
         imageURL: Literal.empty,
         name: Literal.empty
     )

--- a/iOS/traveline/Sources/Domain/RepositoryInterface/PostingRepository.swift
+++ b/iOS/traveline/Sources/Domain/RepositoryInterface/PostingRepository.swift
@@ -1,0 +1,13 @@
+//
+//  PostingRepository.swift
+//  traveline
+//
+//  Created by 김태현 on 11/30/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+protocol PostingRepository {
+    func fetchPostingList() async throws -> TravelList
+}

--- a/iOS/traveline/Sources/Domain/UseCase/HomeUseCase.swift
+++ b/iOS/traveline/Sources/Domain/UseCase/HomeUseCase.swift
@@ -1,0 +1,38 @@
+//
+//  HomeUseCase.swift
+//  traveline
+//
+//  Created by 김태현 on 11/30/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Combine
+import Foundation
+
+protocol HomeUseCase {
+    func fetchHomeList() -> AnyPublisher<TravelList, Error>
+}
+
+final class HomeUseCaseImpl: HomeUseCase {
+    
+    private let repository: PostingRepository
+    
+    init(repository: PostingRepository) {
+        self.repository = repository
+    }
+    
+    func fetchHomeList() -> AnyPublisher<TravelList, Error> {
+        return Future { promise in
+            Task { [weak self] in
+                guard let self else { return }
+                do {
+                    let travelList = try await self.repository.fetchPostingList()
+                    promise(.success(travelList))
+                } catch {
+                    promise(.failure(error))
+                }
+            }
+        }.eraseToAnyPublisher()
+    }
+    
+}

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/VC/HomeVC.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/VC/HomeVC.swift
@@ -275,8 +275,7 @@ extension HomeVC: TLBottomSheetDelegate {
 
 @available(iOS 17, *)
 #Preview("HomeVC") {
-    let homeViewModel = HomeViewModel()
-    let homeVC = HomeVC(viewModel: homeViewModel)
+    let homeVC = VCFactory.makeHomeVC()
     let homeNV = UINavigationController(rootViewController: homeVC)
     return homeNV
 }

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeSideEffect.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeSideEffect.swift
@@ -12,8 +12,9 @@ enum HomeSideEffect: BaseSideEffect {
     case showRecent
     case showRelated(String)
     case showResult(String)
-    case showList
+    case showHomeList(TravelList)
     case showFilter(FilterType)
     case saveFilter([Filter])
     case showTravelWriting
+    case loadFailed(Error)
 }

--- a/iOS/traveline/Sources/Feature/SideFeature/SideScene/ViewModel/SideMenuViewModel.swift
+++ b/iOS/traveline/Sources/Feature/SideFeature/SideScene/ViewModel/SideMenuViewModel.swift
@@ -47,7 +47,6 @@ private extension SideMenuViewModel {
     func loadProfile() -> SideEffectPublisher {
         // TODO: - 프로필을 로드하는 로직. 추후 변경
         let profile = Profile(
-            id: "1234",
             imageURL: "https://avatars.githubusercontent.com/u/91725382?s=400&u=29b8023a56a09685aaab53d4eb0dd556254cd902&v=4",
             name: "hongki"
         )


### PR DESCRIPTION
## 🌎 PR 요약
- HomeUseCase 추가

🌱 작업한 브랜치
- feature/#190

## 📚 작업한 내용
### 1. HomeUseCase 추가
- 논의 이후에 UseCase를 모든 행위당 하나가 아니라 화면 당 일대일로 생성하는 것으로 해서 `HomeUseCase`를 추가했습니다!
- 대신 `HomeUseCase` 안에 다양한 행위들이 들어가게 될 것 같아서 PR을 나누게 되었습니닷
- 행위마다 하나씩 나눠서 올릴 예정이에요!

### 2. PostingRepository 추가
- Posting에 관련된 서비스를 담당할 Repository를 생성했습니다!
- 여기서 서버 Posting 관련된 통신을 담당하면 될까 싶은데 괜찮을까요?? 약간 지금 느낌은 API의 큰 단위 (Postings, Users, Timelines)이런 식으로 Repository를 나누면 어떨까 싶은 느낌이 있어서요!

### 3. Repository Mock 추가
- 원래 JSON 자체를 Mock으로 만들까 했으나 JSON 목 데이터 만드는 작업 자체에 시간 소요가 꽤 될 것 같아서 `Repository` 자체를 Mock으로 생성해서 테스트 해줬습니다 :)
- `UseCase`와 `Repository`가 Interface를 통해 느슨하게 연결되어 있기 때문에 `UseCase`에 `Mock Repository`를 대신 주입해 간단하게 교체할 수 있었습니다 🤔
- 이렇게 작업해두면 나중에 서버를 실제로 붙일때 Repository만 마저 작업해서 갈아끼우면 될 것 같아요!!

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
Profile 객체의 id 필드 충돌 관련 수정사항이 있습니다 ~!
진짜 별개의 얘기긴긴 한데 화면 녹화할 때 맥북 화면 녹화할때랑 외장 모니터 화면 녹화할때랑 용량 차이가 꽤 크네요??
(모니터가 훨씬 작네용,,)

## 📸 스크린샷
https://github.com/boostcampwm2023/iOS07-traveline/assets/51712973/1ad3b6e5-b84f-449b-ae34-59fa85acdfaf

## 관련 이슈
- Resolved: #190 
