### PR TITLE
[fix] 제목 검색 시 500번대 에러 반환하던 에러 해결

### DIFF
--- a/BE/src/postings/postings.controller.ts
+++ b/BE/src/postings/postings.controller.ts
@@ -117,7 +117,7 @@ export class PostingsController {
   @ApiOkResponse({ schema: { example: searchByWord_OK } })
   async searchByKeyWord(
     @Query('keyword', new DefaultValuePipe('')) keyword: string
-  ): Promise<string[]> {
+  ) {
     return this.postingsService.findAllBytitle(keyword);
   }
 

--- a/BE/src/postings/postings.service.ts
+++ b/BE/src/postings/postings.service.ts
@@ -88,14 +88,7 @@ export class PostingsService {
 
   async findAllBytitle(keyword: string) {
     const titles = await this.postingsRepository.findAllByTitle(keyword);
-
-    return [
-      ...new Set(
-        titles
-          .filter((e) => e.reports.length <= BLOCKING_LIMIT)
-          .map((e) => e.title)
-      ),
-    ];
+    return titles.map((e) => e.title);
   }
 
   async findAllByWriter(userId: string) {


### PR DESCRIPTION
500번대 에러 발생 이유: report 개수가 5개 이하인 것만 빼내려고 posting.reports.length를 했지만, report 엔티티를 join하지 않았기 때문에 reports 필드가 없었고, 존재하지 않는 필드에서 length라는 프로퍼티에 접근하려고 하여 에러가 발생했다.

## 🌎 PR 요약

🌱 작업한 브랜치
- be-feature/#269-search-fix

## 📚 작업한 내용
- 게시글 제목 검색 시 서버 내부 에러가 발생했는데, 그 원인 해결!
- 기존엔 일단 모든 게시글을 가져온 다음에, 타입스크립트의 filter로 신고 개수가 5개 이하인지 필터링하고, set으로 중복된 게시글도 제거했는데 이제는 `queryBuilder`로 `DISTINCT` 키워드랑 report `leftJoin` 시 조건을 넣어서 깔끔하게 제목만 반환되도록 했습니다~

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 관련 이슈
- Resolved: #
