### PR TITLE
[fix] 검색 시 각 태그 필터링이 OR로 연결되는 문제 해결

### DIFF
--- a/BE/src/postings/repositories/postings.repository.ts
+++ b/BE/src/postings/repositories/postings.repository.ts
@@ -49,10 +49,94 @@ export class PostingsRepository {
     themes: Theme[],
     withWhos: WithWho[]
   ) {
+    const conditions = ['p.title LIKE :keyword'];
+    let params: { [key: string]: string } = { keyword: `%${keyword}%` };
+
+    if (budget) {
+      conditions.push('p.budget = :budget');
+      params = { ...params, budget };
+    }
+
+    if (headcount) {
+      conditions.push('p.headcount = :headcount');
+      params = { ...params, headcount };
+    }
+
+    if (period) {
+      conditions.push('p.period = :period');
+      params = { ...params, period };
+    }
+
+    if (vehicle) {
+      conditions.push('p.vehicle = :vehicle');
+      params = { ...params, vehicle };
+    }
+
+    if (locations) {
+      const sql = locations
+        .map((location, index) => `p.location = :location${index}`)
+        .join(' OR ');
+      const tagParams = locations.reduce(
+        (params, location, index) => ({
+          ...params,
+          [`location${index}`]: location,
+        }),
+        {}
+      );
+      conditions.push(`(${sql})`);
+      params = { ...params, ...tagParams };
+    }
+
+    if (seasons) {
+      const sql = seasons
+        .map((season, index) => `p.season = :season${index}`)
+        .join(' OR ');
+      const tagParams = seasons.reduce(
+        (params, season, index) => ({
+          ...params,
+          [`season${index}`]: season,
+        }),
+        {}
+      );
+      conditions.push(`(${sql})`);
+      params = { ...params, ...tagParams };
+    }
+
+    if (themes) {
+      const sql = themes
+        .map((theme, index) => `JSON_CONTAINS(p.theme, :theme${index})`)
+        .join(' OR ');
+      const tagParams = themes.reduce(
+        (params, theme, index) => ({
+          ...params,
+          [`theme${index}`]: JSON.stringify(theme),
+        }),
+        {}
+      );
+      conditions.push(`(${sql})`);
+      params = { ...params, ...tagParams };
+    }
+
+    if (withWhos) {
+      const sql = withWhos
+        .map((withWho, index) => `JSON_CONTAINS(p.withWho, :withWho${index})`)
+        .join(' OR ');
+      const tagParams = withWhos.reduce(
+        (params, withWho, index) => ({
+          ...params,
+          [`withWho${index}`]: JSON.stringify(withWho),
+        }),
+        {}
+      );
+      conditions.push(`(${sql})`);
+      params = { ...params, ...tagParams };
+    }
+
+    const sql = conditions.join(' AND ');
     const qb = this.postingsRepository
       .createQueryBuilder('p')
       .leftJoinAndSelect('p.writer', 'u')
-      .where('p.title LIKE :keyword', { keyword: `%${keyword}%` })
+      .where(sql, params)
       .leftJoin('p.likeds', 'l', 'l.isDeleted = :isDeleted', {
         isDeleted: false,
       })
@@ -61,79 +145,7 @@ export class PostingsRepository {
       .having('COUNT(r.posting) <= :BLOCKING_LIMIT', { BLOCKING_LIMIT })
       .groupBy('p.id');
 
-    if (budget) {
-      qb.where('p.budget = :budget', { budget });
-    }
-
-    if (headcount) {
-      qb.andWhere('p.headcount = :headcount', { headcount });
-    }
-
-    if (locations) {
-      const orCondtions = locations
-        .map((location, index) => `p.location = :location${index}`)
-        .join(' OR ');
-      const params = locations.reduce(
-        (params, location, index) => ({
-          ...params,
-          [`location${index}`]: location,
-        }),
-        {}
-      );
-      qb.andWhere(orCondtions, params);
-    }
-
-    if (period) {
-      qb.andWhere('p.period = :period', { period });
-    }
-
-    if (seasons) {
-      const orCondtions = seasons
-        .map((season, index) => `p.season = :season${index}`)
-        .join(' OR ');
-      const params = seasons.reduce(
-        (params, season, index) => ({
-          ...params,
-          [`season${index}`]: season,
-        }),
-        {}
-      );
-      qb.andWhere(orCondtions, params);
-    }
-
-    if (vehicle) {
-      qb.andWhere('p.vehicle = :vehicle', { vehicle });
-    }
-
-    if (themes) {
-      const orCondtions = themes
-        .map((theme, index) => `JSON_CONTAINS(p.theme, :theme${index})`)
-        .join(' OR ');
-      const params = themes.reduce(
-        (params, theme, index) => ({
-          ...params,
-          [`theme${index}`]: JSON.stringify(theme),
-        }),
-        {}
-      );
-      qb.andWhere(orCondtions, params);
-    }
-
-    if (withWhos) {
-      const orCondtions = withWhos
-        .map((withWho, index) => `JSON_CONTAINS(p.with_who, :withWho${index})`)
-        .join(' OR ');
-      const params = withWhos.reduce(
-        (params, withWho, index) => ({
-          ...params,
-          [`withWho${index}`]: JSON.stringify(withWho),
-        }),
-        {}
-      );
-      qb.andWhere(orCondtions, params);
-    }
-
-    if (sorting === Sorting.좋아요순) {
+    if (sorting == Sorting.좋아요순) {
       qb.orderBy('likeds', 'DESC');
     } else {
       qb.orderBy('p.createdAt', 'DESC');


### PR DESCRIPTION
addWhere()로 조건을 추가했었는데, 현재는 아예 쿼리문처럼 문자열로 where문을 하나로 처리했다.

## 🌎 PR 요약

🌱 작업한 브랜치
- be-feature/#310-search-filter

## 📚 작업한 내용
- 기존엔 쿼리 조건문을 `andWhere()`로 처리했는데, 이게 왜인지 OR로 동작을 하여서...
    - ~~그럼 orWhere()랑 andWhere()는 뭔 차이임...~~
- 아예 `where()` 메서드 하나에 모든 조건을 담도록... 수정
    - `p.title LIKE :keyword AND (p.location = :location0 OR p.location = :location1) AND (JSON_CONTAINS(p.theme, :theme0))` 이런 식으로 하나의 조건으로 묶어버리기!

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 관련 이슈
- Close: #310
