### PR TITLE
[fix] 내가 작성한 게시글 목록 반환 에러 해결

### DIFF
--- a/BE/src/postings/repositories/postings.repository.ts
+++ b/BE/src/postings/repositories/postings.repository.ts
@@ -161,7 +161,7 @@ export class PostingsRepository {
       .createQueryBuilder('p')
       .leftJoinAndSelect('p.writer', 'w')
       .where('p.writer = :userId', { userId })
-      .orderBy('post.createdAt', 'DESC')
+      .orderBy('p.createdAt', 'DESC')
       .getMany();
   }
 


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- be-feature/#287-mine-fix

## 📚 작업한 내용
- 내가 작성한 게시글 반환하는 쿼리문에서 `posting.createdAt` → `p.createdAt`으로 변경
    - 언제 alias가 바뀐 거지... 다른 곳은 다 p로 잘 되어 있는데 저 부분만 posting이었다.

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 관련 이슈
- Close: #287
