### PR TITLE
[feat] 타임라인 작성 화면 뷰모델

### DIFF
--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/VC/TimelineVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/VC/TimelineVC.swift
@@ -90,7 +90,12 @@ final class TimelineVC: UIViewController {
     }
     
     @objc private func createPostingButtonDidTapped() {
-        let timelineWritingVC = TimelineWritingVC()
+        let viewModel = TimelineWritingViewModel(
+            postId: "1234",
+            date: "2022년 3월 5일",
+            day: 1
+        )
+        let timelineWritingVC = TimelineWritingVC(viewModel: viewModel)
         navigationController?.pushViewController(timelineWritingVC, animated: true)
     }
     

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/VC/TimelineWritingVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/VC/TimelineWritingVC.swift
@@ -247,7 +247,6 @@ private extension TimelineWritingVC {
     }
     
     private func bind() {
-        
         titleTextField
             .textPublisher
             .withUnretained(self)

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/ViewModel/TimelineWritingViewModel.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/ViewModel/TimelineWritingViewModel.swift
@@ -1,0 +1,92 @@
+//
+//  TimelineWritingViewModel.swift
+//  traveline
+//
+//  Created by KiWoong Hong on 2023/11/29.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Combine
+import Foundation
+
+enum TimelineWritingAction: BaseAction {
+    case titleDidChange(String)
+    case contentDidChange(String)
+    case tapCompleteButton(TimelineDetailInfo)
+}
+
+enum TimelineWritingSideEffect: BaseSideEffect {
+    case createTimeline
+    case checkFilledTitle
+    case checkFilledContent
+}
+
+struct TimelineWritingState: BaseState {
+    var isCompletable: Bool = false
+}
+
+final class TimelineWritingViewModel: BaseViewModel<TimelineWritingAction, TimelineWritingSideEffect, TimelineWritingState> {
+    
+    var isFilledTitle: Bool = false
+    var isFilledContent: Bool = false
+    let postId: String
+    let date: String
+    let day: Int
+    
+    init(postId: String, date: String, day: Int) {
+        self.postId = postId
+        self.date = date
+        self.day = day
+    }
+    
+    override func transform(action: TimelineWritingAction) -> SideEffectPublisher {
+        switch action {
+        case .titleDidChange(let title):
+            return checkFilledTitle(title)
+        case .contentDidChange(let content):
+            return checkFilledContent(content)
+        case .tapCompleteButton(let info):
+            return createTimeline(with: info)
+        }
+    }
+    
+    override func reduceState(state: TimelineWritingState, effect: TimelineWritingSideEffect) -> TimelineWritingState {
+        var newState = state
+        
+        switch effect {
+        case .checkFilledTitle:
+            newState.isCompletable = completeButtonState()
+        case .checkFilledContent:
+            newState.isCompletable = completeButtonState()
+        case .createTimeline:
+            break
+        }
+        
+        return newState
+    }
+    
+}
+
+private extension TimelineWritingViewModel {
+    
+    func createTimeline(with info: TimelineDetailInfo) -> SideEffectPublisher {
+        // TODO: - 타임라인 생성 요청
+        return .just(SideEffect.createTimeline)
+    }
+    
+    func checkFilledTitle(_ title: String) -> SideEffectPublisher {
+        isFilledTitle = title != ""
+        print("title\(title)")
+        return .just(SideEffect.checkFilledTitle)
+    }
+    
+    func checkFilledContent(_ content: String) -> SideEffectPublisher {
+        isFilledContent = content != ""
+        print("content\(content)")
+        return .just(SideEffect.checkFilledContent)
+    }
+    
+    func completeButtonState() -> Bool {
+        return isFilledTitle && isFilledContent
+    }
+}

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/ViewModel/TimelineWritingViewModel.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/ViewModel/TimelineWritingViewModel.swift
@@ -85,7 +85,6 @@ private extension TimelineWritingViewModel {
     
     func checkFilledContent(_ content: String) -> SideEffectPublisher {
         isFilledContent = !content.isEmpty
-        print("content\(content)")
         return .just(SideEffect.checkFilledContent)
     }
     

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/ViewModel/TimelineWritingViewModel.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/ViewModel/TimelineWritingViewModel.swift
@@ -79,13 +79,12 @@ private extension TimelineWritingViewModel {
     }
     
     func checkFilledTitle(_ title: String) -> SideEffectPublisher {
-        isFilledTitle = title != ""
-        print("title\(title)")
+        isFilledTitle = !title.isEmpty
         return .just(SideEffect.checkFilledTitle)
     }
     
     func checkFilledContent(_ content: String) -> SideEffectPublisher {
-        isFilledContent = content != ""
+        isFilledContent = !content.isEmpty
         print("content\(content)")
         return .just(SideEffect.checkFilledContent)
     }

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/ViewModel/TimelineWritingViewModel.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/ViewModel/TimelineWritingViewModel.swift
@@ -43,8 +43,10 @@ final class TimelineWritingViewModel: BaseViewModel<TimelineWritingAction, Timel
         switch action {
         case .titleDidChange(let title):
             return checkFilledTitle(title)
+            
         case .contentDidChange(let content):
             return checkFilledContent(content)
+            
         case .tapCompleteButton(let info):
             return createTimeline(with: info)
         }
@@ -56,8 +58,10 @@ final class TimelineWritingViewModel: BaseViewModel<TimelineWritingAction, Timel
         switch effect {
         case .checkFilledTitle:
             newState.isCompletable = completeButtonState()
+            
         case .checkFilledContent:
             newState.isCompletable = completeButtonState()
+            
         case .createTimeline:
             break
         }


### PR DESCRIPTION
## 🌎 PR 요약
타임라인 작성 화면 뷰모델을 만들었어요.

🌱 작업한 브랜치
- feature/#174

## 📚 작업한 내용
- 타임라인 작성 화면 뷰모델

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 작성 완료 시 타임라인 생성에 필요한 Day, Date, postingId는 이전 VC에서 넘겨줄 수 있게 뷰모델의 인자값으로 추가했어요.
- 사진과 장소를 입력하지않아도 제목과 내용만 입력하면 완료할 수 있도록 버튼을 활성화했어요.

## 📸 스크린샷

https://github.com/boostcampwm2023/iOS07-traveline/assets/91725382/5aa2bc1e-44f6-47d9-b170-a6eebb186f65


## 관련 이슈
- Resolved: #174 
