### PR TITLE
[refactor] 게시글 검색 시 위치, 계절, 테마, 누구랑 다중 필터링

### DIFF
--- a/BE/src/postings/dto/search-posting.dto.ts
+++ b/BE/src/postings/dto/search-posting.dto.ts
@@ -1,4 +1,4 @@
-import { IsIn, IsNumber, IsOptional, IsString } from 'class-validator';
+import { IsArray, IsIn, IsNumber, IsOptional, IsString } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 import {
@@ -88,35 +88,39 @@ export class SearchPostingDto {
     description: '여행위치 태그',
   })
   @IsOptional()
-  @IsString()
-  @IsIn(locations)
-  location: Location;
+  @IsString({ each: true })
+  @IsArray()
+  @IsIn(locations, { each: true })
+  location: Location[];
 
   @ApiProperty({
     required: false,
     enum: Theme,
-    description: '여행테마 태그 (1개만 선택 가능)',
+    description: '여행테마 태그',
   })
   @IsOptional()
-  @IsString()
-  @IsIn(themes)
-  theme: Theme;
+  @IsString({ each: true })
+  @IsArray()
+  @IsIn(themes, { each: true })
+  theme: Theme[];
 
   @ApiProperty({
     required: false,
     enum: WithWho,
-    description: '누구랑 태그 (1개만 선택 가능)',
+    description: '누구랑 태그',
   })
   @IsOptional()
-  @IsString()
-  @IsIn(withWhos)
-  withWho: WithWho;
+  @IsString({ each: true })
+  @IsArray()
+  @IsIn(withWhos, { each: true })
+  withWho: WithWho[];
 
   @ApiProperty({ required: false, enum: Season, description: '여행계절 태그' })
   @IsOptional()
-  @IsString()
-  @IsIn(seasons)
-  season: Season;
+  @IsString({ each: true })
+  @IsArray()
+  @IsIn(seasons, { each: true })
+  season: Season[];
 
   @ApiProperty({ required: false, enum: Vehicle, description: '이동수단 태그' })
   @IsOptional()

--- a/BE/src/postings/dto/search-posting.dto.ts
+++ b/BE/src/postings/dto/search-posting.dto.ts
@@ -85,7 +85,9 @@ export class SearchPostingDto {
   @ApiProperty({
     required: false,
     enum: Location,
-    description: '여행위치 태그',
+    description:
+      '여행위치 태그 (Swagger에선 2개 이상 선택해야만 테스트가 가능합니다)',
+    isArray: true,
   })
   @IsOptional()
   @IsString({ each: true })
@@ -96,7 +98,9 @@ export class SearchPostingDto {
   @ApiProperty({
     required: false,
     enum: Theme,
-    description: '여행테마 태그',
+    description:
+      '여행테마 태그 (Swagger에선 2개 이상 선택해야만 테스트가 가능합니다)',
+    isArray: true,
   })
   @IsOptional()
   @IsString({ each: true })
@@ -107,7 +111,9 @@ export class SearchPostingDto {
   @ApiProperty({
     required: false,
     enum: WithWho,
-    description: '누구랑 태그',
+    description:
+      '누구랑 태그 (Swagger에선 2개 이상 선택해야만 테스트가 가능합니다)',
+    isArray: true,
   })
   @IsOptional()
   @IsString({ each: true })
@@ -115,7 +121,13 @@ export class SearchPostingDto {
   @IsIn(withWhos, { each: true })
   withWho: WithWho[];
 
-  @ApiProperty({ required: false, enum: Season, description: '여행계절 태그' })
+  @ApiProperty({
+    required: false,
+    enum: Season,
+    description:
+      '여행계절 태그 (Swagger에선 2개 이상 선택해야만 테스트가 가능합니다)',
+    isArray: true,
+  })
   @IsOptional()
   @IsString({ each: true })
   @IsArray()

--- a/BE/src/postings/entities/posting.entity.ts
+++ b/BE/src/postings/entities/posting.entity.ts
@@ -72,7 +72,7 @@ export class Posting {
   @Column({ type: 'json', nullable: true })
   theme: Theme[];
 
-  @Column({ type: 'json', nullable: true })
+  @Column({ name: 'with_who', type: 'json', nullable: true })
   withWho: WithWho[];
 
   @OneToMany(() => Timeline, (timeline) => timeline.posting)

--- a/BE/src/postings/repositories/postings.repository.ts
+++ b/BE/src/postings/repositories/postings.repository.ts
@@ -42,12 +42,12 @@ export class PostingsRepository {
     limit: number,
     budget: Budget,
     headcount: Headcount,
-    location: Location,
+    locations: Location[],
     period: Period,
-    season: Season,
+    seasons: Season[],
     vehicle: Vehicle,
-    theme: Theme,
-    withWho: WithWho
+    themes: Theme[],
+    withWhos: WithWho[]
   ) {
     const qb = this.postingsRepository
       .createQueryBuilder('p')
@@ -62,32 +62,68 @@ export class PostingsRepository {
       qb.andWhere('p.headcount = :headcount', { headcount });
     }
 
-    if (location) {
-      qb.andWhere('p.location = :location', { location });
+    if (locations) {
+      const orCondtions = locations
+        .map((location, index) => `p.location = :location${index}`)
+        .join(' OR ');
+      const params = locations.reduce(
+        (params, location, index) => ({
+          ...params,
+          [`location${index}`]: location,
+        }),
+        {}
+      );
+      qb.andWhere(orCondtions, params);
     }
 
     if (period) {
       qb.andWhere('p.period = :period', { period });
     }
 
-    if (season) {
-      qb.andWhere('p.season = :season', { season });
+    if (seasons) {
+      const orCondtions = seasons
+        .map((season, index) => `p.season = :season${index}`)
+        .join(' OR ');
+      const params = seasons.reduce(
+        (params, season, index) => ({
+          ...params,
+          [`season${index}`]: season,
+        }),
+        {}
+      );
+      qb.andWhere(orCondtions, params);
     }
 
     if (vehicle) {
       qb.andWhere('p.vehicle = :vehicle', { vehicle });
     }
 
-    if (theme) {
-      qb.andWhere('JSON_CONTAINS(p.theme, :theme)', {
-        theme: JSON.stringify(theme),
-      });
+    if (themes) {
+      const orCondtions = themes
+        .map((theme, index) => `JSON_CONTAINS(p.theme, :theme${index})`)
+        .join(' OR ');
+      const params = themes.reduce(
+        (params, theme, index) => ({
+          ...params,
+          [`theme${index}`]: JSON.stringify(theme),
+        }),
+        {}
+      );
+      qb.andWhere(orCondtions, params);
     }
 
-    if (withWho) {
-      qb.andWhere('JSON_CONTAINS(p.withWho, :withWho)', {
-        withWho: JSON.stringify(withWho),
-      });
+    if (withWhos) {
+      const orCondtions = withWhos
+        .map((withWho, index) => `JSON_CONTAINS(p.with_who, :withWho${index})`)
+        .join(' OR ');
+      const params = withWhos.reduce(
+        (params, withWho, index) => ({
+          ...params,
+          [`withWho${index}`]: JSON.stringify(withWho),
+        }),
+        {}
+      );
+      qb.andWhere(orCondtions, params);
     }
 
     if (sorting === Sorting.좋아요순) {


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- be-feature/#239-multiple-tags

## 📚 작업한 내용
- 게시글의 누구랑 필드가 DB에서 `withWho`라고 저장되어 있어서 `with_who`로 변경했습니다.
- 위치, 계절, 테마, 누구랑 태그 다중 선택 가능하도록 `SearchPostingDto` 및 검색 TypeORM 코드 수정
   - 각 태그는 and 조건 & 다중 선택 태그 내에서는 or 조건으로 검색

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 관련 이슈
- Close: #239