### PR TITLE
[feat] 최근 검색어 Data-Domain 연결

### DIFF
--- a/iOS/traveline/Sources/Core/Constant/UserDefaultsList.swift
+++ b/iOS/traveline/Sources/Core/Constant/UserDefaultsList.swift
@@ -10,4 +10,5 @@ import Foundation
 
 enum UserDefaultsList {
     @UserDefaultsWrapper<Profile>(key: "profile") static var profile
+    @UserDefaultsWrapper<[String]>(key: "recentSearchKeyword") static var recentSearchKeyword
 }

--- a/iOS/traveline/Sources/Data/Repository/Mock/PostingRepositoryMock.swift
+++ b/iOS/traveline/Sources/Data/Repository/Mock/PostingRepositoryMock.swift
@@ -17,4 +17,22 @@ final class PostingRepositoryMock: PostingRepository {
         return mockData
     }
     
+    func fetchRecentKeyword() -> [String]? {
+        return UserDefaultsList.recentSearchKeyword
+    }
+    
+    func saveRecentKeyword(_ keyword: String) {
+        if let savedKeywordList = UserDefaultsList.recentSearchKeyword {
+            let deDuplicationList = savedKeywordList.filter({ $0 != keyword })
+            if deDuplicationList.count < 15 {
+                UserDefaultsList.recentSearchKeyword = deDuplicationList + [keyword]
+            } else {
+                let removeOldestKeyword = deDuplicationList.dropFirst()
+                UserDefaultsList.recentSearchKeyword = removeOldestKeyword + [keyword]
+            }
+        } else {
+            UserDefaultsList.recentSearchKeyword = [keyword]
+        }
+    }
+    
 }

--- a/iOS/traveline/Sources/Data/Repository/Mock/PostingRepositoryMock.swift
+++ b/iOS/traveline/Sources/Data/Repository/Mock/PostingRepositoryMock.swift
@@ -35,4 +35,10 @@ final class PostingRepositoryMock: PostingRepository {
         }
     }
     
+    func deleteRecentKeyword(_ keyword: String) {
+        guard let savedKeywordList = UserDefaultsList.recentSearchKeyword else { return }
+        let deletedKeywordList = savedKeywordList.filter({ $0 != keyword })
+        UserDefaultsList.recentSearchKeyword = deletedKeywordList
+    }
+    
 }

--- a/iOS/traveline/Sources/Data/Repository/PostingRepositoryImpl.swift
+++ b/iOS/traveline/Sources/Data/Repository/PostingRepositoryImpl.swift
@@ -25,4 +25,22 @@ final class PostingRepositoryImpl: PostingRepository {
         return postingListResponseDTO.map { $0.toDomain() }
     }
     
+    func fetchRecentKeyword() -> [String]? {
+        return UserDefaultsList.recentSearchKeyword
+    }
+    
+    func saveRecentKeyword(_ keyword: String) {
+        if let savedKeywordList = UserDefaultsList.recentSearchKeyword {
+            let deDuplicationList = savedKeywordList.filter({ $0 != keyword })
+            if deDuplicationList.count < 15 {
+                UserDefaultsList.recentSearchKeyword = deDuplicationList + [keyword]
+            } else {
+                let removeOldestKeyword = deDuplicationList.dropFirst()
+                UserDefaultsList.recentSearchKeyword = removeOldestKeyword + [keyword]
+            }
+        } else {
+            UserDefaultsList.recentSearchKeyword = [keyword]
+        }
+    }
+    
 }

--- a/iOS/traveline/Sources/Data/Repository/PostingRepositoryImpl.swift
+++ b/iOS/traveline/Sources/Data/Repository/PostingRepositoryImpl.swift
@@ -43,4 +43,10 @@ final class PostingRepositoryImpl: PostingRepository {
         }
     }
     
+    func deleteRecentKeyword(_ keyword: String) {
+        guard let savedKeywordList = UserDefaultsList.recentSearchKeyword else { return }
+        let deletedKeywordList = savedKeywordList.filter({ $0 != keyword })
+        UserDefaultsList.recentSearchKeyword = deletedKeywordList
+    }
+    
 }

--- a/iOS/traveline/Sources/DesignSystem/View/TLSearch/TLSearchInfoView.swift
+++ b/iOS/traveline/Sources/DesignSystem/View/TLSearch/TLSearchInfoView.swift
@@ -36,12 +36,18 @@ final class TLSearchInfoView: UIView {
         color: TLColor.white
     )
     
-    private let closeButton: UIButton = {
+    let closeButton: UIButton = {
         let button = UIButton()
         button.setImage(TLImage.Common.close, for: .normal)
         button.imageView?.contentMode = .scaleAspectFit
         return button
     }()
+    
+    // MARK: - Properties
+    
+    var keyword: String? {
+        titleLabel.text
+    }
     
     // MARK: - Initializer
     

--- a/iOS/traveline/Sources/Domain/RepositoryInterface/PostingRepository.swift
+++ b/iOS/traveline/Sources/Domain/RepositoryInterface/PostingRepository.swift
@@ -10,4 +10,6 @@ import Foundation
 
 protocol PostingRepository {
     func fetchPostingList() async throws -> TravelList
+    func fetchRecentKeyword() -> [String]?
+    func saveRecentKeyword(_ keyword: String)
 }

--- a/iOS/traveline/Sources/Domain/RepositoryInterface/PostingRepository.swift
+++ b/iOS/traveline/Sources/Domain/RepositoryInterface/PostingRepository.swift
@@ -12,4 +12,5 @@ protocol PostingRepository {
     func fetchPostingList() async throws -> TravelList
     func fetchRecentKeyword() -> [String]?
     func saveRecentKeyword(_ keyword: String)
+    func deleteRecentKeyword(_ keyword: String)
 }

--- a/iOS/traveline/Sources/Domain/UseCase/HomeUseCase.swift
+++ b/iOS/traveline/Sources/Domain/UseCase/HomeUseCase.swift
@@ -13,6 +13,7 @@ protocol HomeUseCase {
     func fetchHomeList() -> AnyPublisher<TravelList, Error>
     func fetchRecentKeyword() -> AnyPublisher<SearchKeywordList, Never>
     func saveRecentKeyword(_ keyword: String)
+    func deleteRecentKeyword(_ keyword: String) -> AnyPublisher<SearchKeywordList, Never>
 }
 
 final class HomeUseCaseImpl: HomeUseCase {
@@ -47,6 +48,11 @@ final class HomeUseCaseImpl: HomeUseCase {
     
     func saveRecentKeyword(_ keyword: String) {
         repository.saveRecentKeyword(keyword)
+    }
+    
+    func deleteRecentKeyword(_ keyword: String) -> AnyPublisher<SearchKeywordList, Never> {
+        repository.deleteRecentKeyword(keyword)
+        return fetchRecentKeyword()
     }
     
 }

--- a/iOS/traveline/Sources/Domain/UseCase/HomeUseCase.swift
+++ b/iOS/traveline/Sources/Domain/UseCase/HomeUseCase.swift
@@ -11,6 +11,8 @@ import Foundation
 
 protocol HomeUseCase {
     func fetchHomeList() -> AnyPublisher<TravelList, Error>
+    func fetchRecentKeyword() -> AnyPublisher<SearchKeywordList, Never>
+    func saveRecentKeyword(_ keyword: String)
 }
 
 final class HomeUseCaseImpl: HomeUseCase {
@@ -33,6 +35,18 @@ final class HomeUseCaseImpl: HomeUseCase {
                 }
             }
         }.eraseToAnyPublisher()
+    }
+    
+    func fetchRecentKeyword() -> AnyPublisher<SearchKeywordList, Never> {
+        if let keywordList = repository.fetchRecentKeyword()?.reversed() {
+            let recentKeywordList = keywordList.map { SearchKeyword(type: .recent, title: $0) }
+            return .just(recentKeywordList)
+        }
+        return .just([])
+    }
+    
+    func saveRecentKeyword(_ keyword: String) {
+        repository.saveRecentKeyword(keyword)
     }
     
 }

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/VC/HomeVC.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/VC/HomeVC.swift
@@ -137,39 +137,14 @@ private extension HomeVC {
     }
     
     func bind() {
+        bindListView()
+        bindSearchView()
+        
         createTravelButton
             .tapPublisher
             .withUnretained(self)
             .sink { owner, _ in
                 owner.viewModel.sendAction(.createTravel)
-            }
-            .store(in: &cancellables)
-        
-        homeListView.didSelectHomeList
-            .withUnretained(self)
-            .sink { owner, _  in
-                let timelineVC = VCFactory.makeTimelineVC()
-                owner.navigationController?.pushViewController(
-                    timelineVC,
-                    animated: true
-                )
-            }
-            .store(in: &cancellables)
-        
-        homeListView.didSelectFilterType
-            .withUnretained(self)
-            .sink { owner, type in
-                owner.viewModel.sendAction(.startFilter(type))
-            }
-            .store(in: &cancellables)
-        
-        homeSearchView.didSelectKeyword
-            .withUnretained(self)
-            .sink { owner, keyword in
-                owner.viewModel.sendAction(.searchDone(keyword))
-                owner.homeSearchView.isHidden = true
-                owner.searchController.searchBar.text = keyword
-                owner.searchController.searchBar.resignFirstResponder()
             }
             .store(in: &cancellables)
         
@@ -241,6 +216,45 @@ private extension HomeVC {
             .sink { owner, _ in
                 let travelVC = TravelVC(viewModel: TravelViewModel())
                 owner.navigationController?.pushViewController(travelVC, animated: true)
+            }
+            .store(in: &cancellables)
+    }
+    
+    func bindListView() {
+        homeListView.didSelectHomeList
+            .withUnretained(self)
+            .sink { owner, _  in
+                let timelineVC = VCFactory.makeTimelineVC()
+                owner.navigationController?.pushViewController(
+                    timelineVC,
+                    animated: true
+                )
+            }
+            .store(in: &cancellables)
+        
+        homeListView.didSelectFilterType
+            .withUnretained(self)
+            .sink { owner, type in
+                owner.viewModel.sendAction(.startFilter(type))
+            }
+            .store(in: &cancellables)
+    }
+    
+    func bindSearchView() {
+        homeSearchView.didSelectKeyword
+            .withUnretained(self)
+            .sink { owner, keyword in
+                owner.viewModel.sendAction(.searchDone(keyword))
+                owner.homeSearchView.isHidden = true
+                owner.searchController.searchBar.text = keyword
+                owner.searchController.searchBar.resignFirstResponder()
+            }
+            .store(in: &cancellables)
+        
+        homeSearchView.didDeleteKeyword
+            .withUnretained(self)
+            .sink { owner, keyword in
+                owner.viewModel.sendAction(.deleteKeyword(keyword))
             }
             .store(in: &cancellables)
     }

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/VC/HomeVC.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/VC/HomeVC.swift
@@ -184,7 +184,6 @@ private extension HomeVC {
         viewModel.$state
             .filter { $0.isSearching }
             .map(\.homeViewType)
-            .removeDuplicates()
             .withUnretained(self)
             .sink { owner, type in
                 let type: SearchViewType = (type == .recent) ? .recent : .related

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/VC/HomeVC.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/VC/HomeVC.swift
@@ -163,6 +163,16 @@ private extension HomeVC {
             }
             .store(in: &cancellables)
         
+        homeSearchView.didSelectKeyword
+            .withUnretained(self)
+            .sink { owner, keyword in
+                owner.viewModel.sendAction(.searchDone(keyword))
+                owner.homeSearchView.isHidden = true
+                owner.searchController.searchBar.text = keyword
+                owner.searchController.searchBar.resignFirstResponder()
+            }
+            .store(in: &cancellables)
+        
         viewModel.$state
             .map(\.travelList)
             .removeDuplicates()

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/View/Cell/SearchCVC.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/View/Cell/SearchCVC.swift
@@ -6,7 +6,12 @@
 //  Copyright © 2023 traveline. All rights reserved.
 //
 
+import Combine
 import UIKit
+
+protocol SearchCVCDelegate: AnyObject {
+    func deleteKeyword(_ keyword: String)
+}
 
 final class SearchCVC: UICollectionViewCell {
     
@@ -14,11 +19,18 @@ final class SearchCVC: UICollectionViewCell {
     
     private let tlSearchInfoView: TLSearchInfoView = .init()
     
+    // MARK: - Properties
+    
+    private var cancellables: Set<AnyCancellable> = .init()
+    
+    weak var delegate: SearchCVCDelegate?
+    
     // MARK: - Initializer
     
     override init(frame: CGRect) {
         super.init(frame: frame)
         
+        setupAttributes()
         setupLayout()
     }
     
@@ -36,6 +48,18 @@ final class SearchCVC: UICollectionViewCell {
 // MARK: - Setup Functions
 
 private extension SearchCVC {
+    func setupAttributes() {
+        tlSearchInfoView.closeButton
+            .tapPublisher
+            .withUnretained(self)
+            .sink { owner, _ in
+                if let keyword = owner.tlSearchInfoView.keyword {
+                    owner.delegate?.deleteKeyword(keyword)
+                }
+            }
+            .store(in: &cancellables)
+    }
+    
     func setupLayout() {
         addSubview(tlSearchInfoView)
         tlSearchInfoView.translatesAutoresizingMaskIntoConstraints = false

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/View/HomeSearchView.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/View/HomeSearchView.swift
@@ -49,6 +49,7 @@ final class HomeSearchView: UIView {
     
     private var dataSource: DataSource!
     
+    let didDeleteKeyword: PassthroughSubject<String, Never> = .init()
     let didSelectKeyword: PassthroughSubject<String, Never> = .init()
     
     // MARK: - Initializer
@@ -73,6 +74,8 @@ final class HomeSearchView: UIView {
         ) { collectionView, indexPath, searchKeyword in
             let cell = collectionView.dequeue(cell: SearchCVC.self, for: indexPath)
             cell.setupData(item: searchKeyword)
+            cell.delegate = self
+            
             return cell
         }
         
@@ -147,6 +150,14 @@ private extension HomeSearchView {
             searchCollectionView.trailingAnchor.constraint(equalTo: trailingAnchor),
             searchCollectionView.bottomAnchor.constraint(equalTo: bottomAnchor)
         ])
+    }
+}
+
+// MARK: - SearchCVCDelegate
+
+extension HomeSearchView: SearchCVCDelegate {
+    func deleteKeyword(_ keyword: String) {
+        didDeleteKeyword.send(keyword)
     }
 }
 

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/View/HomeSearchView.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/View/HomeSearchView.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2023 traveline. All rights reserved.
 //
 
+import Combine
 import UIKit
 
 enum SearchViewType {
@@ -35,6 +36,7 @@ final class HomeSearchView: UIView {
         )
         collectionView.register(cell: SearchCVC.self)
         collectionView.registerHeader(view: RecentHeaderView.self)
+        collectionView.delegate = self
         collectionView.backgroundColor = TLColor.black
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         return collectionView
@@ -46,6 +48,8 @@ final class HomeSearchView: UIView {
     private typealias Snapshot = NSDiffableDataSourceSnapshot<SearchSection, SearchKeyword>
     
     private var dataSource: DataSource!
+    
+    let didSelectKeyword: PassthroughSubject<String, Never> = .init()
     
     // MARK: - Initializer
     
@@ -143,6 +147,16 @@ private extension HomeSearchView {
             searchCollectionView.trailingAnchor.constraint(equalTo: trailingAnchor),
             searchCollectionView.bottomAnchor.constraint(equalTo: bottomAnchor)
         ])
+    }
+}
+
+// MARK: - UICollectionViewDelegate
+
+extension HomeSearchView: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        if let selectedItem = dataSource.itemIdentifier(for: indexPath) {
+            didSelectKeyword.send(selectedItem.title)
+        }
     }
 }
 

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeAction.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeAction.swift
@@ -17,4 +17,5 @@ enum HomeAction: BaseAction {
     case startFilter(FilterType)
     case addFilter([Filter])
     case createTravel
+    case deleteKeyword(String)
 }

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeSideEffect.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeSideEffect.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 enum HomeSideEffect: BaseSideEffect {
-    case showRecent
+    case showRecent(SearchKeywordList)
     case showRelated(String)
     case showResult(String)
     case showHomeList(TravelList)

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeViewModel.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeViewModel.swift
@@ -39,6 +39,9 @@ final class HomeViewModel: BaseViewModel<HomeAction, HomeSideEffect, HomeState> 
             
         case .createTravel:
             return .just(HomeSideEffect.showTravelWriting)
+            
+        case let .deleteKeyword(keyword):
+            return deleteSearchKeyword(keyword)
         }
     }
     
@@ -97,9 +100,9 @@ final class HomeViewModel: BaseViewModel<HomeAction, HomeSideEffect, HomeState> 
     }
 }
 
-// MARK: - Fetch
+// MARK: - Functions
 
-extension HomeViewModel {
+private extension HomeViewModel {
     func fetchHomeList() -> SideEffectPublisher {
         return homeUseCase.fetchHomeList()
             .map { travelList in
@@ -122,4 +125,10 @@ extension HomeViewModel {
         homeUseCase.saveRecentKeyword(keyword)
     }
     
+    func deleteSearchKeyword(_ keyword: String) -> SideEffectPublisher {
+        return homeUseCase.deleteRecentKeyword(keyword)
+            .map { recentKeywordList in
+                return HomeSideEffect.showRecent(recentKeywordList)
+            }.eraseToAnyPublisher()
+    }
 }

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeViewModel.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeViewModel.swift
@@ -23,7 +23,7 @@ final class HomeViewModel: BaseViewModel<HomeAction, HomeSideEffect, HomeState> 
             return fetchHomeList()
             
         case .startSearch:
-            return .just(HomeSideEffect.showRecent)
+            return fetchRecentKeyword()
             
         case let .searching(text):
             return .just(HomeSideEffect.showRelated(text))
@@ -46,9 +46,8 @@ final class HomeViewModel: BaseViewModel<HomeAction, HomeSideEffect, HomeState> 
         var newState = state
         
         switch effect {
-        case .showRecent:
-            // TODO: - 서버 연동 후 수정
-            newState.searchList = SearchKeywordSample.makeRecentList()
+        case let .showRecent(recentSearchKeywordList):
+            newState.searchList = recentSearchKeywordList
             newState.homeViewType = .recent
             newState.curFilter = nil
             newState.isSearching = true
@@ -60,13 +59,14 @@ final class HomeViewModel: BaseViewModel<HomeAction, HomeSideEffect, HomeState> 
             newState.searchText = text
             newState.isSearching = true
             
-        case let .showResult(text):
+        case let .showResult(keyword):
             // TODO: - 서버 연동 후 수정
             newState.travelList = TravelListSample.make()
             newState.homeViewType = .result
-            newState.searchText = text
+            newState.searchText = keyword
             newState.isSearching = false
             newState.resultFilters = .make()
+            saveSearchKeyword(keyword)
             
         case let .showHomeList(travelList):
             // TODO: - 서버 연동 후 수정
@@ -110,4 +110,16 @@ extension HomeViewModel {
             }
             .eraseToAnyPublisher()
     }
+    
+    func fetchRecentKeyword() -> SideEffectPublisher {
+        return homeUseCase.fetchRecentKeyword()
+            .map { recentKeywordList in
+                return HomeSideEffect.showRecent(recentKeywordList)
+            }.eraseToAnyPublisher()
+    }
+    
+    func saveSearchKeyword(_ keyword: String) {
+        homeUseCase.saveRecentKeyword(keyword)
+    }
+    
 }


### PR DESCRIPTION
## 🌎 PR 요약
- 홈 화면의 최근 검색어를 저장, 삭제, 가져오는 Data-Domain 플로우를 연결합니다.

🌱 작업한 브랜치
- feature/#204

## 📚 작업한 내용
### 1. 최근 검색어 불러오기, 저장하기, 삭제하기 구현
- `UserDefaults`를 이용해 최근 검색어를 불러오고, 저장하고, 삭제하는 기능을 연결했습니다~!
- 추가로 구현 간에 검색하지 않고 다시 검색바에 진입하는 경우 최근 검색어 View가 노출되지 않는 이슈가 있어 아래 코드에서 `removeDuplicates()`를 제거해주어 해결했는데 혹시 저친구 어떤 경우를 처리하기 위해 넣어주셨나용?? 제거해도 무방할까요? @0inn 

<img src="https://github.com/boostcampwm2023/iOS07-traveline/assets/51712973/fa6da5bb-3328-4d5f-b8b5-03c87bb72024" width="700">

### 2. 검색어 선택 시 해당 텍스트로 검색 연결
- 최근 검색어, 연관 검색어 선택 시 해당 텍스트로 바로 검색되도록 연결했습니다!
- DiffableDataSource를 사용하니 선택된 아이템의 데이터를 가져오는게 굉장히 편리하더라구요....
~~~swift
extension HomeSearchView: UICollectionViewDelegate {
    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
        if let selectedItem = dataSource.itemIdentifier(for: indexPath) {
            didSelectKeyword.send(selectedItem.title)
        }
    }
}
~~~
### 3. UseCase와 Repository의 역할
- 이번에 UserDefaults를 사용해 저장, 삭제 하면서 역할 분리에 대해서 고민이 있었는데요!
- 최근 검색어가 15개가 넘으면 가장 오래된 검색어부터 지워주는 역할,
UserDefault에는 배열 형태로 검색어가 저장되어 가장 오래된 검색어가 맨 앞에 존재하게 되는데, View에서 최근 검색어를 가장 위로 보여주기 위해 배열을 뒤집어주는 역할 2개가 있었습니다.
- 고민해본 후에 검색어 15개 처리는 Repository에서, 검색어 배열을 뒤집어주는 역할은 UseCase에서 처리해주게 되었는데요!
첫번째는 UseCase에서 검색어를 저장할때 지금 데이터 소스에 검색어가 몇개 있는지 모르는게 자연스러운 것 같아서였고,
두번째는 Repository에서 데이터 소스(UserDefaults)에 접근해 검색어를 가져왔을 때 이걸 뒤집어서 넘겨줘야 한다는걸 모르는게 자연스러운 것 같아서였습니다!
다른 분들 생각은 어떠신지, 괜찮으신지 궁금합니당당

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
왜인지 모르겠는데 오늘 검색바를 선택했을 때 아래와 같은 경고가 간헐적으로 발생하면서 뷰가 멈추는 이슈가 있었습니다,,
이것저것 검색해봤는데 원인이나 해결방법은 찾지못했고, 이상하게 시뮬레이터에서만 그렇더라구요..?
실기기에서는 발생하지 않아 일단 넘어갔습니다.....

![스크린샷 2023-12-02 오후 7 05 20](https://github.com/boostcampwm2023/iOS07-traveline/assets/51712973/443a046c-0552-406c-b03d-032726185739)

## 📸 스크린샷

https://github.com/boostcampwm2023/iOS07-traveline/assets/51712973/8c844000-9fd0-4c02-b33b-ad823fc1c575



## 관련 이슈
- Resolved: #204 
