### PR TITLE
[feat] Multipart 구현 및 타임라인 생성 API 연동

### DIFF
--- a/iOS/traveline/Sources/Core/Constant/Literal.swift
+++ b/iOS/traveline/Sources/Core/Constant/Literal.swift
@@ -10,6 +10,7 @@ import Foundation
 
 enum Literal {
     static let empty: String = ""
+    static let boundary: String = "Boundary-\(UUID().uuidString)"
     
     enum InfoPlistKey {
         static let baseURL: String = "BaseURL"

--- a/iOS/traveline/Sources/Core/Extension/Data+.swift
+++ b/iOS/traveline/Sources/Core/Extension/Data+.swift
@@ -1,0 +1,19 @@
+//
+//  Data+.swift
+//  traveline
+//
+//  Created by 김영인 on 2023/12/07.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+extension Data {
+    
+    /// 데이터의 크기를 MB로 반환합니다.
+    ///
+    /// - Returns: 데이터의 크기를 MB로 표현한 값.
+    func megabytes() -> Double {
+        return Double(self.count / (1024 * 1024))
+    }
+}

--- a/iOS/traveline/Sources/Core/Extension/String+.swift
+++ b/iOS/traveline/Sources/Core/Extension/String+.swift
@@ -59,4 +59,20 @@ extension String {
         self.data(using: .utf8) ?? Data()
     }
     
+    /// 문자열을 원하는 날짜 및 시간 형식으로 변환합니다.
+    /// - Parameters:
+    ///   - type: 변환할 날짜 및 시간 형식 문자열
+    /// - Returns: 변환된 날짜 및 시간 문자열. 변환에 실패하면 "00:00"을 반환합니다.
+    func convertTimeFormat(from fromFormat: String, to toFormat: String) -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.locale = Locale(identifier: "ko_KR")
+        dateFormatter.dateFormat = fromFormat
+        
+        guard let date = dateFormatter.date(from: self) else {
+            return "00:00"
+        }
+        
+        dateFormatter.dateFormat = toFormat
+        return dateFormatter.string(from: date)
+    }
 }

--- a/iOS/traveline/Sources/Core/Extension/String+.swift
+++ b/iOS/traveline/Sources/Core/Extension/String+.swift
@@ -52,4 +52,11 @@ extension String {
         return (self as NSString).range(of: commonPrefix)
     }
     
+    /// 문자열을 UTF-8 인코딩으로 변환하여 해당 인코딩된 데이터를 반환합니다.
+    ///
+    /// - Returns: UTF-8로 인코딩된 데이터
+    func toUTF8() -> Data {
+        self.data(using: .utf8) ?? Data()
+    }
+    
 }

--- a/iOS/traveline/Sources/Data/Network/API/AuthEndPoint.swift
+++ b/iOS/traveline/Sources/Data/Network/API/AuthEndPoint.swift
@@ -24,8 +24,4 @@ extension AuthEndPoint: EndPoint {
     var body: Encodable? {
         return nil
     }
-    
-    var header: [String: String] {
-        return HeaderType.json.value
-    }
 }

--- a/iOS/traveline/Sources/Data/Network/API/LoginEndPoint.swift
+++ b/iOS/traveline/Sources/Data/Network/API/LoginEndPoint.swift
@@ -30,8 +30,4 @@ extension LoginEndPoint: EndPoint {
     var body: Encodable? {
         return nil
     }
-    
-    var header: [String: String] {
-        return HeaderType.json.value
-    }
 }

--- a/iOS/traveline/Sources/Data/Network/API/PostingEndPoint.swift
+++ b/iOS/traveline/Sources/Data/Network/API/PostingEndPoint.swift
@@ -51,7 +51,7 @@ extension PostingEndPoint: EndPoint {
         }
     }
     
-    var header: [String: String] {
-        return HeaderType.authorization.value
+    var header: HeaderType {
+        return .authorization
     }
 }

--- a/iOS/traveline/Sources/Data/Network/API/TimelineDetailEndPoint.swift
+++ b/iOS/traveline/Sources/Data/Network/API/TimelineDetailEndPoint.swift
@@ -35,7 +35,7 @@ extension TimelineDetailEndPoint: EndPoint {
         }
     }
     
-    var multipartData: Any? {
+    var multipartData: MultipartData? {
         switch self {
         case .createTimeline(let timelineDetail):
             return timelineDetail

--- a/iOS/traveline/Sources/Data/Network/API/TimelineDetailEndPoint.swift
+++ b/iOS/traveline/Sources/Data/Network/API/TimelineDetailEndPoint.swift
@@ -17,7 +17,7 @@ extension TimelineDetailEndPoint: EndPoint {
     
     var path: String? {
         switch self {
-        case .specificTimeline(let id): 
+        case .specificTimeline(let id):
             return "/timelines/\(id)"
             
         case .createTimeline:
@@ -35,17 +35,23 @@ extension TimelineDetailEndPoint: EndPoint {
         }
     }
     
-    var body: Encodable? {
+    var multipartData: Any? {
         switch self {
-        case .specificTimeline:
-            return nil
-            
         case .createTimeline(let timelineDetail):
             return timelineDetail
+            
+        default:
+            return nil
         }
     }
     
-    var header: [String: String] {
-        return [:]
+    var header: HeaderType {
+        switch self {
+        case .createTimeline:
+            return .multipart
+            
+        default:
+            return .authorization
+        }
     }
 }

--- a/iOS/traveline/Sources/Data/Network/API/TimelineEndPoint.swift
+++ b/iOS/traveline/Sources/Data/Network/API/TimelineEndPoint.swift
@@ -31,7 +31,7 @@ extension TimelineEndPoint: EndPoint {
         return nil
     }
     
-    var header: [String: String] {
-        return HeaderType.authorization.value
+    var header: HeaderType {
+        return .authorization
     }
 }

--- a/iOS/traveline/Sources/Data/Network/API/UserEndPoint.swift
+++ b/iOS/traveline/Sources/Data/Network/API/UserEndPoint.swift
@@ -41,7 +41,7 @@ extension UserEndPoint: EndPoint {
         return nil
     }
     
-    var header: [String: String] {
-        return HeaderType.authorization.value
+    var header: HeaderType {
+        return .authorization
     }
 }

--- a/iOS/traveline/Sources/Data/Network/Base/EndPoint.swift
+++ b/iOS/traveline/Sources/Data/Network/Base/EndPoint.swift
@@ -12,7 +12,7 @@ protocol EndPoint {
     var path: String? { get }
     var httpMethod: HTTPMethod { get }
     var body: Encodable? { get }
-    var multipartData: Any? { get }
+    var multipartData: MultipartData? { get }
     var header: HeaderType { get }
 }
 
@@ -26,7 +26,7 @@ extension EndPoint {
         return nil
     }
     
-    var multipartData: Any? {
+    var multipartData: MultipartData? {
         return nil
     }
     

--- a/iOS/traveline/Sources/Data/Network/Base/EndPoint.swift
+++ b/iOS/traveline/Sources/Data/Network/Base/EndPoint.swift
@@ -12,12 +12,25 @@ protocol EndPoint {
     var path: String? { get }
     var httpMethod: HTTPMethod { get }
     var body: Encodable? { get }
-    var header: [String: String] { get }
+    var multipartData: Any? { get }
+    var header: HeaderType { get }
 }
 
 extension EndPoint {
     
     var baseURL: String? {
         return Bundle.main.object(forInfoDictionaryKey: Literal.InfoPlistKey.baseURL) as? String
+    }
+    
+    var body: Encodable? {
+        return nil
+    }
+    
+    var multipartData: Any? {
+        return nil
+    }
+    
+    var header: HeaderType {
+        return .json
     }
 }

--- a/iOS/traveline/Sources/Data/Network/Base/HeaderType.swift
+++ b/iOS/traveline/Sources/Data/Network/Base/HeaderType.swift
@@ -16,26 +16,21 @@ enum HeaderType {
     var value: [String: String] {
         switch self {
         case .json:
-            let header = [
+            return [
                 "Content-Type": "application/json"
             ]
             
-            return header
-            
         case .authorization:
-            let header = [
+            return [
                 "Content-Type": "application/json",
                 "Authorization": "Bearer \(KeychainList.accessToken ?? "EMPTY")"
             ]
             
-            return header
-            
         case .multipart:
-            let header = [
-                "Content-Type": "application/json"
+            return [
+                "Content-Type": "multipart/form-data; boundary=\(Literal.boundary)",
+                "Authorization": "Bearer \(KeychainList.accessToken ?? "EMPTY")"
             ]
-            
-            return header
         }
     }
 }

--- a/iOS/traveline/Sources/Data/Network/Base/MultipartData.swift
+++ b/iOS/traveline/Sources/Data/Network/Base/MultipartData.swift
@@ -1,0 +1,13 @@
+//
+//  MultipartData.swift
+//  traveline
+//
+//  Created by 김영인 on 2023/12/07.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+protocol MultipartData {
+    var image: Data? { get }
+}

--- a/iOS/traveline/Sources/Data/Network/Base/NetworkManager.swift
+++ b/iOS/traveline/Sources/Data/Network/Base/NetworkManager.swift
@@ -134,7 +134,7 @@ private extension NetworkManager {
         return urlRequest
     }
     
-    func makeBody(multipartData: Any) -> Data {
+    func makeBody(multipartData: MultipartData) -> Data {
         var body = Data()
         let imageLabel = "image"
         let boundaryPrefix = "--\(Literal.boundary)\r\n"

--- a/iOS/traveline/Sources/Data/Network/DataMapping/TimelineDetailRequestDTO.swift
+++ b/iOS/traveline/Sources/Data/Network/DataMapping/TimelineDetailRequestDTO.swift
@@ -8,11 +8,11 @@
 
 import Foundation
 
-struct TimelineDetailRequestDTO {
+struct TimelineDetailRequestDTO: MultipartData {
     let title: String
     let day: Int
     let description: String
-    let image: Data?
+    var image: Data?
     let coordX: Double?
     let coordY: Double?
     let date: String

--- a/iOS/traveline/Sources/Data/Network/DataMapping/TimelineDetailRequestDTO.swift
+++ b/iOS/traveline/Sources/Data/Network/DataMapping/TimelineDetailRequestDTO.swift
@@ -7,7 +7,8 @@
 //
 
 import Foundation
-struct TimelineDetailRequestDTO: Encodable {
+
+struct TimelineDetailRequestDTO {
     let title: String
     let day: Int
     let description: String
@@ -31,7 +32,7 @@ extension TimelineDetailRequest {
             coordY: nil,
             date: date,
             place: place,
-            time: time,
+            time: time.convertTimeFormat(from: "a hh:mm", to: "HH:mm"),
             posting: posting
         )
     }

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/VC/TimelineWritingVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/VC/TimelineWritingVC.swift
@@ -86,7 +86,7 @@ final class TimelineWritingVC: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
-    //MARK: - Life Cycle
+    // MARK: - Life Cycle
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -300,6 +300,16 @@ private extension TimelineWritingVC {
             .sink { owner, detail in
                 owner.tlNavigationBar.setupTitle(to: "Day \(detail.day)")
                 owner.dateLabel.setText(to: detail.date)
+            }
+            .store(in: &cancellables)
+        
+        viewModel.state
+            .map(\.popToTimeline)
+            .filter { $0 }
+            .removeDuplicates()
+            .withUnretained(self)
+            .sink { owner, _ in
+                owner.navigationController?.popViewController(animated: true)
             }
             .store(in: &cancellables)
     }

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/ViewModel/TimelineWritingViewModel.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/ViewModel/TimelineWritingViewModel.swift
@@ -34,6 +34,7 @@ enum TimelineWritingSideEffect: BaseSideEffect {
 struct TimelineWritingState: BaseState {
     var isCompletable: Bool = false
     var timelineDetailRequest: TimelineDetailRequest = .empty
+    var popToTimeline: Bool = false
 }
 
 final class TimelineWritingViewModel: BaseViewModel<TimelineWritingAction, TimelineWritingSideEffect, TimelineWritingState> {
@@ -88,7 +89,6 @@ final class TimelineWritingViewModel: BaseViewModel<TimelineWritingAction, Timel
         case .updateTitleState(let title):
             newState.timelineDetailRequest.title = title
             newState.isCompletable = completeButtonState(newState)
-
             
         case .updateContentState(let content):
             newState.timelineDetailRequest.content = content
@@ -105,7 +105,7 @@ final class TimelineWritingViewModel: BaseViewModel<TimelineWritingAction, Timel
             newState.timelineDetailRequest.image = imageData
             
         case .createTimeline:
-            break
+            newState.popToTimeline = true
             
         case .error:
             break
@@ -136,8 +136,8 @@ private extension TimelineWritingViewModel {
     
     func completeButtonState(_ state: State) -> Bool {
         return  !state.timelineDetailRequest.title.isEmpty &&
-                !state.timelineDetailRequest.content.isEmpty &&
-                !state.timelineDetailRequest.place.isEmpty
+        !state.timelineDetailRequest.content.isEmpty &&
+        !state.timelineDetailRequest.place.isEmpty
     }
     
 }


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- feature/#256, #267

## 📚 작업한 내용
- multipart 구현
- 타임라인 생성 API 연동
- headers 타입 변경

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

### HeaderType 적용
기존 방식이 HeaderType을 잘 사용하지 못하는 방식이라는 생각이 들어서
Endpoint 내부 headers 타입을 HeaderType으로 선언해뒀습니다.
NetworkManager의 reqeust 시점에서 .value로 접근해서 [String: String] 타입을 받아오는 구조입니다.

```Swift
var header: HeaderType {
    return .authorization
}
```
이제 이렇게 사용하실 수 있습니다 ~

### Multipart 사용
1. MultipartData 프로토콜 채택해 request 구조체 생성
2. header 타입 .multipart로 설정

TimelineDetailEndPoint 쪽 보시면 바로 이해가 되실 것 같아요 :)

### Multipart 구현
image와 여러 필드들을 넣을 수  있도록 multipart 구현했습니다.
어떻게 현재 구조를 그대로 가져가면서 편리하게 사용할 수 있을까 고민하다가 Mirror()를 사용하게 되었는데요.
Mirror를 통해 구조체 내부의 프로퍼티들을 mirror의 children들에서 label과 value의 형태로 받아올 수 있습니다.

```Swift
struct ReqeustDTO {
    let id: String
}

let reqeust: ReqeustDTO = .init(id: "0inn")
```
이렇게 request를 만들고 값을 보면
- label: id
- value: 0inn

이 되겠군요.

https://developer.apple.com/documentation/swift/mirror

이 때 문제 상황은 Optional인 필드가 존재한다는 점인데요.
타임라인 생성 API의 request 중 image, place, coordX, coordY는 Optional인 상황입니다.
하지만 mirror의 경우 value가 Any로 존재하기에 해당 변수를 통해 nil 여부를 판단할 수 없었습니다.

<img width="494" alt="image" src="https://github.com/boostcampwm2023/iOS07-traveline/assets/74968390/04e5c5dc-b964-4814-9624-d9a252db909f">


그래서 Optional의 some 값이 존재하는 경우를 비교해 해당 값의 Optional 여부를 판단합니다.

```Swift
// NetworkManager.swift

Mirror(reflecting: multipartData).children
    .filter {
        if case Optional<Any>.some = $0.value { return true }
        return false
    }
// 생략
```

### 타임라인 생성 API
현재 타임라인 하나 작성한 후 화면 전환 로직까지 연결해뒀습니다 !
아직 이미지 다운샘플링 구현을 안해서 스크린샷 정도만 . .  아마 업로드가 될 것 같습니다 ㅎㅎ
일단 처리할 서버들이 많아서 다 헤치운 후에 다운샘플링 적용해놓겠습니다 : )

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 관련 이슈
- Resolved: #256
- Resolved: #267
