### PR TITLE
[feat] 타임라인 생성, 수정, 삭제 작업 시 게시글 썸네일 처리

### DIFF
--- a/BE/src/postings/dto/create-posting.dto.ts
+++ b/BE/src/postings/dto/create-posting.dto.ts
@@ -7,7 +7,7 @@ import {
   IsIn,
   ArrayMaxSize,
   IsArray,
-  IsDateString,
+  IsISO8601,
 } from 'class-validator';
 import {
   Budget,
@@ -32,14 +32,14 @@ export class CreatePostingDto {
   title: string;
 
   @ApiProperty({ example: '2023-12-13', description: 'YYYY-MM-DD 형식' })
-  @IsDateString()
+  @IsISO8601({ strict: true })
   startDate: string;
 
   @ApiProperty({
     example: '2023-12-15',
     description: 'YYYY-MM-DD 형식, startDate보다 이른 날짜일 수 없습니다.',
   })
-  @IsDateString()
+  @IsISO8601({ strict: true })
   endDate: string;
 
   @ApiProperty({ required: false, enum: Headcount })

--- a/BE/src/postings/dto/search-posting.dto.ts
+++ b/BE/src/postings/dto/search-posting.dto.ts
@@ -25,7 +25,6 @@ export class SearchPostingDto {
   @ApiProperty({
     required: false,
     description: '검색어가 제목에 포함될 경우 검색됩니다.',
-    example: 'bread',
   })
   @IsOptional()
   @IsString()
@@ -43,18 +42,20 @@ export class SearchPostingDto {
 
   @ApiProperty({
     required: false,
-    default: 0,
+    default: 1,
     description: '몇 번째 페이지부터 게시글을 가져올지 나타냅니다.',
   })
+  @Transform(({ value }) => parseInt(value))
   @IsOptional()
   @IsNumber()
-  offset: number = 0;
+  offset: number = 1;
 
   @ApiProperty({
     required: false,
     default: 20,
     description: 'offset에서부터 몇 개의 게시글을 반환하는지 나타냅니다.',
   })
+  @Transform(({ value }) => parseInt(value))
   @IsOptional()
   @IsNumber()
   limit: number = 20;

--- a/BE/src/postings/postings.controller.ts
+++ b/BE/src/postings/postings.controller.ts
@@ -20,6 +20,7 @@ import {
   ApiBadRequestResponse,
   ApiBearerAuth,
   ApiConflictResponse,
+  ApiConsumes,
   ApiCreatedResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
@@ -73,6 +74,7 @@ export class PostingsController {
     summary: '게시글 생성',
     description: '사용자가 입력한 정보를 토대로 새로운 게시글을 생성합니다.',
   })
+  @ApiConsumes('application/x-www-form-urlencoded')
   @ApiCreatedResponse({ schema: { example: create_OK } })
   @ApiBadRequestResponse({
     schema: {
@@ -157,6 +159,7 @@ export class PostingsController {
     summary: '게시글 수정',
     description: 'id 값에 해당되는 게시글을 수정합니다.',
   })
+  @ApiConsumes('application/x-www-form-urlencoded')
   @ApiOkResponse({ schema: { example: update_OK } })
   async update(
     @Req() request,

--- a/BE/src/postings/postings.service.ts
+++ b/BE/src/postings/postings.service.ts
@@ -154,23 +154,19 @@ export class PostingsService {
     postingDto: CreatePostingDto | UpdatePostingDto
   ): Promise<Posting> {
     const posting = new Posting();
-    posting.title = postingDto.title;
-    posting.startDate = new Date(postingDto.startDate);
-    posting.endDate = new Date(postingDto.endDate);
+    Object.assign(posting, postingDto);
     posting.days = this.calculateDays(posting.startDate, posting.endDate);
     posting.period = this.findPeriod(posting.days);
-    posting.headcount = postingDto.headcount;
-    posting.budget = postingDto.budget;
-    posting.location = postingDto.location;
     posting.season = this.findSeason(posting.startDate);
-    posting.vehicle = postingDto.vehicle;
-    posting.theme = postingDto.theme;
-    posting.withWho = postingDto.withWho;
     return posting;
   }
 
   private calculateDays(startDate: Date, endDate: Date): number {
-    return (endDate.getTime() - startDate.getTime()) / (1000 * 3600 * 24) + 1;
+    return (
+      (new Date(endDate).getTime() - new Date(startDate).getTime()) /
+        (1000 * 3600 * 24) +
+      1
+    );
   }
 
   private findPeriod(days: number): Period {
@@ -188,7 +184,7 @@ export class PostingsService {
   }
 
   private findSeason(startDate: Date): Season {
-    const month = startDate.getMonth() + 1;
+    const month = new Date(startDate).getMonth() + 1;
     return month >= 3 && month <= 5
       ? Season.봄
       : month >= 6 && month <= 9

--- a/BE/src/postings/repositories/postings.repository.ts
+++ b/BE/src/postings/repositories/postings.repository.ts
@@ -127,4 +127,8 @@ export class PostingsRepository {
   async remove(posting: Posting) {
     return this.postingsRepository.remove(posting);
   }
+
+  async updateThumbnail(id: string, thumbnail: string) {
+    return this.postingsRepository.update(id, { thumbnail });
+  }
 }

--- a/BE/src/timelines/timelines.repository.ts
+++ b/BE/src/timelines/timelines.repository.ts
@@ -15,7 +15,10 @@ export class TimelinesRepository {
   }
 
   async findOne(id: string) {
-    return this.timelineRepository.findOneBy({ id });
+    return this.timelineRepository.findOne({
+      where: { id },
+      relations: { posting: true },
+    });
   }
 
   async findAll(posting: string, day: number) {
@@ -35,6 +38,14 @@ export class TimelinesRepository {
       .andWhere('day = :day', { day })
       .orderBy('time', 'ASC')
       .getRawMany();
+  }
+
+  async findOneWithNonEmptyImage(posting: string) {
+    return this.timelineRepository
+      .createQueryBuilder()
+      .where('posting = :posting', { posting })
+      .andWhere('image IS NOT NULL AND image != ""')
+      .getOne();
   }
 
   async update(id: string, timeline: Timeline) {

--- a/BE/src/timelines/timelines.service.ts
+++ b/BE/src/timelines/timelines.service.ts
@@ -106,12 +106,23 @@ export class TimelinesService {
 
   async remove(id: string) {
     const timeline = await this.findOne(id);
+    await this.timelinesRepository.remove(timeline);
+
+    if (timeline.image === timeline.posting.thumbnail) {
+      const result = await this.timelinesRepository.findOneWithNonEmptyImage(
+        timeline.posting.id
+      );
+      await this.postingsRepository.updateThumbnail(
+        timeline.posting.id,
+        result ? result.image : ''
+      );
+    }
 
     if (timeline.image) {
       await this.storageService.delete(timeline.image);
     }
 
-    return this.timelinesRepository.remove(timeline);
+    return timeline;
   }
 
   private async initialize(

--- a/BE/src/timelines/timelines.service.ts
+++ b/BE/src/timelines/timelines.service.ts
@@ -11,11 +11,13 @@ import { Timeline } from './entities/timeline.entity';
 import { StorageService } from '../storage/storage.service';
 import { PostingsService } from '../postings/postings.service';
 import { KAKAO_KEYWORD_SEARCH } from './timelines.constants';
+import { PostingsRepository } from '../postings/repositories/postings.repository';
 
 @Injectable()
 export class TimelinesService {
   constructor(
     private readonly timelinesRepository: TimelinesRepository,
+    private readonly postingsRepository: PostingsRepository,
     private readonly postingsService: PostingsService,
     private readonly storageService: StorageService
   ) {}
@@ -42,6 +44,10 @@ export class TimelinesService {
       const filePath = `${userId}/${posting.id}`;
       const { path } = await this.storageService.upload(filePath, file);
       timeline.image = path;
+
+      if (!posting.thumbnail) {
+        await this.postingsRepository.updateThumbnail(posting.id, path);
+      }
     }
 
     return this.timelinesRepository.save(timeline);

--- a/BE/src/timelines/timelines.swagger.ts
+++ b/BE/src/timelines/timelines.swagger.ts
@@ -7,9 +7,9 @@ export const create_OK = {
   place: '서울역',
   time: '07:30',
   posting: {
-    id: '4e8076d2-48e6-4397-8652-3e163d1c09b3',
-    title: 'bread lover❤️',
-    createdAt: '2023-11-30T02:39:18.314Z',
+    id: '9a0396ba-4892-436a-a97c-58be59b59327',
+    title: '대전 여행😎 ',
+    createdAt: '2023-12-02T08:36:04.676Z',
     thumbnail: null,
     startDate: '2023-08-16',
     endDate: '2023-08-18',
@@ -51,6 +51,24 @@ export const findOne_OK = {
   date: '2023-08-16',
   place: '서울역',
   time: '07:30',
+  posting: {
+    id: '9a0396ba-4892-436a-a97c-58be59b59327',
+    title: '대전 여행😎 ',
+    createdAt: '2023-12-02T08:36:04.676Z',
+    thumbnail:
+      '123456789012345678901234567890123456/9a0396ba-4892-436a-a97c-58be59b59327e735eca5-21e8-4c0b-bbce-abd54f0643dc.jpg',
+    startDate: '2023-08-16',
+    endDate: '2023-08-18',
+    days: 3,
+    period: '2박 3일',
+    headcount: '5인 이상',
+    budget: '10 - 50만 원',
+    location: '대전',
+    season: '여름',
+    vehicle: null,
+    theme: ['힐링', '맛집'],
+    withWho: ['가족'],
+  },
 };
 
 export const update_OK = {
@@ -71,6 +89,24 @@ export const remove_OK = {
   date: '2023-08-16',
   place: '서울역',
   time: '07:30',
+  posting: {
+    id: '9a0396ba-4892-436a-a97c-58be59b59327',
+    title: '대전 여행😎 ',
+    createdAt: '2023-12-02T08:36:04.676Z',
+    thumbnail:
+      '123456789012345678901234567890123456/9a0396ba-4892-436a-a97c-58be59b59327e735eca5-21e8-4c0b-bbce-abd54f0643dc.jpg',
+    startDate: '2023-08-16',
+    endDate: '2023-08-18',
+    days: 3,
+    period: '2박 3일',
+    headcount: '5인 이상',
+    budget: '10 - 50만 원',
+    location: '대전',
+    season: '여름',
+    vehicle: null,
+    theme: ['힐링', '맛집'],
+    withWho: ['가족'],
+  },
 };
 
 export const findAll_OK = [


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- be-feature/#185-thumbnail

## 📚 작업한 내용
- 자잘한 수정
    - Swagger 관련 수정
    - dto의 데코레이터 수정
    - 변수 초기화 방식 변경
- 게시글에서 처음으로 생성되는 타임라인의 이미지가 썸네일로 지정됨
    - Day1의 첫 번째 타임라인의 이미지가 썸네일이 아닐 수도 있음
- A 타임라인이 게시글의 썸네일인데, **A 타임라인이 `수정`될 경우**
    - 먼저 타임라인 수정
    - 게시글 관련 타임라인 중 1개의 이미지를 게시글 썸네일로 지정
    - 반드시 수정된 A 타임라인의 이미지가 게시글의 썸네일이 아닐 수도 있음 (랜덤)
- A 타임라인의 게시글의 썸네일인데, **A 타임라인이 `삭제`될 경우**
    - 먼저 타임라인 삭제
    - 게시글 관련 타임라인 중 1개의 이미지를 게시글 썸네일로 지정
    - 반드시 수정된 A 타임라인의 이미지가 게시글의 썸네일이 아닐 수도 있음 (랜덤)

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

### feat 커밋부터가 실제 썸네일 관련 작업입니다!

### 추가된 40줄 정도는 Swagger 예제 때문에 추가된 겁니다!

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|request body 형식을 json에서 x-www-form-urlencoded로 변경함에 따라 ENUM을 적극 활용할 수 있게 됨!|![image](https://github.com/boostcampwm2023/iOS07-traveline/assets/62174395/dc586fe9-3a8e-4bcb-862c-86095b48d593)| 

## 관련 이슈
- Close: #185
