### PR TITLE
[feat] 타임라인 상세화면 UseCase

### DIFF
--- a/iOS/traveline/Sources/Data/Repository/Mock/TimelineDetailRepositoryMock.swift
+++ b/iOS/traveline/Sources/Data/Repository/Mock/TimelineDetailRepositoryMock.swift
@@ -1,0 +1,19 @@
+//
+//  TimelineDetailRepositoryMock.swift
+//  traveline
+//
+//  Created by KiWoong Hong on 2023/12/02.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+final class TimelineDetailRepositoryMock: TimelineDetailRepository {
+    func fetchTimelineDetailInfo(id: String) async throws -> TimelineDetailInfo {
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+        
+        let mockData = TimelineDetailInfo.sample
+        return mockData
+    }
+    
+}

--- a/iOS/traveline/Sources/Domain/Model/Timeline/TimelineSample.swift
+++ b/iOS/traveline/Sources/Domain/Model/Timeline/TimelineSample.swift
@@ -136,16 +136,4 @@ enum TimelineSample {
         )
     }
     
-    static func makeDetailInfo() -> TimelineDetailInfo {
-        .init(
-            id: "1",
-            title: "광안리 최고~",
-            day: 1,
-            description: "어쩌고 저쩌고 이러쿵 저러쿵",
-            imageURL: "",
-            date: "2023.11.23",
-            location: "광안리 해수욕장",
-            time: "오후 02:00"
-        )
-    }
 }

--- a/iOS/traveline/Sources/Domain/Model/TimelineDetailInfo.swift
+++ b/iOS/traveline/Sources/Domain/Model/TimelineDetailInfo.swift
@@ -14,43 +14,36 @@ struct TimelineDetailInfo: Hashable {
     let day: Int
     let description: String
     let imageURL: String?
-    let coordX: String?
-    let coordY: String?
+    let coordX: Double?
+    let coordY: Double?
     let date: String
-    let location: String?
+    let location: String
     let time: String
-    
-    init(
-        id: String,
-        title: String,
-        day: Int,
-        description: String,
-        imageURL: String? = nil,
-        coordX: String? = nil,
-        coordY: String? = nil,
-        date: String,
-        location: String? = nil,
-        time: String
-    ) {
-        self.id = id
-        self.title = title
-        self.day = day
-        self.description = description
-        self.imageURL = imageURL
-        self.coordX = coordX
-        self.coordY = coordY
-        self.date = date
-        self.location = location
-        self.time = time
-    }
     
     static let empty: TimelineDetailInfo = .init(
         id: Literal.empty,
         title: Literal.empty,
         day: 0,
         description: Literal.empty,
+        imageURL: nil,
+        coordX: nil,
+        coordY: nil,
         date: Literal.empty,
+        location: Literal.empty,
         time: Literal.empty
+    )
+    
+    static let sample: TimelineDetailInfo = .init(
+        id: "ae12a997-159c-40d1-b3c6-62af7fd981d1",
+        title: "두근두근 출발 날 😍",
+        day: 1,
+        description: "서울역의 상징성은 정치적으로도 연관이 깊다. 이는 신의 한 수가 된다. 영서 지방은 ITX-청춘 용산발 춘천행, DMZ-train 서울발 백마고지행 둘뿐이었다.",
+        imageURL: "https://user-images.githubusercontent.com/51712973/280571628-e1126b86-4941-49fc-852b-9ce16f3e0c4e.jpg",
+        coordX: 100.1,
+        coordY: 100.3,
+        date: "2023-08-16",
+        location: "서울역",
+        time: "07:30"
     )
     
     static func == (lhs: TimelineDetailInfo, rhs: TimelineDetailInfo) -> Bool {

--- a/iOS/traveline/Sources/Domain/RepositoryInterface/TimelineDetailRepository.swift
+++ b/iOS/traveline/Sources/Domain/RepositoryInterface/TimelineDetailRepository.swift
@@ -1,0 +1,15 @@
+//
+//  TimelineDetailRepository.swift
+//  traveline
+//
+//  Created by KiWoong Hong on 2023/12/02.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+import Foundation
+
+protocol TimelineDetailRepository {
+    func fetchTimelineDetailInfo(id: String) async throws -> TimelineDetailInfo
+}

--- a/iOS/traveline/Sources/Domain/UseCase/TimelineDetailUseCase.swift
+++ b/iOS/traveline/Sources/Domain/UseCase/TimelineDetailUseCase.swift
@@ -1,0 +1,38 @@
+//
+//  TimelineDetailUseCase.swift
+//  traveline
+//
+//  Created by KiWoong Hong on 2023/12/02.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Combine
+import Foundation
+
+protocol TimelineDetailUseCase {
+    func fetchTimelineDetail(with id: String) -> AnyPublisher<TimelineDetailInfo, Error>
+}
+
+final class TimelineDetailUseCaseImpl: TimelineDetailUseCase {
+    
+    private let repository: TimelineDetailRepository
+    
+    init(repository: TimelineDetailRepository) {
+        self.repository = repository
+    }
+    
+    func fetchTimelineDetail(with id: String) -> AnyPublisher<TimelineDetailInfo, Error> {
+        return Future { promise in
+            Task { [weak self] in
+                guard let self else { return }
+                do {
+                    let detailInfo = try await self.repository.fetchTimelineDetailInfo(id: id)
+                    promise(.success(detailInfo))
+                } catch {
+                    promise(.failure(error))
+                }
+            }
+        }.eraseToAnyPublisher()
+    }
+    
+}

--- a/iOS/traveline/Sources/Feature/TimelineDetailFeature/TimelineDetailScene/VC/TimelineDetailVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineDetailFeature/TimelineDetailScene/VC/TimelineDetailVC.swift
@@ -94,7 +94,7 @@ final class TimelineDetailVC: UIViewController {
         titleLabel.setText(to: info.title)
         dateLabel.setText(to: info.date)
         timeLabel.setText(to: info.time)
-        locationLabel.setText(to: info.location ?? Literal.empty)
+        locationLabel.setText(to: info.location)
         contentView.setText(to: info.description)
         guard let url = info.imageURL else {
             imageView.isHidden = true

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineMapScene/VC/TimelineMapVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineMapScene/VC/TimelineMapVC.swift
@@ -60,7 +60,9 @@ final class TimelineMapVC: UIViewController {
     @objc private func showTimelineDetail() {
         if let selected = selectedAnnotation as? TLMarkerAnnotation {
             let id = selected.cardInfo.detailId
-            let viewModel = TimelineDetailViewModel(timelineId: String(id))
+            let repositoryMock = TimelineDetailRepositoryMock()
+            let useCase = TimelineDetailUseCaseImpl(repository: repositoryMock)
+            let viewModel = TimelineDetailViewModel(timelineDetailUseCase: useCase, timelineId: String(id))
             let timelineDetailVC = TimelineDetailVC(viewModel: viewModel)
             navigationController?.pushViewController(timelineDetailVC, animated: true)
         }

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/VC/TimelineVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/VC/TimelineVC.swift
@@ -264,7 +264,9 @@ private extension TimelineVC {
 
 extension TimelineVC: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let viewModel = TimelineDetailViewModel(timelineId: "1212")
+        let repositoryMock = TimelineDetailRepositoryMock()
+        let useCase = TimelineDetailUseCaseImpl(repository: repositoryMock)
+        let viewModel = TimelineDetailViewModel(timelineDetailUseCase: useCase, timelineId: "1212")
         let timelineDetailVC = TimelineDetailVC(viewModel: viewModel)
         
         navigationController?.pushViewController(timelineDetailVC, animated: true)


### PR DESCRIPTION
## 🌎 PR 요약
타임라인 상세화면 UseCase를 작성했어요.

🌱 작업한 브랜치
- feature/#207

## 📚 작업한 내용
- 타임라인 상세화면 UseCase 작성


## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 타임라인 상세 목업 레포지토리를 만들어서 TimelineDetailUseCase에 넣어주었습니다.
- Data-Domain에 대한 연결은 따로 이슈 만들겠습니다.

## 📸 스크린샷

https://github.com/boostcampwm2023/iOS07-traveline/assets/91725382/c035c127-69ef-4379-844b-422fdae73ae6


## 관련 이슈
- Resolved: #
