### PR TITLE
[feat] 사이드바 데이터 레이어 로직 추가

### DIFF
--- a/iOS/traveline/Sources/Data/Network/API/UserEndPoint.swift
+++ b/iOS/traveline/Sources/Data/Network/API/UserEndPoint.swift
@@ -19,6 +19,8 @@ extension UserEndPoint: EndPoint {
         switch self {
         case .checkDuplicatedName:
             return "/users/duplicate"
+        case .requestUserInfo:
+            return "/users"
         default:
             return "/users"
         }
@@ -28,6 +30,8 @@ extension UserEndPoint: EndPoint {
         switch self {
         case .updateUserInfo:
             return .PUT
+        case .requestUserInfo:
+            return .GET
         default:
             return .GET
         }
@@ -38,6 +42,6 @@ extension UserEndPoint: EndPoint {
     }
     
     var header: [String: String] {
-        return HeaderType.json.value
+        return HeaderType.authorization.value
     }
 }

--- a/iOS/traveline/Sources/Data/Repository/UserRepositoryImpl.swift
+++ b/iOS/traveline/Sources/Data/Repository/UserRepositoryImpl.swift
@@ -17,11 +17,18 @@ final class UserRepositoryImpl: UserRepository {
     }
     
     func fetchUserInfo() async throws -> Profile {
-        let userResponseDTO = try await network.request(
+        if let profile = UserDefaultsList.profile {
+            return profile
+        }
+        
+        let profile = try await network.request(
             endPoint: UserEndPoint.requestUserInfo,
             type: UserResponseDTO.self
-        )
-        return userResponseDTO.toDomain()
+        ).toDomain()
+        
+        UserDefaultsList.profile = profile
+        
+        return profile
     }
     
     func updateUserInfo(name: String, imageData: Data?) async throws -> Profile {

--- a/iOS/traveline/Sources/Feature/SideFeature/SideScene/View/ProfileLabel.swift
+++ b/iOS/traveline/Sources/Feature/SideFeature/SideScene/View/ProfileLabel.swift
@@ -20,8 +20,8 @@ final class ProfileLabel: UIView {
     
     private let imageView: UIImageView = {
         let view = UIImageView()
-        view.image = UIImage(systemName: "leaf")
-        view.contentMode = .scaleAspectFit
+        view.image = UIImage(systemName: "person.fill")
+        view.contentMode = .center
         view.layer.cornerRadius = Metric.imageWidth / 2
         view.backgroundColor = TLColor.backgroundGray
         view.clipsToBounds = true


### PR DESCRIPTION
## 🌎 PR 요약
사이드바 데이터 레이어 로직 추가했어요.

🌱 작업한 브랜치
- feature/#260

## 📚 작업한 내용
사이드 바의 데이터 로직을 추가했어요.
기본 이미지는 일단 sf symbol person.fill로 해뒀습니다. 나중에 기본이미지 정해서 추가하면 될 것 같아요!

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
UserRepository 내에서 먼저 유저디폴트에 프로필이 있는지 확인합니다.
있다면 여기서 꺼내서 사용하고, 없다면 API 호출을 합니다.
그리고 API 호출한 데이터를 유저디폴트에 저장해줍니다.

근데 여기서 profile은 도메인에서 사용하는 데이터기때문에 유저디폴트에 저장하는 데이터 타입을 UserResponseDTO 타입으로 변경하는게 자연스러울 것 같은데 어떻게 생각하시나요???
혹시 다른 쪽에서 Profile을 코더블을 이용해서 사용하고 있는 곳이 있나요??

## 📸 스크린샷
서버에서 lemon 닉네임을 불러오는 영상

https://github.com/boostcampwm2023/iOS07-traveline/assets/91725382/265b3077-f568-4c3f-b7ec-6256e13c8c64


## 관련 이슈
- Resolved: #260
