### PR TITLE
[fix] 로그인 시 500 에러 해결

### DIFF
--- a/BE/src/auth/auth.service.ts
+++ b/BE/src/auth/auth.service.ts
@@ -109,7 +109,12 @@ export class AuthService {
       }
     } else {
       const allowedIpArray = user.allowedIp;
-      const bannedIpArray = user.bannedIp;
+      let bannedIpArray;
+      if (user.bannedIp === null) {
+        bannedIpArray = [];
+      } else {
+        bannedIpArray = user.bannedIp;
+      }
       if (ipAddress in bannedIpArray) {
         throw new UnauthorizedException(
           '접속하신 IP에서의 계정 접근이 차단되어있습니다.'


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- feature/#282

## 📚 작업한 내용
- 재로그인 시 500이 뜨는 에러를 해결
- bannedIp가 null인 경우 예외처리를 하지 않아 발생한 문제

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 관련 이슈
- close #282 
