### PR TITLE
[feat] 타임라인에서 이미지 관련 로직 추가

### DIFF
--- a/BE/src/timelines/dto/create-timeline.dto.ts
+++ b/BE/src/timelines/dto/create-timeline.dto.ts
@@ -34,10 +34,13 @@ export class CreateTimelineDto {
   @MaxLength(500)
   description: string;
 
-  @ApiProperty({ required: false, description: '업로드하는 사진' })
+  @ApiProperty({
+    required: false,
+    type: 'file',
+    description: '업로드하는 사진',
+  })
   @IsOptional()
-  @IsString()
-  image: string;
+  image: Express.Multer.File;
 
   @ApiProperty({
     required: false,

--- a/BE/src/timelines/dto/create-timeline.dto.ts
+++ b/BE/src/timelines/dto/create-timeline.dto.ts
@@ -9,6 +9,7 @@ import {
   IsUUID,
 } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
 
 export class CreateTimelineDto {
   @ApiProperty({ example: '서울역에서 출발~', maxLength: 14, minLength: 1 })
@@ -18,6 +19,7 @@ export class CreateTimelineDto {
   title: string;
 
   @ApiProperty({ example: 1, description: 'Day1에서의 1' })
+  @Transform(({ value }) => parseInt(value))
   @IsNumber()
   day: number;
 
@@ -44,6 +46,7 @@ export class CreateTimelineDto {
     description: '장소의 X 좌표',
   })
   @IsOptional()
+  @Transform(({ value }) => parseFloat(value))
   @IsNumber()
   coordX: number;
 
@@ -54,6 +57,7 @@ export class CreateTimelineDto {
     description: '장소의 Y 좌표',
   })
   @IsOptional()
+  @Transform(({ value }) => parseFloat(value))
   @IsNumber()
   coordY: number;
 

--- a/BE/src/timelines/timelines.controller.ts
+++ b/BE/src/timelines/timelines.controller.ts
@@ -68,7 +68,7 @@ export class TimelinesController {
   constructor(private readonly timelinesService: TimelinesService) {}
 
   @Post()
-  @UseInterceptors(FileInterceptor('file'))
+  @UseInterceptors(FileInterceptor('image'))
   @ApiOperation({
     summary: '타임라인 생성',
     description:
@@ -90,12 +90,12 @@ export class TimelinesController {
   })
   async create(
     @Req() request,
-    @UploadedFile() file: Express.Multer.File,
+    @UploadedFile() image: Express.Multer.File,
     @Body()
     createTimelineDto: CreateTimelineDto
   ): Promise<Timeline> {
     const userId = request['user'].id;
-    return this.timelinesService.create(userId, file, createTimelineDto);
+    return this.timelinesService.create(userId, image, createTimelineDto);
   }
 
   @Get()

--- a/BE/src/timelines/timelines.controller.ts
+++ b/BE/src/timelines/timelines.controller.ts
@@ -91,8 +91,7 @@ export class TimelinesController {
   async create(
     @Req() request,
     @UploadedFile() image: Express.Multer.File,
-    @Body()
-    createTimelineDto: CreateTimelineDto
+    @Body() createTimelineDto: CreateTimelineDto
   ): Promise<Timeline> {
     const userId = request['user'].id;
     return this.timelinesService.create(userId, image, createTimelineDto);
@@ -154,16 +153,21 @@ export class TimelinesController {
   }
 
   @Put(':id')
+  @UseInterceptors(FileInterceptor('image'))
   @ApiOperation({
     summary: 'id에 해당하는 타임라인 수정',
     description: 'id에 해당하는 타임라인을 수정합니다.',
   })
+  @ApiConsumes('multipart/form-data')
   @ApiOkResponse({ schema: { example: update_OK } })
   async update(
+    @Req() request,
     @Param('id', ParseUUIDPipe) id: string,
+    @UploadedFile() image: Express.Multer.File,
     @Body() updateTimelineDto: UpdateTimelineDto
   ) {
-    return this.timelinesService.update(id, updateTimelineDto);
+    const userId = request['user'].id;
+    return this.timelinesService.update(id, userId, image, updateTimelineDto);
   }
 
   @Delete(':id')

--- a/BE/src/timelines/timelines.controller.ts
+++ b/BE/src/timelines/timelines.controller.ts
@@ -150,7 +150,7 @@ export class TimelinesController {
   })
   @ApiOkResponse({ schema: { example: findOne_OK } })
   async findOne(@Param('id', ParseUUIDPipe) id: string): Promise<Timeline> {
-    return this.timelinesService.findOne(id);
+    return this.timelinesService.findOneWithURL(id);
   }
 
   @Put(':id')

--- a/BE/src/timelines/timelines.module.ts
+++ b/BE/src/timelines/timelines.module.ts
@@ -6,14 +6,15 @@ import { DatabaseModule } from '../database/database.module';
 import { PostingsModule } from '../postings/postings.module';
 import { TimelinesRepository } from './timelines.repository';
 import { PostingsService } from '../postings/postings.service';
-import { UsersModule } from 'src/users/users.module';
-import { PostingsRepository } from 'src/postings/repositories/postings.repository';
-import { LikedsRepository } from 'src/postings/repositories/likeds.repository';
-import { ReportsRepository } from 'src/postings/repositories/reports.repository';
-import { postingsProviders } from 'src/postings/postings.providers';
+import { UsersModule } from '../users/users.module';
+import { PostingsRepository } from '../postings/repositories/postings.repository';
+import { LikedsRepository } from '../postings/repositories/likeds.repository';
+import { ReportsRepository } from '../postings/repositories/reports.repository';
+import { postingsProviders } from '../postings/postings.providers';
+import { StorageModule } from '../storage/storage.module';
 
 @Module({
-  imports: [DatabaseModule, PostingsModule, UsersModule],
+  imports: [DatabaseModule, PostingsModule, UsersModule, StorageModule],
   controllers: [TimelinesController],
   providers: [
     ...timelinesProviders,

--- a/BE/src/timelines/timelines.service.ts
+++ b/BE/src/timelines/timelines.service.ts
@@ -74,10 +74,26 @@ export class TimelinesService {
     return timeline;
   }
 
-  async update(id: string, updateTimelineDto: UpdateTimelineDto) {
-    await this.findOne(id);
+  async update(
+    id: string,
+    userId: string,
+    image: Express.Multer.File,
+    updateTimelineDto: UpdateTimelineDto
+  ) {
+    const timeline = await this.findOne(id);
+
+    if (timeline.image) {
+      await this.storageService.delete(timeline.image);
+    }
+
     const updatedTimeline = await this.initialize(updateTimelineDto);
     updatedTimeline.id = id;
+
+    if (image) {
+      const imagePath = `${userId}/${id}`;
+      const { path } = await this.storageService.upload(imagePath, image);
+      updatedTimeline.image = path;
+    }
 
     return this.timelinesRepository.update(id, updatedTimeline);
   }

--- a/BE/src/timelines/timelines.service.ts
+++ b/BE/src/timelines/timelines.service.ts
@@ -50,9 +50,18 @@ export class TimelinesService {
   async findAll(postingId: string, day: number) {
     const timelines = await this.timelinesRepository.findAll(postingId, day);
 
-    return timelines.map((timeline) => {
-      return { ...timeline, description: timeline.description + '...' };
-    });
+    return Promise.all(
+      timelines.map(async (timeline) => {
+        const imageUrl = timeline.image
+          ? await this.storageService.getImageUrl(timeline.image)
+          : null;
+        return {
+          ...timeline,
+          description: timeline.description + '...',
+          image: imageUrl,
+        };
+      })
+    );
   }
 
   async findOne(id: string) {
@@ -60,6 +69,10 @@ export class TimelinesService {
 
     if (!timeline) {
       throw new NotFoundException('타임라인이 존재하지 않습니다.');
+    }
+
+    if (timeline.image) {
+      timeline.image = await this.storageService.getImageUrl(timeline.image);
     }
 
     return timeline;
@@ -84,7 +97,6 @@ export class TimelinesService {
   ): Promise<Timeline> {
     const timeline = new Timeline();
     Object.assign(timeline, timelineDto);
-    // timeline.image = timelineDto.image;
     return timeline;
   }
 

--- a/BE/src/timelines/timelines.service.ts
+++ b/BE/src/timelines/timelines.service.ts
@@ -64,12 +64,8 @@ export class TimelinesService {
     );
   }
 
-  async findOne(id: string) {
-    const timeline = await this.timelinesRepository.findOne(id);
-
-    if (!timeline) {
-      throw new NotFoundException('타임라인이 존재하지 않습니다.');
-    }
+  async findOneWithURL(id: string) {
+    const timeline = await this.findOne(id);
 
     if (timeline.image) {
       timeline.image = await this.storageService.getImageUrl(timeline.image);
@@ -89,6 +85,10 @@ export class TimelinesService {
   async remove(id: string) {
     const timeline = await this.findOne(id);
 
+    if (timeline.image) {
+      await this.storageService.delete(timeline.image);
+    }
+
     return this.timelinesRepository.remove(timeline);
   }
 
@@ -97,6 +97,16 @@ export class TimelinesService {
   ): Promise<Timeline> {
     const timeline = new Timeline();
     Object.assign(timeline, timelineDto);
+    return timeline;
+  }
+
+  private async findOne(id: string) {
+    const timeline = await this.timelinesRepository.findOne(id);
+
+    if (!timeline) {
+      throw new NotFoundException('타임라인이 존재하지 않습니다.');
+    }
+
     return timeline;
   }
 

--- a/BE/src/timelines/timelines.swagger.ts
+++ b/BE/src/timelines/timelines.swagger.ts
@@ -34,7 +34,8 @@ export const create_OK = {
   },
   coordX: '126.970606917394',
   coordY: '37.5546788388674',
-  image: null,
+  image:
+    '123456789012345678901234567890123456/4d2084e5-0b1f-449a-9908-2918bd384f661a1a8809-2ee7-4a39-ab02-e7b50f4ded4e.jpg',
   id: '01d97f2b-515c-4a44-91b8-dfa48d806b00',
 };
 


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- be-feature/#184-timeline-image

## 📚 작업한 내용
-  타임라인 POST 시 File 전달 받고, Object Storage에 저장
-  타임라인 GET 시 Object Storage에서 URL을 생성하여 전달
-  타임라인 PUT 시 Object Storage에서 기존 사진 삭제 및 새 사진으로 저장
-  타임라인 DELETE 시 Object Storage에서 사진 삭제

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
### Swagger에서도 파일 넣고 테스트 가능합니다~!

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|POSTMAN 테스트 시 image 파라미터|![image](https://github.com/boostcampwm2023/iOS07-traveline/assets/62174395/bf408f82-4ed0-460e-8d99-66fa38a48457)|
|Swagger 테스트 시 image 파라미터|![image](https://github.com/boostcampwm2023/iOS07-traveline/assets/62174395/265c530c-bdfe-4904-97b9-2fe21cd61f2c)|

## 관련 이슈
- close #184
