### PR TITLE
[fix] swagger 수정 (request body, 안내 메시지)

### DIFF
--- a/BE/src/postings/postings.controller.ts
+++ b/BE/src/postings/postings.controller.ts
@@ -74,7 +74,6 @@ export class PostingsController {
     summary: '게시글 생성',
     description: '사용자가 입력한 정보를 토대로 새로운 게시글을 생성합니다.',
   })
-  @ApiConsumes('application/x-www-form-urlencoded')
   @ApiCreatedResponse({ schema: { example: create_OK } })
   @ApiBadRequestResponse({
     schema: {

--- a/BE/src/timelines/dto/create-timeline.dto.ts
+++ b/BE/src/timelines/dto/create-timeline.dto.ts
@@ -46,7 +46,8 @@ export class CreateTimelineDto {
     required: false,
     type: 'double',
     example: 126.970606917394,
-    description: '장소의 X 좌표',
+    description:
+      '장소의 X 좌표 (값을 보내지 않을 때는 Send empty value를 체크하지 말아주세요)',
   })
   @IsOptional()
   @Transform(({ value }) => parseFloat(value))
@@ -57,7 +58,8 @@ export class CreateTimelineDto {
     required: false,
     type: 'double',
     example: 37.5546788388674,
-    description: '장소의 Y 좌표',
+    description:
+      '장소의 Y 좌표 (값을 보내지 않을 때는 Send empty value를 체크하지 말아주세요)',
   })
   @IsOptional()
   @Transform(({ value }) => parseFloat(value))


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- be-feature/#223-feedback

## 📚 작업한 내용
- 게시글 POST 시 request body 형식 json으로 변경
    - form-data로 하면, 인원수, 이동수단 등 옵셔널 태그에 값을 넣지 않았을 때 에러가 발생할 수 있고
    - 테마/누구랑 태그에서 배열을 전달할 수가 없어요ㅎㅎ...

- 타임라인 POST 시 coordX, coordY는 옵셔널인데, 이것들의 값을 전달하지 않을 때는 `Send empty value` 체크를 해지해야 한다는 안내를 넣었습니다.
    - 체크한 채로 보내면 coordX, coordY는 Number여야 한다는 에러가 발생합니다.

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 관련 이슈
- Close: #223
