### PR TITLE
[feat] 로그인 화면 분기 처리

### DIFF
--- a/iOS/traveline/Sources/App/SceneDelegate.swift
+++ b/iOS/traveline/Sources/App/SceneDelegate.swift
@@ -16,10 +16,27 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
             
         window = UIWindow(windowScene: windowScene)
-        let rootContainerVC = RootContainerVC()
-        window?.rootViewController = rootContainerVC
+        let autoLoginVC = VCFactory.makeAutoLoginVC()
+        window?.rootViewController = autoLoginVC
         window?.tintColor = TLColor.main
         window?.makeKeyAndVisible()
     }
 
+}
+
+extension SceneDelegate {
+    
+    /// 로그인 화면으로 이동, ViewController 스택 초기화
+    func changeRootViewControllerToLogin() {
+        guard let window = self.window else { return }
+        window.rootViewController = VCFactory.makeLoginVC()
+        
+        UIView.transition(
+            with: window,
+            duration: 0.2,
+            options: [.transitionCrossDissolve],
+            animations: nil
+        )
+    }
+    
 }

--- a/iOS/traveline/Sources/Core/Enum/VCFactory.swift
+++ b/iOS/traveline/Sources/Core/Enum/VCFactory.swift
@@ -12,6 +12,12 @@ enum VCFactory {
     
     static let network: NetworkType = NetworkManager(urlSession: URLSession.shared)
     
+    static func makeAutoLoginVC() -> AutoLoginVC {
+        let repository = AuthRepositoryImpl(network: network)
+        let useCase = AutoLoginUseCaseImpl(repository: repository)
+        let viewModel = AutoLoginViewModel(useCase: useCase)
+        return AutoLoginVC(viewModel: viewModel)
+    }
     static func makeTimelineVC(id: TravelID) -> TimelineVC {
         let postingRepository = PostingRepositoryMock()
         let timelineRepository = TimelineRepositoryMock()

--- a/iOS/traveline/Sources/Core/Enum/VCFactory.swift
+++ b/iOS/traveline/Sources/Core/Enum/VCFactory.swift
@@ -18,6 +18,13 @@ enum VCFactory {
         let viewModel = AutoLoginViewModel(useCase: useCase)
         return AutoLoginVC(viewModel: viewModel)
     }
+    
+    static func makeLoginVC() -> LoginVC {
+        let repository = AuthRepositoryImpl(network: network)
+        let useCase = LoginUseCaseImpl(repository: repository)
+        let viewModel = LoginViewModel(useCase: useCase)
+        return LoginVC(viewModel: viewModel)
+    }
     static func makeTimelineVC(id: TravelID) -> TimelineVC {
         let postingRepository = PostingRepositoryMock()
         let timelineRepository = TimelineRepositoryMock()

--- a/iOS/traveline/Sources/Core/Enum/VCFactory.swift
+++ b/iOS/traveline/Sources/Core/Enum/VCFactory.swift
@@ -25,6 +25,11 @@ enum VCFactory {
         let viewModel = LoginViewModel(useCase: useCase)
         return LoginVC(viewModel: viewModel)
     }
+    
+    static func makeRootContainerVC() -> RootContainerVC {
+        return RootContainerVC()
+    }
+    
     static func makeTimelineVC(id: TravelID) -> TimelineVC {
         let postingRepository = PostingRepositoryMock()
         let timelineRepository = TimelineRepositoryMock()

--- a/iOS/traveline/Sources/Data/Network/API/AuthEndPoint.swift
+++ b/iOS/traveline/Sources/Data/Network/API/AuthEndPoint.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 enum AuthEndPoint {
-    case login(LoginRequestDTO)
+    case appleLogin(AppleLoginRequestDTO)
     case withdrawal(WithdrawRequestDTO)
     case refresh
 }
@@ -19,7 +19,7 @@ extension AuthEndPoint: EndPoint {
         switch self {
         case .withdrawal:
             return "/auth/withdrawal"
-        case .login:
+        case .appleLogin:
             return "/auth/login"
         case .refresh:
             return "/auth/refresh"
@@ -30,7 +30,7 @@ extension AuthEndPoint: EndPoint {
         switch self {
         case .withdrawal:
             return .DELETE
-        case .login:
+        case .appleLogin:
             return .POST
         case .refresh:
             return .GET
@@ -41,7 +41,7 @@ extension AuthEndPoint: EndPoint {
         switch self {
         case .withdrawal(let requestDTO):
             return requestDTO
-        case .login(let idToken):
+        case .appleLogin(let idToken):
             return idToken
         case .refresh:
             return nil
@@ -52,7 +52,7 @@ extension AuthEndPoint: EndPoint {
         switch self {
         case .withdrawal:
             return .authorization
-        case .login:
+        case .appleLogin:
             return .json
         case .refresh:
             return .refresh

--- a/iOS/traveline/Sources/Data/Network/API/AuthEndPoint.swift
+++ b/iOS/traveline/Sources/Data/Network/API/AuthEndPoint.swift
@@ -11,6 +11,7 @@ import Foundation
 enum AuthEndPoint {
     case login(LoginRequestDTO)
     case withdrawal(WithdrawRequestDTO)
+    case refresh
 }
 
 extension AuthEndPoint: EndPoint {
@@ -20,6 +21,8 @@ extension AuthEndPoint: EndPoint {
             return "/auth/withdrawal"
         case .login:
             return "/auth/login"
+        case .refresh:
+            return "/auth/refresh"
         }
     }
     
@@ -29,6 +32,8 @@ extension AuthEndPoint: EndPoint {
             return .DELETE
         case .login:
             return .POST
+        case .refresh:
+            return .GET
         }
     }
     
@@ -38,6 +43,8 @@ extension AuthEndPoint: EndPoint {
             return requestDTO
         case .login(let idToken):
             return idToken
+        case .refresh:
+            return nil
         }
     }
     
@@ -47,6 +54,8 @@ extension AuthEndPoint: EndPoint {
             return .authorization
         case .login:
             return .json
+        case .refresh:
+            return .refresh
         }
     }
 

--- a/iOS/traveline/Sources/Data/Network/Base/HeaderType.swift
+++ b/iOS/traveline/Sources/Data/Network/Base/HeaderType.swift
@@ -11,6 +11,7 @@ import Foundation
 enum HeaderType {
     case json
     case authorization
+    case refresh
     case multipart
     
     var value: [String: String] {
@@ -24,6 +25,12 @@ enum HeaderType {
             return [
                 "Content-Type": "application/json",
                 "Authorization": "Bearer \(KeychainList.accessToken ?? "EMPTY")"
+            ]
+            
+        case .refresh:
+            return [
+                "Content-Type": "application/json",
+                "Authorization": "Bearer \(KeychainList.refreshToken ?? "EMPTY")"
             ]
             
         case .multipart:

--- a/iOS/traveline/Sources/Data/Network/Base/NetworkManager.swift
+++ b/iOS/traveline/Sources/Data/Network/Base/NetworkManager.swift
@@ -34,7 +34,12 @@ final class NetworkManager: NetworkType {
             throw NetworkError.httpResponseError
         }
         
-        try validateStatusCode(httpResponse.statusCode)
+        do {
+            try validateStatusCode(httpResponse.statusCode)
+        } catch {
+            let error = try JSONDecoder().decode(ErrorResponseDTO.self, from: data)
+            os_log("message: \(error.message)\nerror: \(error.error)\nstatusCode: \(error.statusCode)")
+        }
         
         os_log("statusCode: \(httpResponse.statusCode)")
         

--- a/iOS/traveline/Sources/Data/Network/DataMapping/AppleLoginRequestDTO.swift
+++ b/iOS/traveline/Sources/Data/Network/DataMapping/AppleLoginRequestDTO.swift
@@ -1,5 +1,5 @@
 //
-//  LoginRequestDTO.swift
+//  AppleLoginRequestDTO.swift
 //  traveline
 //
 //  Created by KiWoong Hong on 2023/12/07.
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct LoginRequestDTO: Encodable {
+struct AppleLoginRequestDTO: Encodable {
     
     let idToken: String
     let email: String?
@@ -16,5 +16,14 @@ struct LoginRequestDTO: Encodable {
     init(idToken: String, email: String? = nil) {
         self.idToken = idToken
         self.email = email
+    }
+}
+
+extension AppleLoginRequest {
+    func toDTO() -> AppleLoginRequestDTO {
+        return .init(
+            idToken: idToken,
+            email: email
+        )
     }
 }

--- a/iOS/traveline/Sources/Data/Network/DataMapping/ErrorResponseDTO.swift
+++ b/iOS/traveline/Sources/Data/Network/DataMapping/ErrorResponseDTO.swift
@@ -1,0 +1,15 @@
+//
+//  ErrorResponseDTO.swift
+//  traveline
+//
+//  Created by 김태현 on 12/7/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+struct ErrorResponseDTO: Decodable {
+    let message: String
+    let error: String
+    let statusCode: Int
+}

--- a/iOS/traveline/Sources/Data/Network/DataMapping/LoginResponseDTO.swift
+++ b/iOS/traveline/Sources/Data/Network/DataMapping/LoginResponseDTO.swift
@@ -12,3 +12,12 @@ struct LoginResponseDTO: Decodable {
     let accessToken: String
     let refreshToken: String
 }
+
+extension LoginResponseDTO {
+    func toDomain() -> TLToken {
+        return .init(
+            accessToken: accessToken,
+            refreshToken: refreshToken
+        )
+    }
+}

--- a/iOS/traveline/Sources/Data/Network/DataMapping/RefreshResponseDTO.swift
+++ b/iOS/traveline/Sources/Data/Network/DataMapping/RefreshResponseDTO.swift
@@ -1,0 +1,19 @@
+//
+//  RefreshResponseDTO.swift
+//  traveline
+//
+//  Created by 김태현 on 12/7/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+struct RefreshResponseDTO: Decodable {
+    let accessToken: String
+}
+
+extension RefreshResponseDTO {
+    func toDomain() -> String {
+        return accessToken
+    }
+}

--- a/iOS/traveline/Sources/Data/Network/DataMapping/WithdrawalResponseDTO.swift
+++ b/iOS/traveline/Sources/Data/Network/DataMapping/WithdrawalResponseDTO.swift
@@ -1,0 +1,13 @@
+//
+//  WithdrawalResponseDTO.swift
+//  traveline
+//
+//  Created by 김태현 on 12/7/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+struct WithdrawalResponseDTO: Decodable {
+    let revoke: Bool
+}

--- a/iOS/traveline/Sources/Data/Repository/AuthRepositoryImpl.swift
+++ b/iOS/traveline/Sources/Data/Repository/AuthRepositoryImpl.swift
@@ -17,6 +17,15 @@ final class AuthRepositoryImpl: AuthRepository {
         self.network = network
     }
     
+    func appleLogin(with info: AppleLoginRequest) async throws -> TLToken {
+        let loginResponseDTO = try await network.request(
+            endPoint: AuthEndPoint.appleLogin(info.toDTO()),
+            type: LoginResponseDTO.self
+        )
+        
+        return loginResponseDTO.toDomain()
+    }
+    
     func refresh() async throws -> String {
         let refreshResponseDTO = try await network.request(
             endPoint: AuthEndPoint.refresh,

--- a/iOS/traveline/Sources/Data/Repository/AuthRepositoryImpl.swift
+++ b/iOS/traveline/Sources/Data/Repository/AuthRepositoryImpl.swift
@@ -17,6 +17,14 @@ final class AuthRepositoryImpl: AuthRepository {
         self.network = network
     }
     
+    func refresh() async throws -> String {
+        let refreshResponseDTO = try await network.request(
+            endPoint: AuthEndPoint.refresh,
+            type: RefreshResponseDTO.self
+        )
+        
+        return refreshResponseDTO.toDomain()
+    }
     func logout() {
         KeychainList.accessToken = nil
         KeychainList.refreshToken = nil

--- a/iOS/traveline/Sources/Data/Repository/AuthRepositoryImpl.swift
+++ b/iOS/traveline/Sources/Data/Repository/AuthRepositoryImpl.swift
@@ -34,25 +34,27 @@ final class AuthRepositoryImpl: AuthRepository {
         
         return refreshResponseDTO.toDomain()
     }
+    
     func logout() {
         KeychainList.accessToken = nil
         KeychainList.refreshToken = nil
     }
     
     func withdrawal() async throws -> Bool {
-        guard let idToken = KeychainList.identityToken else { return false }
-        guard let authorizationCode = KeychainList.authorizationCode else { return false }
+        guard let idToken = KeychainList.identityToken,
+              let authorizationCode = KeychainList.authorizationCode else { return false }
         
         let withdrawRequestDTO: WithdrawRequestDTO = .init(
             idToken: idToken,
             authorizationCode: authorizationCode
         )
         
-        let result = try await network.request(endPoint: AuthEndPoint.withdrawal(withdrawRequestDTO), type: Bool.self)
+        let result = try await network.request(
+            endPoint: AuthEndPoint.withdrawal(withdrawRequestDTO),
+            type: WithdrawalResponseDTO.self
+        )
         
-        KeychainList.allClear()
-        
-        return result
+        return result.revoke
     }
     
 }

--- a/iOS/traveline/Sources/Domain/Model/Auth/AppleLoginRequest.swift
+++ b/iOS/traveline/Sources/Domain/Model/Auth/AppleLoginRequest.swift
@@ -1,0 +1,14 @@
+//
+//  AppleLoginRequest.swift
+//  traveline
+//
+//  Created by 김태현 on 12/7/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+struct AppleLoginRequest {
+    let idToken: String
+    let email: String?
+}

--- a/iOS/traveline/Sources/Domain/Model/Auth/TLToken.swift
+++ b/iOS/traveline/Sources/Domain/Model/Auth/TLToken.swift
@@ -1,0 +1,14 @@
+//
+//  TLToken.swift
+//  traveline
+//
+//  Created by 김태현 on 12/7/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+struct TLToken {
+    let accessToken: String
+    let refreshToken: String
+}

--- a/iOS/traveline/Sources/Domain/RepositoryInterface/AuthRepository.swift
+++ b/iOS/traveline/Sources/Domain/RepositoryInterface/AuthRepository.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 protocol AuthRepository {
+    func refresh() async throws -> String
     func withdrawal() async throws -> Bool
     func logout()
 }

--- a/iOS/traveline/Sources/Domain/RepositoryInterface/AuthRepository.swift
+++ b/iOS/traveline/Sources/Domain/RepositoryInterface/AuthRepository.swift
@@ -10,6 +10,7 @@ import Foundation
 
 protocol AuthRepository {
     func refresh() async throws -> String
+    func appleLogin(with info: AppleLoginRequest) async throws -> TLToken
     func withdrawal() async throws -> Bool
     func logout()
 }

--- a/iOS/traveline/Sources/Domain/UseCase/AutoLoginUseCase.swift
+++ b/iOS/traveline/Sources/Domain/UseCase/AutoLoginUseCase.swift
@@ -1,0 +1,37 @@
+//
+//  AutoLoginUseCase.swift
+//  traveline
+//
+//  Created by 김태현 on 12/7/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Combine
+import Foundation
+
+protocol AutoLoginUseCase {
+    func requestLogin() -> AnyPublisher<Bool, Error>
+}
+
+final class AutoLoginUseCaseImpl: AutoLoginUseCase {
+    
+    private let repository: AuthRepository
+    
+    init(repository: AuthRepository) {
+        self.repository = repository
+    }
+    
+    func requestLogin() -> AnyPublisher<Bool, Error> {
+        return Future { promise in
+            Task {
+                do {
+                    let accessToken = try await self.repository.refresh()
+                    KeychainList.accessToken = accessToken
+                    promise(.success(true))
+                } catch {
+                    promise(.failure(error))
+                }
+            }
+        }.eraseToAnyPublisher()
+    }
+}

--- a/iOS/traveline/Sources/Domain/UseCase/LoginUseCase.swift
+++ b/iOS/traveline/Sources/Domain/UseCase/LoginUseCase.swift
@@ -1,0 +1,38 @@
+//
+//  LoginUseCase.swift
+//  traveline
+//
+//  Created by 김태현 on 12/7/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Combine
+import Foundation
+
+protocol LoginUseCase {
+    func requestLogin(with info: AppleLoginRequest) -> AnyPublisher<Bool, Error>
+}
+
+final class LoginUseCaseImpl: LoginUseCase {
+    
+    private let repository: AuthRepository
+    
+    init(repository: AuthRepository) {
+        self.repository = repository
+    }
+    
+    func requestLogin(with info: AppleLoginRequest) -> AnyPublisher<Bool, Error> {
+        return Future { promise in
+            Task {
+                do {
+                    let tlToken = try await self.repository.appleLogin(with: info)
+                    KeychainList.accessToken = tlToken.accessToken
+                    KeychainList.refreshToken = tlToken.refreshToken
+                    promise(.success(true))
+                } catch {
+                    promise(.failure(error))
+                }
+            }
+        }.eraseToAnyPublisher()
+    }
+}

--- a/iOS/traveline/Sources/Domain/UseCase/SettingUseCase.swift
+++ b/iOS/traveline/Sources/Domain/UseCase/SettingUseCase.swift
@@ -31,6 +31,7 @@ final class SettingUseCaseImpl: SettingUseCase {
             Task {
                 do {
                     let result = try await self.repository.withdrawal()
+                    KeychainList.allClear()
                     promise(.success(result))
                 } catch {
                     promise(.failure(error))

--- a/iOS/traveline/Sources/Feature/LoginFeature/AutoLoginScene/VC/AutoLoginVC.swift
+++ b/iOS/traveline/Sources/Feature/LoginFeature/AutoLoginScene/VC/AutoLoginVC.swift
@@ -1,0 +1,101 @@
+//
+//  AutoLoginVC.swift
+//  traveline
+//
+//  Created by 김태현 on 12/7/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Combine
+import UIKit
+
+final class AutoLoginVC: UIViewController {
+    
+    private enum Metric {
+        static let topInset: CGFloat = 200 * BaseMetric.Adjust.height
+    }
+    
+    // MARK: - UI Components
+    
+    private let logoImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
+        imageView.image = TLImage.Common.logo
+        return imageView
+    }()
+    
+    // MARK: - Properties
+    
+    private let viewModel: AutoLoginViewModel
+    private var cancellabels: Set<AnyCancellable> = .init()
+    
+    // MARK: - Initializer
+    
+    init(viewModel: AutoLoginViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setupAttributes()
+        setupLayout()
+        bind()
+        viewModel.sendAction(.startAutoLogin)
+    }
+    
+}
+
+// MARK: - Setup Functions
+
+private extension AutoLoginVC {
+    func setupAttributes() {
+        view.backgroundColor = TLColor.black
+    }
+    
+    func setupLayout() {
+        view.addSubviews(logoImageView)
+        
+        view.subviews.forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+        
+        NSLayoutConstraint.activate([
+            logoImageView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: Metric.topInset),
+            logoImageView.centerXAnchor.constraint(equalTo: view.centerXAnchor)
+        ])
+    }
+    
+    func bind() {
+        viewModel.state
+            .map(\.moveToLogin)
+            .filter { $0 }
+            .removeDuplicates()
+            .withUnretained(self)
+            .sink { owner, _ in
+                let loginVC = VCFactory.makeLoginVC()
+                loginVC.modalPresentationStyle = .overFullScreen
+                owner.present(loginVC, animated: false)
+            }
+            .store(in: &cancellabels)
+        
+        viewModel.state
+            .map(\.moveToMain)
+            .filter { $0 }
+            .removeDuplicates()
+            .withUnretained(self)
+            .sink { owner, _ in
+                let rootContainerVC = VCFactory.makeRootContainerVC()
+                rootContainerVC.modalPresentationStyle = .overFullScreen
+                owner.present(rootContainerVC, animated: false)
+            }
+            .store(in: &cancellabels)
+    }
+}

--- a/iOS/traveline/Sources/Feature/LoginFeature/AutoLoginScene/ViewModel/AutoLoginViewModel.swift
+++ b/iOS/traveline/Sources/Feature/LoginFeature/AutoLoginScene/ViewModel/AutoLoginViewModel.swift
@@ -1,0 +1,89 @@
+//
+//  AutoLoginViewModel.swift
+//  traveline
+//
+//  Created by 김태현 on 12/7/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Combine
+import Foundation
+
+enum AutoLoginAction: BaseAction {
+    case startAutoLogin
+}
+
+enum AutoLoginSideEffect: BaseSideEffect {
+    case finishDelay
+    case finishLogin(Bool)
+    case loginFailed(Error)
+}
+
+struct AutoLoginState: BaseState {
+    var isFinishDelay: Bool = false
+    var isSuccessLogin: Bool = false
+    
+    var moveToLogin: Bool {
+        isFinishDelay && !isSuccessLogin
+    }
+    
+    var moveToMain: Bool {
+        isFinishDelay && isSuccessLogin
+    }
+}
+
+final class AutoLoginViewModel: BaseViewModel<AutoLoginAction, AutoLoginSideEffect, AutoLoginState> {
+    
+    private let useCase: AutoLoginUseCase
+    
+    init(useCase: AutoLoginUseCase) {
+        self.useCase = useCase
+    }
+    
+    override func transform(action: AutoLoginAction) -> BaseViewModel<AutoLoginAction, AutoLoginSideEffect, AutoLoginState>.SideEffectPublisher {
+        switch action {
+        case .startAutoLogin:
+            return Publishers.Merge(
+                startDelay(),
+                requestLogin()
+            ).eraseToAnyPublisher()
+        }
+    }
+    
+    override func reduceState(state: AutoLoginState, effect: AutoLoginSideEffect) -> AutoLoginState {
+        var newState = state
+        
+        switch effect {
+        case .finishDelay:
+            newState.isFinishDelay = true
+            
+        case let .finishLogin(isSuccess):
+            newState.isSuccessLogin = isSuccess
+            
+        case let .loginFailed(error):
+            newState.isSuccessLogin = false
+            print(error)
+        }
+        
+        return newState
+    }
+}
+
+private extension AutoLoginViewModel {
+    func startDelay() -> SideEffectPublisher {
+        return Just(AutoLoginSideEffect.finishDelay)
+            .delay(for: 1.0, scheduler: DispatchQueue.main)
+            .eraseToAnyPublisher()
+    }
+    
+    func requestLogin() -> SideEffectPublisher {
+        return useCase.requestLogin()
+            .map { isSuccess in
+                return AutoLoginSideEffect.finishLogin(isSuccess)
+            }
+            .catch { error in
+                return Just(AutoLoginSideEffect.loginFailed(error))
+            }
+            .eraseToAnyPublisher()
+    }
+}

--- a/iOS/traveline/Sources/Feature/LoginFeature/VC/LoginVC.swift
+++ b/iOS/traveline/Sources/Feature/LoginFeature/VC/LoginVC.swift
@@ -107,8 +107,10 @@ private extension LoginVC {
             .map(\.isSuccessLogin)
             .filter { $0 }
             .withUnretained(self)
-            .sink { _, _ in
-                // TODO: 로그인 성공 후 로직 구현
+            .sink { owner, _ in
+                let rootContainerVC = VCFactory.makeRootContainerVC()
+                rootContainerVC.modalPresentationStyle = .overFullScreen
+                owner.present(rootContainerVC, animated: false)
             }
             .store(in: &cancellabels)
     }
@@ -129,7 +131,6 @@ extension LoginVC: ASAuthorizationControllerDelegate {
 
 @available(iOS 17, *)
 #Preview("LoginVC") {
-    let vm = LoginViewModel()
-    let view = LoginVC(viewModel: vm)
+    let view = VCFactory.makeLoginVC()
     return view
 }

--- a/iOS/traveline/Sources/Feature/MyPageFeature/SettingScene/VC/SettingVC.swift
+++ b/iOS/traveline/Sources/Feature/MyPageFeature/SettingScene/VC/SettingVC.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2023 traveline. All rights reserved.
 //
 
+import Combine
 import SafariServices
 import UIKit
 
@@ -84,6 +85,7 @@ final class SettingVC: UIViewController {
     // MARK: - Properties
     
     private let viewModel: SettingViewModel
+    private var cancellabels: Set<AnyCancellable> = .init()
     
     // MARK: - Initialize
     
@@ -103,6 +105,7 @@ final class SettingVC: UIViewController {
         
         setupAttributes()
         setupLayout()
+        bind()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -215,5 +218,17 @@ extension SettingVC {
         ])
     }
     
+    func bind() {
+        viewModel.state
+            .map(\.moveToLogin)
+            .filter { $0 }
+            .removeDuplicates()
+            .sink { _ in
+                guard let firstScene = UIApplication.shared.connectedScenes.first,
+                      let sceneDelegate = firstScene.delegate as? SceneDelegate else { return }
+                
+                sceneDelegate.changeRootViewControllerToLogin()
+            }
+            .store(in: &cancellabels)
+    }
 }
-

--- a/iOS/traveline/Sources/Feature/MyPageFeature/SettingScene/ViewModel/SettingViewModel.swift
+++ b/iOS/traveline/Sources/Feature/MyPageFeature/SettingScene/ViewModel/SettingViewModel.swift
@@ -1,5 +1,5 @@
 //
-//  SettingVeiwModel.swift
+//  SettingViewModel.swift
 //  traveline
 //
 //  Created by KiWoong Hong on 2023/12/05.
@@ -16,12 +16,12 @@ enum SettingAction: BaseAction {
 
 enum SettingSideEffect: BaseSideEffect {
     case logout
-    case requestWithdraw
+    case requestWithdraw(Bool)
     case error(String)
 }
 
 struct SettingState: BaseState {
-    
+    var moveToLogin: Bool = false
 }
 
 final class SettingViewModel: BaseViewModel<SettingAction, SettingSideEffect, SettingState> {
@@ -47,10 +47,10 @@ final class SettingViewModel: BaseViewModel<SettingAction, SettingSideEffect, Se
         
         switch effect {
         case .logout:
-            break
+            newState.moveToLogin = true
             
-        case .requestWithdraw:
-            break
+        case let .requestWithdraw(isSuccess):
+            newState.moveToLogin = isSuccess
             
         case .error:
             break
@@ -68,10 +68,9 @@ extension SettingViewModel {
     }
     
     private func requestWithdraw() -> SideEffectPublisher {
-        // TODO: - 회원탈퇴 요청 로직
         return useCase.requestWithdrawal()
-            .map { _ in
-                return .requestWithdraw
+            .map { isSuccess in
+                return .requestWithdraw(isSuccess)
             }
             .catch { _ in
                 return Just(.error("failed request withdrawal"))


### PR DESCRIPTION
## 🌎 PR 요약
- 로그인, 로그아웃, 회원탈퇴 시 화면 분기 처리

🌱 작업한 브랜치
- feature/#286

## 📚 작업한 내용
### 1. AutoLoginVC
- AutoLoginVC를 만들어서 첫 화면으로 사용하고 있습니다.
- AutoLoginVC -> refresh 시도 -> 로그인 화면 or 메인 화면 이동

### 2. 화면 분기
- 로그아웃, 회원탈퇴 시 SceneDelegate에서 rootViewController를 loginVC로 변경해줍니다.
- AutoLoginVC -> refresh 실패 -> 로그인 -> 로그아웃 -> loginVC
- AutoLoginVC -> refresh 성공 -> 메인 -> 탈퇴 -> loginVC

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
AutoLoginVC 구현하고 LoginVC 서버 연결 파일 옮겼더니 코드양이 좀 많네용 ,,

PR을 급하게 작성하다보니,, 영상을 참고해주세용
아무래도 이곳저곳에 로딩뷰가 필요해보입니다,,

## 📸 스크린샷

https://github.com/boostcampwm2023/iOS07-traveline/assets/51712973/9a3f63b7-3741-43ce-93b0-28e76c33f213


## 관련 이슈
- Resolved: #286 
