### PR TITLE
[feat] 홈 화면 새로고침 구현

### DIFF
--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/VC/HomeVC.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/VC/HomeVC.swift
@@ -208,7 +208,7 @@ private extension HomeVC {
             .map(\.homeFilters)
             .removeDuplicates()
             .withUnretained(self)
-            .sink { owner, filters in
+            .sink { owner, _ in
                 owner.viewModel.sendAction(.filterChanged)
             }
             .store(in: &cancellables)
@@ -229,7 +229,7 @@ private extension HomeVC {
             .dropFirst()
             .removeDuplicates()
             .withUnretained(self)
-            .sink { owner, filters in
+            .sink { owner, _ in
                 owner.viewModel.sendAction(.filterChanged)
             }
             .store(in: &cancellables)

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/VC/HomeVC.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/VC/HomeVC.swift
@@ -199,6 +199,7 @@ private extension HomeVC {
             .sink { owner, filters in
                 owner.homeListView.setupData(list: .sortFilters(filters))
                 owner.createTravelButton.isHidden = false
+                owner.homeListView.isRefreshEnabled = true
             }
             .store(in: &cancellables)
         
@@ -218,6 +219,7 @@ private extension HomeVC {
             .withUnretained(self)
             .sink { owner, filters in
                 owner.homeListView.setupData(list: .sortFilters(filters))
+                owner.homeListView.isRefreshEnabled = false
             }
             .store(in: &cancellables)
         
@@ -266,6 +268,13 @@ private extension HomeVC {
             .withUnretained(self)
             .sink { owner, _ in
                 owner.viewModel.sendAction(.didScrollToEnd)
+            }
+            .store(in: &cancellables)
+        
+        homeListView.didRefreshHomeList
+            .withUnretained(self)
+            .sink { owner, _ in
+                owner.viewModel.sendAction(.refresh)
             }
             .store(in: &cancellables)
     }

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/View/HomeListView.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/View/HomeListView.swift
@@ -53,6 +53,19 @@ final class HomeListView: UIView {
         return collectionView
     }()
     
+    private lazy var refreshControl: UIRefreshControl = {
+        let refresh = UIRefreshControl()
+        
+        refresh.tintColor = TLColor.main
+        refresh.addTarget(
+            self,
+            action: #selector(refreshList),
+            for: .valueChanged
+        )
+        
+        return refresh
+    }()
+    
     // MARK: - Properties
     
     private typealias DataSource = UICollectionViewDiffableDataSource<HomeSection, HomeItem>
@@ -63,9 +76,16 @@ final class HomeListView: UIView {
     let didSelectHomeList: PassthroughSubject<Void, Never> = .init()
     let didSelectFilterType: PassthroughSubject<FilterType, Never> = .init()
     let didScrollToBottom: PassthroughSubject<Void, Never> = .init()
+    let didRefreshHomeList: PassthroughSubject<Void, Never> = .init()
     
     private var isPaging: Bool = true
     private var cancellables: Set<AnyCancellable> = .init()
+    
+    var isRefreshEnabled: Bool = true {
+        didSet {
+            homeCollectionView.refreshControl = isRefreshEnabled ? refreshControl : nil
+        }
+    }
     
     // MARK: - Initializer
     
@@ -198,6 +218,14 @@ final class HomeListView: UIView {
         
         dataSource.apply(snapshot, animatingDifferences: false)
         isPaging = false
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+            self?.refreshControl.endRefreshing()
+        }
+    }
+    
+    @objc private func refreshList() {
+        didRefreshHomeList.send(Void())
     }
 }
 

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeAction.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeAction.swift
@@ -21,4 +21,5 @@ enum HomeAction: BaseAction {
     case createTravel
     case deleteKeyword(String)
     case didScrollToEnd
+    case refresh
 }

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeViewModel.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeViewModel.swift
@@ -57,6 +57,9 @@ final class HomeViewModel: BaseViewModel<HomeAction, HomeSideEffect, HomeState> 
             
         case .didScrollToEnd:
             return fetchNextPage()
+            
+        case .refresh:
+            return fetchNewSearchList()
         }
     }
     


### PR DESCRIPTION
## 🌎 PR 요약
- 홈 화면에서 끌어내려 새로고침을 구현했습니닷

🌱 작업한 브랜치
- feature/#314

## 📚 작업한 내용
### HomeListView -> RefreshControl 추가
- RefreshControl을 통해 끌어내렸을 때 새로고침 되도록 구현했습니다~!
- 서버 응답 왔을 때 바로 refreshControl 꺼주니까 너무 또 금방 (거의 깜빡) 거리면서 끝나서, 0.5초 딜레이를 일단 넣어놔봤어용

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
refreshControl 색상을 main 컬러로 지정해봤는데 괜찮은가요?? 그냥 default가 더 나은가 싶기도 하고,, 의견 주시면 감사드림다 🫡

|main|default|
|:--:|:--:|
|![IMG_9921](https://github.com/boostcampwm2023/iOS07-traveline/assets/51712973/2df39af1-fc6a-460a-a132-427b30ec2e71)|![IMG_9922](https://github.com/boostcampwm2023/iOS07-traveline/assets/51712973/dc0cc28a-ac51-47b7-ba69-38cff3e4a801)|


## 📸 스크린샷


https://github.com/boostcampwm2023/iOS07-traveline/assets/51712973/94a18630-2b88-4d5d-8d3b-4286555df619


## 관련 이슈
- Resolved: #314 
