### PR TITLE
[docs] swagger에서 사진 전송 가능하도록 변경

### DIFF
--- a/BE/src/users/dto/update-user.dto.ts
+++ b/BE/src/users/dto/update-user.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+import { IsString, MaxLength, MinLength } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class UpdateUserDto {
@@ -7,12 +7,4 @@ export class UpdateUserDto {
   @MaxLength(14)
   @ApiProperty({ example: '레몬', description: '변경할 사용자 이름' })
   name: string;
-
-  @IsOptional()
-  @ApiProperty({
-    required: false,
-    type: 'file',
-    description: '프로필 사진으로 등록하려는 이미지',
-  })
-  image: Express.Multer.File;
 }

--- a/BE/src/users/dto/update-user.dto.ts
+++ b/BE/src/users/dto/update-user.dto.ts
@@ -1,10 +1,8 @@
 import { IsString, MaxLength, MinLength } from 'class-validator';
-import { ApiProperty } from '@nestjs/swagger';
 
 export class UpdateUserDto {
   @IsString()
   @MinLength(1)
   @MaxLength(14)
-  @ApiProperty({ example: '레몬', description: '변경할 사용자 이름' })
   name: string;
 }

--- a/BE/src/users/users.controller.ts
+++ b/BE/src/users/users.controller.ts
@@ -70,7 +70,14 @@ export class UsersController {
       '닉네임 변경사항이 없을 경우 기존 name을 전송해주시면 됩니다.',
     schema: {
       type: 'object',
-      properties: { name: { type: 'string' }, image: { type: 'file' } },
+      required: ['name'],
+      properties: {
+        name: { type: 'string' },
+        image: {
+          type: 'file',
+          description: '프로필 사진으로 등록하려는 이미지',
+        },
+      },
     },
   })
   update(

--- a/BE/src/users/users.controller.ts
+++ b/BE/src/users/users.controller.ts
@@ -68,6 +68,10 @@ export class UsersController {
       '프로필사진을 기본 사진으로 변경할 경우 파일을 전송하지 않으시면 됩니다. ' +
       '프로필 사진 변경이 없을 경우 기존 사진을 다시 보내주시면 됩니다. ' +
       '닉네임 변경사항이 없을 경우 기존 name을 전송해주시면 됩니다.',
+    schema: {
+      type: 'object',
+      properties: { name: { type: 'string' }, image: { type: 'file' } },
+    },
   })
   update(
     @Req() request,

--- a/BE/src/users/users.controller.ts
+++ b/BE/src/users/users.controller.ts
@@ -72,7 +72,11 @@ export class UsersController {
       type: 'object',
       required: ['name'],
       properties: {
-        name: { type: 'string' },
+        name: {
+          type: 'string',
+          example: '레몬',
+          description: '변경할 사용자 이름',
+        },
         image: {
           type: 'file',
           description: '프로필 사진으로 등록하려는 이미지',


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- feature/#240

## 📚 작업한 내용
swagger 데코레이터를 수정해서 이제 users API에서도 스웨거를 통한 사진 전송이 가능합니다!

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|사진 전송 가능!|![image](https://github.com/boostcampwm2023/iOS07-traveline/assets/138637345/00c1bdc8-b98b-4b53-a7cc-bcd7d7d5d021)|

## 관련 이슈
- close #240 
