### PR TITLE
[refactor] ViewModel State 수정

### DIFF
--- a/iOS/traveline/Sources/Core/Base/BaseViewModel.swift
+++ b/iOS/traveline/Sources/Core/Base/BaseViewModel.swift
@@ -27,7 +27,15 @@ class BaseViewModel<Action: BaseAction, SideEffect: BaseSideEffect, State: BaseS
     private var actions = PassthroughSubject<Action, Never>()
     private var sideEffects = PassthroughSubject<SideEffect, Never>()
     
-    @Published private(set) var state: State = .init()
+    private let stateSubject: CurrentValueSubject<State, Never> = .init(.init())
+    
+    var state: AnyPublisher<State, Never> {
+        return stateSubject.eraseToAnyPublisher()
+    }
+    
+    var currentState: State {
+        return stateSubject.value
+    }
     
     // MARK: - Initializer
     
@@ -44,9 +52,9 @@ class BaseViewModel<Action: BaseAction, SideEffect: BaseSideEffect, State: BaseS
             .store(in: &cancellables)
         
         self.sideEffects
-            .scan(state, reduceState)
+            .scan(stateSubject.value, reduceState)
             .receive(on: DispatchQueue.main)
-            .assign(to: \.state, on: self)
+            .assign(to: \.stateSubject.value, on: self)
             .store(in: &cancellables)
     }
     

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/VC/HomeVC.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/VC/HomeVC.swift
@@ -149,7 +149,7 @@ private extension HomeVC {
             }
             .store(in: &cancellables)
         
-        viewModel.$state
+        viewModel.state
             .map(\.travelList)
             .removeDuplicates()
             .withUnretained(self)
@@ -158,7 +158,7 @@ private extension HomeVC {
             }
             .store(in: &cancellables)
         
-        viewModel.$state
+        viewModel.state
             .map(\.searchList)
             .removeDuplicates()
             .withUnretained(self)
@@ -167,7 +167,7 @@ private extension HomeVC {
             }
             .store(in: &cancellables)
         
-        viewModel.$state
+        viewModel.state
             .filter { $0.isSearching }
             .map(\.homeViewType)
             .withUnretained(self)
@@ -179,7 +179,7 @@ private extension HomeVC {
             }
             .store(in: &cancellables)
         
-        viewModel.$state
+        viewModel.state
             .filter { !$0.isSearching }
             .compactMap(\.curFilter)
             .filter { $0 != .emtpy }
@@ -191,7 +191,7 @@ private extension HomeVC {
             }
             .store(in: &cancellables)
         
-        viewModel.$state
+        viewModel.state
             .filter { $0.homeViewType == .home }
             .map(\.homeFilters)
             .withUnretained(self)
@@ -201,7 +201,7 @@ private extension HomeVC {
             }
             .store(in: &cancellables)
         
-        viewModel.$state
+        viewModel.state
             .filter { $0.homeViewType == .home }
             .map(\.homeFilters)
             .removeDuplicates()
@@ -211,7 +211,7 @@ private extension HomeVC {
             }
             .store(in: &cancellables)
         
-        viewModel.$state
+        viewModel.state
             .filter { $0.homeViewType == .result }
             .map(\.resultFilters)
             .withUnretained(self)
@@ -220,7 +220,7 @@ private extension HomeVC {
             }
             .store(in: &cancellables)
         
-        viewModel.$state
+        viewModel.state
             .filter { $0.homeViewType == .result }
             .map(\.resultFilters)
             .removeDuplicates()
@@ -230,7 +230,7 @@ private extension HomeVC {
             }
             .store(in: &cancellables)
         
-        viewModel.$state
+        viewModel.state
             .map(\.moveToTravelWriting)
             .filter { $0 }
             .withUnretained(self)

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeViewModel.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeViewModel.swift
@@ -116,7 +116,7 @@ final class HomeViewModel: BaseViewModel<HomeAction, HomeSideEffect, HomeState> 
 private extension HomeViewModel {
     
     func makeSearchQuery(from filters: FilterDictionary) -> SearchQuery {
-        var query = state.searchQuery
+        var query = currentState.searchQuery
 
         query.selectedFilter = filters.values
             .filter { !$0.selected.isEmpty }

--- a/iOS/traveline/Sources/Feature/LoginFeature/VC/LoginVC.swift
+++ b/iOS/traveline/Sources/Feature/LoginFeature/VC/LoginVC.swift
@@ -91,7 +91,7 @@ private extension LoginVC {
             }
             .store(in: &cancellabels)
         
-        viewModel.$state
+        viewModel.state
             .compactMap(\.appleIDRequests)
             .removeDuplicates()
             .withUnretained(self)
@@ -103,7 +103,7 @@ private extension LoginVC {
             }
             .store(in: &cancellabels)
         
-        viewModel.$state
+        viewModel.state
             .map(\.isSuccessLogin)
             .filter { $0 }
             .withUnretained(self)

--- a/iOS/traveline/Sources/Feature/MyPageFeature/MyPostListScene/VC/MyPostListVC.swift
+++ b/iOS/traveline/Sources/Feature/MyPageFeature/MyPostListScene/VC/MyPostListVC.swift
@@ -152,7 +152,7 @@ private extension MyPostListVC {
     }
     
     private func bind() {
-        viewModel.$state
+        viewModel.state
             .map(\.travelList)
             .removeDuplicates()
             .withUnretained(self)

--- a/iOS/traveline/Sources/Feature/MyPageFeature/ProfileEditingScene/VC/ProfileEditingVC.swift
+++ b/iOS/traveline/Sources/Feature/MyPageFeature/ProfileEditingScene/VC/ProfileEditingVC.swift
@@ -217,7 +217,7 @@ extension ProfileEditingVC {
             }
             .store(in: &cancellables)
         
-        viewModel.$state
+        viewModel.state
             .map(\.isCompletable)
             .removeDuplicates()
             .withUnretained(self)
@@ -226,7 +226,7 @@ extension ProfileEditingVC {
             }
             .store(in: &cancellables)
         
-        viewModel.$state
+        viewModel.state
             .map(\.caption)
             .withUnretained(self)
             .sink { owner, caption in
@@ -235,7 +235,7 @@ extension ProfileEditingVC {
             }
             .store(in: &cancellables)
         
-        viewModel.$state
+        viewModel.state
             .map(\.profile)
             .removeDuplicates()
             .withUnretained(self)

--- a/iOS/traveline/Sources/Feature/SideFeature/SideScene/VC/SideMenuVC.swift
+++ b/iOS/traveline/Sources/Feature/SideFeature/SideScene/VC/SideMenuVC.swift
@@ -147,7 +147,7 @@ private extension SideMenuVC {
     }
     
     func bind() {
-        viewModel.$state
+        viewModel.state
             .map(\.profile)
             .removeDuplicates()
             .withUnretained(self)

--- a/iOS/traveline/Sources/Feature/TimelineDetailFeature/TimelineDetailScene/VC/TimelineDetailVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineDetailFeature/TimelineDetailScene/VC/TimelineDetailVC.swift
@@ -174,7 +174,7 @@ private extension TimelineDetailVC {
     
     private func bind() {
         
-        viewModel.$state
+        viewModel.state
             .map(\.timelineDetailInfo)
             .removeDuplicates()
             .withUnretained(self)

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/VC/TimelineVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/VC/TimelineVC.swift
@@ -173,7 +173,7 @@ private extension TimelineVC {
     }
     
     func bind() {
-        viewModel.$state
+        viewModel.state
             .map(\.travelInfo)
             .filter { $0 != .empty }
             .removeDuplicates()
@@ -183,7 +183,7 @@ private extension TimelineVC {
             }
             .store(in: &cancellables)
         
-        viewModel.$state
+        viewModel.state
             .map(\.timelineCardList)
             .withUnretained(self)
             .sink { owner, cardlist in
@@ -191,7 +191,7 @@ private extension TimelineVC {
             }
             .store(in: &cancellables)
         
-        viewModel.$state
+        viewModel.state
             .map(\.isOwner)
             .withUnretained(self)
             .sink { owner, isOwner in

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/VC/TimelineWritingVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/VC/TimelineWritingVC.swift
@@ -285,7 +285,7 @@ private extension TimelineWritingVC {
             }
             .store(in: &cancellables)
         
-        viewModel.$state
+        viewModel.state
             .map(\.isCompletable)
             .removeDuplicates()
             .withUnretained(self)
@@ -294,7 +294,7 @@ private extension TimelineWritingVC {
             }
             .store(in: &cancellables)
         
-        viewModel.$state
+        viewModel.state
             .map(\.timelineDetailRequest)
             .withUnretained(self)
             .sink { owner, detail in

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/ViewModel/TimelineWritingViewModel.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/ViewModel/TimelineWritingViewModel.swift
@@ -61,7 +61,7 @@ final class TimelineWritingViewModel: BaseViewModel<TimelineWritingAction, Timel
             return .just(.updateBasicInfo)
             
         case .tapCompleteButton:
-            return createTimeline(with: state.timelineDetailRequest)
+            return createTimeline(with: currentState.timelineDetailRequest)
             
         case .titleDidChange(let title):
             return .just(.updateTitleState(title))

--- a/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/VC/TravelVC.swift
+++ b/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/VC/TravelVC.swift
@@ -229,7 +229,7 @@ private extension TravelVC {
             }
             .store(in: &cancellables)
         
-        viewModel.$state
+        viewModel.state
             .map(\.canPost)
             .removeDuplicates()
             .withUnretained(self)
@@ -238,7 +238,7 @@ private extension TravelVC {
             }
             .store(in: &cancellables)
         
-        viewModel.$state
+        viewModel.state
             .map(\.startDate)
             .withUnretained(self)
             .sink { owner, startDate in
@@ -246,7 +246,7 @@ private extension TravelVC {
             }
             .store(in: &cancellables)
         
-        viewModel.$state
+        viewModel.state
             .map(\.endDate)
             .removeDuplicates()
             .withUnretained(self)
@@ -255,7 +255,7 @@ private extension TravelVC {
             }
             .store(in: &cancellables)
         
-        viewModel.$state
+        viewModel.state
             .compactMap(\.travelID)
             .removeDuplicates()
             .withUnretained(self)
@@ -268,7 +268,7 @@ private extension TravelVC {
             }
             .store(in: &cancellables)
         
-        viewModel.$state
+        viewModel.state
             .compactMap(\.titleValidation)
             .filter { $0 == .invalidate }
             .removeDuplicates()

--- a/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/ViewModel/TravelViewModel.swift
+++ b/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/ViewModel/TravelViewModel.swift
@@ -129,10 +129,10 @@ private extension TravelViewModel {
 private extension TravelViewModel {
     func postTravel(_ tags: [Tag]) -> SideEffectPublisher {
         let travelReqeust = TravelRequest(
-            title: state.titleText,
-            region: state.region,
-            startDate: state.startDate,
-            endDate: state.endDate,
+            title: currentState.titleText,
+            region: currentState.region,
+            startDate: currentState.startDate,
+            endDate: currentState.endDate,
             tags: tags
         )
         


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- feature/#255

## 📚 작업한 내용
- 기존 @Published에서 CurrentValueSubject 방식으로 수정

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

### @ Published 문제 상황
원래 @ Published로 구현된 state를 바인딩해서 뷰를 업데이트하고 있는데요.
@ Published의 경우, willSet 시점에 publish를 하여 값이 변경되기 직전에 호출됩니다.
그렇기 때문에 VC에서 바인딩한 후 관찰하는 state는 변경되지 직전의 상태가 되는데요.
https://stackoverflow.com/questions/58676249/difference-between-currentvaluesubject-and-published

### CurrentValueSubject 도입
이를 해결하기 위해서 CurrentValueSubject를 사용해서 State를 관리하도록 수정했습니다.
해당 Subject는 didSet 시점에 publish하기 때문에 업데이트된 값을 바라볼 수 있습니다.
하지만 해당 subject는 private(set)이나 let을 통해 선언해도 어디서든 send() 메서드를 통해 state가 변경될 가능성이 존재했는데요.
이를 위해 AnyPubliser<State, Never> 형태로 방출된 값을 받을 수만 있는 state를 생성했습니다.

```Swift
// BaseViewModel.swift

private let stateSubject: CurrentValueSubject<State, Never> = .init(.init())

var state: AnyPublisher<State, Never> { // VC에서 viewmodel.state로 바인딩
    return stateSubject.eraseToAnyPublisher()
}

var currentState: State { // 실제 state 값에 접근해야 할 경우, currentState 사용
    return stateSubject.value
}
```

태현님이 알려주신 replace로 야무지게 수정했습니다 ~ ! ~ !
해당 PR 머지되고 나면 바로 현재 작업에 반영해주시면 감사하겠습니다 (꾸벅)

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 관련 이슈
- Resolved: #255
