### PR TITLE
[fix] 검색 리스트 셀 재사용 문제 해결

### DIFF
--- a/iOS/traveline/Sources/DesignSystem/Component/TLTag/TLTag.swift
+++ b/iOS/traveline/Sources/DesignSystem/Component/TLTag/TLTag.swift
@@ -134,6 +134,7 @@ final class TLTag: UIButton {
     
     func updateTag(text: String) {
         tagTitleLabel.setText(to: text)
+        invalidateIntrinsicContentSize()
     }
 }
 

--- a/iOS/traveline/Sources/DesignSystem/View/TLList/TLInfoView.swift
+++ b/iOS/traveline/Sources/DesignSystem/View/TLList/TLInfoView.swift
@@ -124,6 +124,9 @@ final class TLInfoView: UIView {
         thumbnailImageView.image = TravelineAsset.Images.travelImage.image
         profileImageView.cancel()
         profileImageView.image = nil
+        tags.forEach {
+            $0.updateTag(text: Literal.empty)
+        }
     }
 }
 


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- feature/#323

## 📚 작업한 내용
### 리스트 셀 재사용 문제 해결
- 리스트 셀 재사용 시에 이미지만 초기화해주고 있었는데, Tag들의 제목 또한 초기화해주었습니다.!
- 그리고 `TLTag`에서 제목을 변경했을 때 `intrinsicContentSize`를 다시 계산하게 해서 해결할 수 있었습니다 :)

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
N/A

## 📸 스크린샷
|변경 전|변경 후|
|:--:|:--:|
|<img src="https://github.com/boostcampwm2023/iOS07-traveline/assets/51712973/b4d38c81-5e98-4792-9ff7-ce99b60b50d6" width="400">|<img src="https://github.com/boostcampwm2023/iOS07-traveline/assets/51712973/7839b9c5-fc5e-4280-90e0-1a26a1bcf7cb" width="400">|

## 관련 이슈
- Resolved: #323 
