### PR TITLE
[feat] 검색 결과 서버 연결

### DIFF
--- a/iOS/traveline/Sources/Core/Enum/VCFactory.swift
+++ b/iOS/traveline/Sources/Core/Enum/VCFactory.swift
@@ -30,7 +30,8 @@ enum VCFactory {
     
     static func makeHomeVC() -> HomeVC {
         // TODO: - 서버 연결 후 Repository 변경
-        let repository = PostingRepositoryMock()
+//        let repository = PostingRepositoryMock()
+        let repository = PostingRepositoryImpl(network: network)
         let useCase = HomeUseCaseImpl(repository: repository)
         let viewModel = HomeViewModel(homeUseCase: useCase)
         return HomeVC(viewModel: viewModel)

--- a/iOS/traveline/Sources/Core/Extension/String+.swift
+++ b/iOS/traveline/Sources/Core/Extension/String+.swift
@@ -31,25 +31,13 @@ extension String {
         return attributedString
     }
     
-    /// 비교할 문자열과 공통 부분의 범위를 반환합니다.
-    /// - Parameter compareString: 비교할 문자열
+    /// 문자열에서 해당 단어의 범위를 반환합니다.
+    /// - Parameter searchString: 찾을 단어
     /// - Returns: 공통 부분의 범위
-    func findCommonPrefixRange(_ compareString: String) -> NSRange {
-        let minLength = min(self.count, compareString.count)
-        var commonPrefix = ""
+    func findCommonWordRange(_ searchString: String) -> NSRange {
+        guard let range = self.range(of: searchString) else { return .init() }
         
-        for offset in 0..<minLength {
-            let index1 = self.index(self.startIndex, offsetBy: offset)
-            let index2 = compareString.index(compareString.startIndex, offsetBy: offset)
-            
-            if self[index1] == compareString[index2] {
-                commonPrefix.append(self[index1])
-            } else {
-                break
-            }
-        }
-        
-        return (self as NSString).range(of: commonPrefix)
+        return NSRange(range, in: self)
     }
     
 }

--- a/iOS/traveline/Sources/Data/Network/API/PostingEndPoint.swift
+++ b/iOS/traveline/Sources/Data/Network/API/PostingEndPoint.swift
@@ -14,6 +14,7 @@ enum PostingEndPoint {
     case createPosting(TravelRequestDTO) /// 게시글 생성
     case fetchPostingInfo(String) /// 특정 게시글 반환
     case specificPosting
+    case postingTitleList(String)
 }
 
 extension PostingEndPoint: EndPoint {
@@ -28,6 +29,8 @@ extension PostingEndPoint: EndPoint {
             return curPath + searchQuery.makeQuery()
         case let .fetchPostingInfo(id):
             return "\(curPath)/\(id)"
+        case let .postingTitleList(keyword):
+            return "\(curPath)/titles?keyword=\(keyword)"
         default:
             return curPath
         }

--- a/iOS/traveline/Sources/Data/Network/DataMapping/PostingResponseDTO.swift
+++ b/iOS/traveline/Sources/Data/Network/DataMapping/PostingResponseDTO.swift
@@ -17,7 +17,7 @@ struct PostingResponseDTO: Decodable {
     let thumbnail: String?
     let startDate: String
     let endDate: String
-    let days: [String]
+    let days: Int
     let period: String
     let headcount: String?
     let budget: String?
@@ -25,9 +25,8 @@ struct PostingResponseDTO: Decodable {
     let season: String
     let vehicle: String?
     let theme: [String]?
-    let withWho: String?
+    let withWho: [String]?
     let writer: WriterDTO
-    let likeds: [LikedsDTO]
 }
 
 // MARK: - Mapping
@@ -42,7 +41,8 @@ extension PostingResponseDTO {
                 imageURL: writer.avatar ?? Literal.empty,
                 name: writer.name
             ),
-            like: likeds.count,
+            // TODO: - 서버 반환 값 변경 후 수정
+            like: 100,
             isLiked: true,
             tags: [
                 .init(title: location, type: .region),

--- a/iOS/traveline/Sources/Data/Network/DataMapping/PostingResponseDTO.swift
+++ b/iOS/traveline/Sources/Data/Network/DataMapping/PostingResponseDTO.swift
@@ -15,9 +15,6 @@ struct PostingResponseDTO: Decodable {
     let title: String
     let createdAt: String
     let thumbnail: String?
-    let startDate: String
-    let endDate: String
-    let days: Int
     let period: String
     let headcount: String?
     let budget: String?
@@ -27,6 +24,12 @@ struct PostingResponseDTO: Decodable {
     let theme: [String]?
     let withWho: [String]?
     let writer: WriterDTO
+    let likeds: String
+    
+    enum CodingKeys: String, CodingKey {
+        case createdAt = "created_at"
+        case id, title, thumbnail, period, headcount, budget, location, season, vehicle, theme, withWho, writer, likeds
+    }
 }
 
 // MARK: - Mapping
@@ -41,8 +44,7 @@ extension PostingResponseDTO {
                 imageURL: writer.avatar ?? Literal.empty,
                 name: writer.name
             ),
-            // TODO: - 서버 반환 값 변경 후 수정
-            like: 100,
+            like: Int(likeds) ?? 0,
             isLiked: true,
             tags: [
                 .init(title: location, type: .region),

--- a/iOS/traveline/Sources/Data/Network/DataMapping/WriterDTO.swift
+++ b/iOS/traveline/Sources/Data/Network/DataMapping/WriterDTO.swift
@@ -12,6 +12,4 @@ struct WriterDTO: Decodable {
     let id: String
     let name: String
     let avatar: String?
-    let resourceId: String
-    let socialType: Int
 }

--- a/iOS/traveline/Sources/Data/Repository/PostingRepositoryImpl.swift
+++ b/iOS/traveline/Sources/Data/Repository/PostingRepositoryImpl.swift
@@ -58,7 +58,7 @@ final class PostingRepositoryImpl: PostingRepository {
     
     func fetchPostingTitleList(_ keyword: String) async throws -> SearchKeywordList {
         let postingTitleListResponseDTO = try await network.request(
-            endPoint: PostingEndPoint.myPostingList,
+            endPoint: PostingEndPoint.postingTitleList(keyword),
             type: PostingTitleListResponseDTO.self
         )
         

--- a/iOS/traveline/Sources/DesignSystem/View/TLList/TLInfoView.swift
+++ b/iOS/traveline/Sources/DesignSystem/View/TLList/TLInfoView.swift
@@ -108,15 +108,22 @@ final class TLInfoView: UIView {
     // MARK: - Functions
     
     func setupData(item: TravelListInfo) {
-        // TODO: - 이미지 캐싱 구현
-//        thumbnailImageView.image = model.imageURL
-//        profileImageView.image = model.profile.imageURL
+        thumbnailImageView.setImage(from: item.imageURL)
+        profileImageView.setImage(from: item.profile.imageURL)
         nameLabel.setText(to: item.profile.name)
         likeCountLabel.setText(to: "\(item.like)")
         titleLabel.setText(to: item.title)
         zip(tags, item.tags).forEach { tagView, tagModel in
             tagView.updateTag(text: tagModel.title)
         }
+    }
+    
+    /// View 재사용 시 reset
+    func reset() {
+        thumbnailImageView.cancel()
+        thumbnailImageView.image = TravelineAsset.Images.travelImage.image
+        profileImageView.cancel()
+        profileImageView.image = nil
     }
 }
 

--- a/iOS/traveline/Sources/DesignSystem/View/TLList/TLListCVC.swift
+++ b/iOS/traveline/Sources/DesignSystem/View/TLList/TLListCVC.swift
@@ -28,6 +28,12 @@ final class TLListCVC: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        tlInfoView.reset()
+    }
+    
     // MARK: - Functions
     
     func setupData(item: TravelListInfo) {

--- a/iOS/traveline/Sources/DesignSystem/View/TLSearch/TLSearchInfoView.swift
+++ b/iOS/traveline/Sources/DesignSystem/View/TLSearch/TLSearchInfoView.swift
@@ -71,7 +71,7 @@ final class TLSearchInfoView: UIView {
         if let searchedKeyword = item.searchedKeyword {
             titleLabel.setColor(
                 to: TLColor.main,
-                range: item.title.findCommonPrefixRange(searchedKeyword)
+                range: item.title.findCommonWordRange(searchedKeyword)
             )
         }
     }

--- a/iOS/traveline/Sources/Domain/Model/SearchQuery.swift
+++ b/iOS/traveline/Sources/Domain/Model/SearchQuery.swift
@@ -14,39 +14,40 @@ protocol Query {
 
 struct SearchQuery: Query {
     var keyword: String?
-    var offset: Int?
-    var limit: Int?
+    var offset: Int = 1
+    var limit: Int = 20
     var selectedFilter: [DetailFilter]?
     
     func makeQuery() -> String {
-        guard let selectedFilter else { return Literal.empty }
         let baseQuery = "?"
         var queries: [String] = []
+        queries.append("offset=\(offset)")
+        queries.append("limit=\(limit)")
         
         if let keyword { queries.append("keyword=\(keyword)") }
-        if let offset { queries.append("offset=\(offset)") }
-        if let limit { queries.append("limit=\(limit)") }
 
-        selectedFilter.forEach {
-            switch $0 {
-            case let .sort(sorting):
-                queries.append("sorting=\(sorting.query)")
-            case let .theme(theme):
-                queries.append("theme[]=\(theme.query)")
-            case let .region(location):
-                queries.append("location[]=\(location.query)")
-            case let .cost(budget):
-                queries.append("budget=\(budget.query)")
-            case let .people(headcount):
-                queries.append("headcount=\(headcount.query)")
-            case let .with(withWho):
-                queries.append("withWho[]=\(withWho.query)")
-            case let .transportation(vehicle):
-                queries.append("vehicle=\(vehicle.query)")
-            case let .period(period):
-                queries.append("period=\(period.query)")
-            case let .season(season):
-                queries.append("season[]=\(season.query)")
+        if let selectedFilter {
+            selectedFilter.forEach {
+                switch $0 {
+                case let .sort(sorting):
+                    queries.append("sorting=\(sorting.query)")
+                case let .theme(theme):
+                    queries.append("theme[]=\(theme.query)")
+                case let .region(location):
+                    queries.append("location[]=\(location.query)")
+                case let .cost(budget):
+                    queries.append("budget=\(budget.query)")
+                case let .people(headcount):
+                    queries.append("headcount=\(headcount.query)")
+                case let .with(withWho):
+                    queries.append("withWho[]=\(withWho.query)")
+                case let .transportation(vehicle):
+                    queries.append("vehicle=\(vehicle.query)")
+                case let .period(period):
+                    queries.append("period=\(period.query)")
+                case let .season(season):
+                    queries.append("season[]=\(season.query)")
+                }
             }
         }
         

--- a/iOS/traveline/Sources/Domain/Model/SearchResult.swift
+++ b/iOS/traveline/Sources/Domain/Model/SearchResult.swift
@@ -1,0 +1,14 @@
+//
+//  SearchResult.swift
+//  traveline
+//
+//  Created by 김태현 on 12/6/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+struct SearchResult {
+    let keyword: String
+    let travelList: TravelList
+}

--- a/iOS/traveline/Sources/Domain/Model/Travel/TravelListInfo.swift
+++ b/iOS/traveline/Sources/Domain/Model/Travel/TravelListInfo.swift
@@ -18,8 +18,4 @@ struct TravelListInfo: Hashable {
     let like: Int
     let isLiked: Bool
     let tags: [Tag]
-    
-    static func == (lhs: TravelListInfo, rhs: TravelListInfo) -> Bool {
-        lhs.id == rhs.id
-    }
 }

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/VC/HomeVC.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/VC/HomeVC.swift
@@ -151,6 +151,7 @@ private extension HomeVC {
         
         viewModel.state
             .map(\.travelList)
+            .dropFirst()
             .removeDuplicates()
             .withUnretained(self)
             .sink { owner, list in
@@ -257,6 +258,13 @@ private extension HomeVC {
             .withUnretained(self)
             .sink { owner, type in
                 owner.viewModel.sendAction(.startFilter(type))
+            }
+            .store(in: &cancellables)
+        
+        homeListView.didScrollToBottom
+            .withUnretained(self)
+            .sink { owner, _ in
+                owner.viewModel.sendAction(.didScrollToEnd)
             }
             .store(in: &cancellables)
     }

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/VC/HomeVC.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/VC/HomeVC.swift
@@ -224,6 +224,7 @@ private extension HomeVC {
         viewModel.state
             .filter { $0.homeViewType == .result }
             .map(\.resultFilters)
+            .dropFirst()
             .removeDuplicates()
             .withUnretained(self)
             .sink { owner, filters in

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/VC/HomeVC.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/VC/HomeVC.swift
@@ -208,7 +208,7 @@ private extension HomeVC {
             .removeDuplicates()
             .withUnretained(self)
             .sink { owner, filters in
-                owner.viewModel.sendAction(.filterChanged(filters))
+                owner.viewModel.sendAction(.filterChanged)
             }
             .store(in: &cancellables)
         
@@ -228,7 +228,7 @@ private extension HomeVC {
             .removeDuplicates()
             .withUnretained(self)
             .sink { owner, filters in
-                owner.viewModel.sendAction(.filterChanged(filters))
+                owner.viewModel.sendAction(.filterChanged)
             }
             .store(in: &cancellables)
         

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/View/HomeListView.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/View/HomeListView.swift
@@ -62,7 +62,9 @@ final class HomeListView: UIView {
     
     let didSelectHomeList: PassthroughSubject<Void, Never> = .init()
     let didSelectFilterType: PassthroughSubject<FilterType, Never> = .init()
+    let didScrollToBottom: PassthroughSubject<Void, Never> = .init()
     
+    private var isPaging: Bool = true
     private var cancellables: Set<AnyCancellable> = .init()
     
     // MARK: - Initializer
@@ -195,6 +197,7 @@ final class HomeListView: UIView {
         list.forEach { snapshot.appendItems([.travelListItem($0)], toSection: .travelList) }
         
         dataSource.apply(snapshot, animatingDifferences: false)
+        isPaging = false
     }
 }
 
@@ -222,6 +225,15 @@ extension HomeListView {
 extension HomeListView: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         didSelectHomeList.send(Void())
+    }
+    
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        if scrollView.contentOffset.y > scrollView.contentSize.height - scrollView.bounds.size.height {
+            if !isPaging {
+                isPaging = true
+                didScrollToBottom.send(Void())
+            }
+        }
     }
 }
 

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeAction.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeAction.swift
@@ -20,4 +20,5 @@ enum HomeAction: BaseAction {
     case filterChanged(FilterDictionary)
     case createTravel
     case deleteKeyword(String)
+    case didScrollToEnd
 }

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeAction.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeAction.swift
@@ -17,7 +17,7 @@ enum HomeAction: BaseAction {
     case cancelSearch
     case startFilter(FilterType)
     case addFilter([Filter])
-    case filterChanged(FilterDictionary)
+    case filterChanged
     case createTravel
     case deleteKeyword(String)
     case didScrollToEnd

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeSideEffect.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeSideEffect.swift
@@ -14,9 +14,10 @@ enum HomeSideEffect: BaseSideEffect {
     case showRecent(SearchKeywordList)
     case showRelated(SearchKeywordList)
     case showResult(String)
-    case showHomeList(TravelList)
+    case showNewList(TravelList)
     case showFilter(FilterType)
     case saveFilter([Filter])
     case showTravelWriting
     case loadFailed(Error)
+    case showNextPage(TravelList)
 }

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeSideEffect.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeSideEffect.swift
@@ -14,6 +14,7 @@ enum HomeSideEffect: BaseSideEffect {
     case showRecent(SearchKeywordList)
     case showRelated(SearchKeywordList)
     case showSearchResult(SearchResult)
+    case showNewHomeList(TravelList)
     case showNewList(TravelList)
     case showFilter(FilterType)
     case saveFilter([Filter])

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeSideEffect.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeSideEffect.swift
@@ -13,7 +13,7 @@ enum HomeSideEffect: BaseSideEffect {
     case showPrevious
     case showRecent(SearchKeywordList)
     case showRelated(SearchKeywordList)
-    case showResult(String)
+    case showSearchResult(SearchResult)
     case showNewList(TravelList)
     case showFilter(FilterType)
     case saveFilter([Filter])

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeViewModel.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeViewModel.swift
@@ -46,8 +46,8 @@ final class HomeViewModel: BaseViewModel<HomeAction, HomeSideEffect, HomeState> 
         case let .addFilter(filterList):
             return .just(HomeSideEffect.saveFilter(filterList))
             
-        case let .filterChanged(filters):
-            return fetchNewSearchList(from: filters)
+        case .filterChanged:
+            return fetchNewSearchList()
             
         case .createTravel:
             return .just(HomeSideEffect.showTravelWriting)
@@ -153,7 +153,8 @@ private extension HomeViewModel {
             .eraseToAnyPublisher()
     }
     
-    func fetchNewSearchList(from filters: FilterDictionary) -> SideEffectPublisher {
+    func fetchNewSearchList() -> SideEffectPublisher {
+        let filters = currentState.homeViewType == .home ? currentState.homeFilters : currentState.resultFilters
         var query = makeSearchQuery(from: filters)
         query.offset = 1
         
@@ -168,7 +169,7 @@ private extension HomeViewModel {
     }
     
     func fetchNextPage() -> SideEffectPublisher {
-        let filters = state.homeViewType == .home ? state.homeFilters : state.resultFilters
+        let filters = currentState.homeViewType == .home ? currentState.homeFilters : currentState.resultFilters
         let query = makeSearchQuery(from: filters)
         
         return homeUseCase.fetchSearchList(with: query)

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeViewModel.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeViewModel.swift
@@ -92,6 +92,11 @@ final class HomeViewModel: BaseViewModel<HomeAction, HomeSideEffect, HomeState> 
                 offset: 2
             )
             
+        case let .showNewHomeList(travelList):
+            newState.travelList = travelList
+            newState.searchQuery.offset = 2
+            newState.searchQuery.keyword = nil
+            
         case let .showNewList(travelList):
             newState.travelList = travelList
             newState.searchQuery.offset = 2
@@ -140,12 +145,12 @@ private extension HomeViewModel {
     }
     
     func fetchHomeList() -> SideEffectPublisher {
-        var query = makeSearchQuery(from: state.homeFilters)
-        query.offset = 1
+        var query = SearchQuery()
+        query.selectedFilter = makeSearchQuery(from: currentState.homeFilters).selectedFilter
         
         return homeUseCase.fetchSearchList(with: query)
             .map { travelList in
-                return HomeSideEffect.showNewList(travelList)
+                return HomeSideEffect.showNewHomeList(travelList)
             }
             .catch { error in
                 return Just(HomeSideEffect.loadFailed(error))


### PR DESCRIPTION
## 🌎 PR 요약
- 검색 결과, 필터링 서버 연결
- 연관 검색어 서버 연결

🌱 작업한 브랜치
- feature/#261

## 📚 작업한 내용
### 1. 검색 결과 서버 연결, 페이지네이션 구현
- 페이지네이션을 위해 `SearchQuery`에 `offset`과 `limit`을 관리하고 있습니다!
- 서버분들께 여쭤본 결과 `offset`은 1부터 페이지 넘버를 나타내고, `limit`은 한 페이지에 몇 개의 데이터를 가져올 지를 나타냅니다. 만약 `offset` 1에 `limit` 20을 주면 1~20 결과를, `offset` 2에 `limit` 20을 주면 21~40 결과를 반환합니다!
- `SearchQuery`에도 기본값을 1과 20으로 지정해두었고, 변경가능하도록 했습니당
- `scrollViewDidScroll(_:)`에서 바닥까지 스크롤한 걸 감지해서 페이지네이션 진행했습니당
- 이 과정에서 바닥에 도착했을때 계속 호출하는걸 방지하기 위해 `isPaging` 변수를 추가했어요!

### 2. 검색 결과, 필터 플로우
- 홈 -> 페이지네이션 -> 필터 적용 -> 다시 로드
- 홈 -> 검색 -> 키워드로 로드 (기존 검색 필터는 초기화)
- 검색 -> 필터 적용 -> 다시 로드 -> 취소 -> 홈에 저장된 필터로 다시 로드
- 위와 같은 플로우로 진행되게 됩니덩

### 3. 검색 결과 문자열 색상 범위 수정
- 기존에 Extension으로 문자열의 CommonPrefix 범위를 계산해서 색상을 변경해줬는데, 서버 연결하고 보니 Prefix가 아니라 내부에 문자열이 포함되어 있는 경우도 검색이 되더라구요?!
- 그래서 내부 문자열의 범위에 색상을 변경할 수 있도록 수정했습니다 :)

### 4. Diffable DataSource에서 종종 충돌이 발생하는 문제
- 홈 화면과 검색 결과 화면에서 필터를 적용했을 때, 종종 충돌 (Crash)가 발생하는 이슈가 있었습니다.
- `TravelListInfo` (Item)의 `Hashable` 구현부에서 문제가 있을 수 있겠다는 판단 하에 구현부를 제거해주었고, 현재는 해당 충돌이 발생하지는 않고 있습니다!
- [노션 트러블 슈팅 정리](https://spiky-rat-16e.notion.site/DiffableDataSource-Crash-bf4e2731cf7749f08684b61cf000e5ad?pvs=4)
- 위 링크에서도 확인 가능합니당

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
자잘자잘한 버그들을 중간중간 계속 수정하다보니 커밋 수는 많은데 코드 수는 많지 않네용 ㅋㅋㅋ

## 📸 스크린샷

https://github.com/boostcampwm2023/iOS07-traveline/assets/51712973/abe218c4-1fb2-4f79-9677-da98fdea25be


## 관련 이슈
- Resolved: #261 
