### PR TITLE
[refactor] 타임라인에 트랜잭션 적용

### DIFF
--- a/BE/package-lock.json
+++ b/BE/package-lock.json
@@ -28,6 +28,7 @@
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.1",
         "typeorm": "^0.3.17",
+        "typeorm-transactional": "^0.5.0",
         "winston": "^3.11.0",
         "winston-daily-rotate-file": "^4.7.1"
       },
@@ -2050,6 +2051,14 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cls-hooked": {
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/@types/cls-hooked/-/cls-hooked-4.3.8.tgz",
+      "integrity": "sha512-tf/7H883gFA6MPlWI15EQtfNZ+oPL0gLKkOlx9UHFrun1fC/FkuyNBpTKq1B5E3T4fbvjId6WifHUdSGsMMuPg==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -2849,6 +2858,17 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
       "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
     },
+    "node_modules/async-hook-jl": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
+      "integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
+      "dependencies": {
+        "stack-chain": "^1.3.7"
+      },
+      "engines": {
+        "node": "^4.7 || >=6.9 || >=7.3"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -3611,6 +3631,27 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/cls-hooked": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
+      "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
+      "dependencies": {
+        "async-hook-jl": "^1.7.6",
+        "emitter-listener": "^1.0.1",
+        "semver": "^5.4.1"
+      },
+      "engines": {
+        "node": "^4.7 || >=6.9 || >=7.3 || >=8.2.1"
+      }
+    },
+    "node_modules/cls-hooked/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -4268,6 +4309,14 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.578.tgz",
       "integrity": "sha512-V0ZhSu1BQZKfG0yNEL6Dadzik8E1vAzfpVOapdSiT9F6yapEJ3Bk+4tZ4SMPdWiUchCgnM/ByYtBzp5ntzDMIA==",
       "dev": true
+    },
+    "node_modules/emitter-listener": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
+      "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
+      "dependencies": {
+        "shimmer": "^1.2.0"
+      }
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -8537,6 +8586,11 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
+    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -8631,6 +8685,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/stack-chain": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
+      "integrity": "sha512-D8cWtWVdIe/jBA7v5p5Hwl5yOSOrmZPWDPe2KxQ5UAGD+nxbxU0lKXA4h85Ta6+qgdKVL3vUxsbIZjc1kBG7ug=="
     },
     "node_modules/stack-trace": {
       "version": "0.0.10",
@@ -9444,6 +9503,23 @@
         "typeorm-aurora-data-api-driver": {
           "optional": true
         }
+      }
+    },
+    "node_modules/typeorm-transactional": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/typeorm-transactional/-/typeorm-transactional-0.5.0.tgz",
+      "integrity": "sha512-53/CwnXpOIJnWU3oVCNbhHB95FwciKSGbY+m/Hw4e2dBM2c4toiOHwf4pmk83Ne7guznmDgVr/5IUfbp+JTPCg==",
+      "dependencies": {
+        "@types/cls-hooked": "^4.3.3",
+        "cls-hooked": "^4.2.2",
+        "semver": "^7.5.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "reflect-metadata": ">= 0.1.12",
+        "typeorm": ">= 0.2.8"
       }
     },
     "node_modules/typeorm/node_modules/brace-expansion": {

--- a/BE/package.json
+++ b/BE/package.json
@@ -39,6 +39,7 @@
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
     "typeorm": "^0.3.17",
+    "typeorm-transactional": "^0.5.0",
     "winston": "^3.11.0",
     "winston-daily-rotate-file": "^4.7.1"
   },

--- a/BE/src/database/database.providers.ts
+++ b/BE/src/database/database.providers.ts
@@ -1,3 +1,4 @@
+import { addTransactionalDataSource } from 'typeorm-transactional';
 import { DataSource } from 'typeorm';
 
 export const databaseProviders = [
@@ -14,7 +15,7 @@ export const databaseProviders = [
         entities: [__dirname + '/../**/*.entity{.ts,.js}'],
         synchronize: false,
       });
-      return dataSource.initialize();
+      return addTransactionalDataSource(await dataSource.initialize());
     },
   },
 ];

--- a/BE/src/main.ts
+++ b/BE/src/main.ts
@@ -4,8 +4,11 @@ import { LoggingInterceptor } from './logging/logging.interceptor';
 import { HttpExceptionFilter } from './exception/exception.filter';
 import { setupSwagger } from './swagger/swagger.setting';
 import { ValidationPipe } from '@nestjs/common';
+import { initializeTransactionalContext } from 'typeorm-transactional';
 
 async function bootstrap() {
+  initializeTransactionalContext();
+
   const app = await NestFactory.create(AppModule);
   app.useGlobalInterceptors(new LoggingInterceptor());
   app.useGlobalFilters(new HttpExceptionFilter());

--- a/BE/src/timelines/timelines.service.ts
+++ b/BE/src/timelines/timelines.service.ts
@@ -5,6 +5,7 @@ import {
 } from '@nestjs/common';
 import { firstValueFrom } from 'rxjs';
 import { HttpService } from '@nestjs/axios';
+import { Transactional } from 'typeorm-transactional';
 import { CreateTimelineDto } from './dto/create-timeline.dto';
 import { UpdateTimelineDto } from './dto/update-timeline.dto';
 import { TimelinesRepository } from './timelines.repository';
@@ -24,6 +25,7 @@ export class TimelinesService {
     private readonly httpService: HttpService
   ) {}
 
+  @Transactional()
   async create(
     userId: string,
     file: Express.Multer.File,
@@ -43,7 +45,7 @@ export class TimelinesService {
     timeline.posting = posting;
 
     if (file) {
-      const filePath = `${userId}/${posting.id}`;
+      const filePath = `${userId}/${posting.id}/`;
       const { path } = await this.storageService.upload(filePath, file);
       timeline.image = path;
 
@@ -82,6 +84,7 @@ export class TimelinesService {
     return timeline;
   }
 
+  @Transactional()
   async update(
     id: string,
     userId: string,
@@ -90,7 +93,6 @@ export class TimelinesService {
   ) {
     const timeline = await this.findOne(id);
     const isThumbnail = timeline.image === timeline.posting.thumbnail;
-
     if (timeline.image) {
       await this.storageService.delete(timeline.image);
     }
@@ -99,7 +101,7 @@ export class TimelinesService {
     updatedTimeline.id = id;
 
     if (image) {
-      const imagePath = `${userId}/${id}`;
+      const imagePath = `${userId}/${timeline.posting.id}/`;
       const { path } = await this.storageService.upload(imagePath, image);
       updatedTimeline.image = path;
     }
@@ -116,6 +118,7 @@ export class TimelinesService {
     return updatedResult;
   }
 
+  @Transactional()
   async remove(id: string) {
     const timeline = await this.findOne(id);
     await this.timelinesRepository.remove(timeline);


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- be-feature/#215-transaction

## 📚 작업한 내용
- timeline service에서 `create`, `update`, `delete` 메서드에 트랜잭션 적용

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
### 당연한 얘기지만,,, 오브젝트 스토리지에는 트랜잭션 적용 안 됩니다!
- 만약 사진을 오브젝트에 스토리지에 저장하고, 새로운 이미지 경로로 타임라인을 update한 다음에, 게시글의 썸네일을 update 과정에서 에러가 난다면
- 타임라인에서 경로가 udpate 됐던 쿼리문은 취소가 되지만
- 오브젝트 스토리지에는 이미 기존 이미지가 삭제되고, 새로운 이미지가 업로드된 채로 복구되지 않습니다,,,^^;;
- 해결... 할 수 있다면....... 해... 보겠...

### 그 외
- 게시글에는 하나의 메서드에 여러 쿼리가 묶여 있지 않아서 `@Transactional` 데코레이터 추가 안 했습니다.
- user와 auth에서 트랜잭션 처리 필요하신 부분이 있다면 추가해주세요~~

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 관련 이슈
- Close: #215
