### PR TITLE
[feat] 연관 검색어 Data-Domain 연결

### DIFF
--- a/iOS/traveline/Sources/Core/Extension/String+.swift
+++ b/iOS/traveline/Sources/Core/Extension/String+.swift
@@ -30,4 +30,26 @@ extension String {
         
         return attributedString
     }
+    
+    /// 비교할 문자열과 공통 부분의 범위를 반환합니다.
+    /// - Parameter compareString: 비교할 문자열
+    /// - Returns: 공통 부분의 범위
+    func findCommonPrefixRange(_ compareString: String) -> NSRange {
+        let minLength = min(self.count, compareString.count)
+        var commonPrefix = ""
+        
+        for offset in 0..<minLength {
+            let index1 = self.index(self.startIndex, offsetBy: offset)
+            let index2 = compareString.index(compareString.startIndex, offsetBy: offset)
+            
+            if self[index1] == compareString[index2] {
+                commonPrefix.append(self[index1])
+            } else {
+                break
+            }
+        }
+        
+        return (self as NSString).range(of: commonPrefix)
+    }
+    
 }

--- a/iOS/traveline/Sources/Data/Network/DataMapping/PostingTitleListResponseDTO.swift
+++ b/iOS/traveline/Sources/Data/Network/DataMapping/PostingTitleListResponseDTO.swift
@@ -1,0 +1,11 @@
+//
+//  PostingTitleListResponseDTO.swift
+//  traveline
+//
+//  Created by 김태현 on 12/4/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+typealias PostingTitleListResponseDTO = [String]

--- a/iOS/traveline/Sources/Data/Repository/Mock/PostingRepositoryMock.swift
+++ b/iOS/traveline/Sources/Data/Repository/Mock/PostingRepositoryMock.swift
@@ -46,4 +46,18 @@ final class PostingRepositoryMock: PostingRepository {
         UserDefaultsList.recentSearchKeyword = deletedKeywordList
     }
     
+    func fetchPostingTitleList(_ keyword: String) async throws -> SearchKeywordList {
+        try await Task.sleep(nanoseconds: 1_000)
+        
+        let mockTitleList: SearchKeywordList = [
+            SearchKeyword(type: .related, title: keyword, searchedKeyword: keyword),
+            SearchKeyword(type: .related, title: keyword + "테스트2", searchedKeyword: keyword),
+            SearchKeyword(type: .related, title: keyword + "스트테3", searchedKeyword: keyword),
+            SearchKeyword(type: .related, title: keyword + "트테스4", searchedKeyword: keyword),
+            SearchKeyword(type: .related, title: keyword + "5", searchedKeyword: keyword),
+            SearchKeyword(type: .related, title: keyword + "6", searchedKeyword: keyword)
+        ]
+        return mockTitleList
+    }
+    
 }

--- a/iOS/traveline/Sources/Data/Repository/PostingRepositoryImpl.swift
+++ b/iOS/traveline/Sources/Data/Repository/PostingRepositoryImpl.swift
@@ -56,4 +56,14 @@ final class PostingRepositoryImpl: PostingRepository {
         UserDefaultsList.recentSearchKeyword = deletedKeywordList
     }
     
+    func fetchPostingTitleList(_ keyword: String) async throws -> SearchKeywordList {
+        let postingTitleListResponseDTO = try await network.request(
+            endPoint: PostingEndPoint.postingList,
+            type: PostingTitleListResponseDTO.self
+        )
+        
+        return postingTitleListResponseDTO
+            .map { SearchKeyword(type: .related, title: $0, searchedKeyword: keyword) }
+    }
+    
 }

--- a/iOS/traveline/Sources/DesignSystem/Component/TLLabel.swift
+++ b/iOS/traveline/Sources/DesignSystem/Component/TLLabel.swift
@@ -85,6 +85,18 @@ final class TLLabel: UILabel {
         setupAttributes()
     }
     
+    func setColor(to color: UIColor, range: NSRange) {
+        guard let mutableAttributedText = attributedText?.mutableCopy() as? NSMutableAttributedString else { return }
+        
+        mutableAttributedText.addAttribute(
+            .foregroundColor,
+            value: TLColor.main,
+            range: range
+        )
+        
+        attributedText = mutableAttributedText
+    }
+    
     func setFont(to font: TLFont) {
         travelineFont = font
         setupAttributes()

--- a/iOS/traveline/Sources/DesignSystem/View/TLSearch/TLSearchInfoView.swift
+++ b/iOS/traveline/Sources/DesignSystem/View/TLSearch/TLSearchInfoView.swift
@@ -67,6 +67,13 @@ final class TLSearchInfoView: UIView {
         titleLabel.setText(to: item.title)
         closeButton.isHidden = (item.type == .related)
         searchIcon.isHidden = (item.type == .recent)
+        
+        if let searchedKeyword = item.searchedKeyword {
+            titleLabel.setColor(
+                to: TLColor.main,
+                range: item.title.findCommonPrefixRange(searchedKeyword)
+            )
+        }
     }
 }
 

--- a/iOS/traveline/Sources/Domain/Model/SearchKeyword.swift
+++ b/iOS/traveline/Sources/Domain/Model/SearchKeyword.swift
@@ -13,4 +13,5 @@ typealias SearchKeywordList = [SearchKeyword]
 struct SearchKeyword: Hashable {
     let type: SearchViewType
     let title: String
+    var searchedKeyword: String?
 }

--- a/iOS/traveline/Sources/Domain/RepositoryInterface/PostingRepository.swift
+++ b/iOS/traveline/Sources/Domain/RepositoryInterface/PostingRepository.swift
@@ -15,4 +15,5 @@ protocol PostingRepository {
     func saveRecentKeyword(_ keyword: String)
     func saveRecentKeywordList(_ keywordList: [String])
     func deleteRecentKeyword(_ keyword: String)
+    func fetchPostingTitleList(_ keyword: String) async throws -> SearchKeywordList
 }

--- a/iOS/traveline/Sources/Domain/UseCase/HomeUseCase.swift
+++ b/iOS/traveline/Sources/Domain/UseCase/HomeUseCase.swift
@@ -14,6 +14,7 @@ protocol HomeUseCase {
     func fetchRecentKeyword() -> AnyPublisher<SearchKeywordList, Never>
     func saveRecentKeyword(_ keyword: String)
     func deleteRecentKeyword(_ keyword: String) -> AnyPublisher<SearchKeywordList, Never>
+    func fetchRelatedKeyword(_ keyword: String) -> AnyPublisher<SearchKeywordList, Error>
 }
 
 final class HomeUseCaseImpl: HomeUseCase {
@@ -64,6 +65,20 @@ final class HomeUseCaseImpl: HomeUseCase {
     func deleteRecentKeyword(_ keyword: String) -> AnyPublisher<SearchKeywordList, Never> {
         repository.deleteRecentKeyword(keyword)
         return fetchRecentKeyword()
+    }
+    
+    func fetchRelatedKeyword(_ keyword: String) -> AnyPublisher<SearchKeywordList, Error> {
+        return Future { promise in
+            Task { [weak self] in
+                guard let self else { return }
+                do {
+                    let relatedKeyword = try await self.repository.fetchPostingTitleList(keyword)
+                    promise(.success(relatedKeyword))
+                } catch {
+                    promise(.failure(error))
+                }
+            }
+        }.eraseToAnyPublisher()
     }
     
 }

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeSideEffect.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeSideEffect.swift
@@ -11,7 +11,7 @@ import Foundation
 enum HomeSideEffect: BaseSideEffect {
     case showHome
     case showRecent(SearchKeywordList)
-    case showRelated(String)
+    case showRelated(SearchKeywordList)
     case showResult(String)
     case showHomeList(TravelList)
     case showFilter(FilterType)

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeViewModel.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeViewModel.swift
@@ -80,7 +80,6 @@ final class HomeViewModel: BaseViewModel<HomeAction, HomeSideEffect, HomeState> 
         case let .showHomeList(travelList):
             // TODO: - 서버 연동 후 수정
             newState.travelList = travelList
-            newState.homeViewType = .home
             
         case let .showFilter(type):
             newState.curFilter = (state.homeViewType == .home) ? state.homeFilters[type] : state.resultFilters[type]


### PR DESCRIPTION
## 🌎 PR 요약
- 홈 화면의 연관 검색어를 가져오는 Data-Domain 플로우를 연결했습니다!

🌱 작업한 브랜치
- feature/#205

## 📚 작업한 내용
### 1. 검색어와 일치하는 부분 색상 처리
- 검색어와 일치하는 결과 부분에만 색상 처리를 추가해주기 위해 `String+ Extension`에 문자열의 일치하는 부분 `range`를 계산해주는 `findCommonPrefixRange(_ compareString: String)` 메서드를 추가했습니다!
- 추가로 `TLLabel`에서 기존 font 설정은 유지한채로 해당 범위의 색상만 변경해주기 위해 `setColor(to color: UIColor, range: NSRange)` 메서드도 추가했어요!
~~~ swift 
titleLabel.setColor(
    to: TLColor.main,
    range: "일치 부분 찾고싶은 문자열".findCommonPrefixRange("비교할 문자열")
)
~~~
- 요런식으로 사용하시면 됩니다 ㅎ (장소 검색에서도 동일하게 사용하시면 될 것 같아요!)

### 2. 검색어 다 지웠을 때 처리
- 검색어를 다 지웠을 때는 다시 검색 기록이 노출되도록 하는 로직을 `searching` action 쪽으로 옮겼습니다!
- searching -> fetchRelatedKeyword -> 여기서 keyword가 없다면 fetchRecentKeyword 방출, 없으면 fetchRelatedKeyword 방출 이렇게 흘러갑니다!

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
검색 화면에서 여전히 [+] 버튼 노출되는 문제가 있었는데, `showHome`에서 `homeViewType`을 바꿔주는데 `showHomeList`에서도 `homeViewType`을 중복해서 바꾸고 있어서 발생한 문제였습니다 :)
`showHomeList`에서 `homeViewType` 변경하는 부분을 제거해서 해결했어요!

### EndPoint
- EndPoint 관리하는걸 아무래도 통일해서 관리를 해야할 것 같아서 (이대로 쭉 작업하면 conflict가 계속 날거 같아서)
일단 EndPoint는 이번에 제외하고 작업해뒀습니다~!

## 📸 스크린샷

https://github.com/boostcampwm2023/iOS07-traveline/assets/51712973/0e35053c-cdaf-4464-aa2e-c5c7f8bbef1e


## 관련 이슈
- Resolved: #205 
