### PR TITLE
[fix, feat] 1차 QA 버그 수정 및 타임라인 서버 연결

### DIFF
--- a/iOS/traveline/Sources/Core/Enum/VCFactory.swift
+++ b/iOS/traveline/Sources/Core/Enum/VCFactory.swift
@@ -31,10 +31,10 @@ enum VCFactory {
     }
     
     static func makeTimelineVC(id: TravelID) -> TimelineVC {
-        let postingRepository = PostingRepositoryMock()
-        let timelineRepository = TimelineRepositoryMock()
-//        let postingRepository = PostingRepositoryImpl(network: network)
-//        let timelineRepository = TimelineRepositoryImpl(network: network)
+//        let postingRepository = PostingRepositoryMock()
+//        let timelineRepository = TimelineRepositoryMock()
+        let postingRepository = PostingRepositoryImpl(network: network)
+        let timelineRepository = TimelineRepositoryImpl(network: network)
         let useCase = TimelineUseCaseImpl(
             postingRepository: postingRepository,
             timelineRepository: timelineRepository
@@ -47,7 +47,6 @@ enum VCFactory {
     }
     
     static func makeHomeVC() -> HomeVC {
-        // TODO: - 서버 연결 후 Repository 변경
 //        let repository = PostingRepositoryMock()
         let repository = PostingRepositoryImpl(network: network)
         let useCase = HomeUseCaseImpl(repository: repository)
@@ -80,21 +79,26 @@ enum VCFactory {
         return TravelVC(viewModel: viewModel)
     }
     
-    static func makeTimelineWritingVC() -> TimelineWritingVC {
-        let repository = TimelineDetailRepositoryMock()
+    static func makeTimelineWritingVC(
+        id: TravelID,
+        date: String,
+        day: Int
+    ) -> TimelineWritingVC {
+//        let repository = TimelineDetailRepositoryMock()
+        let repository = TimelineDetailRepositoryImpl(network: network)
         let useCase = TimelineWritingUseCaseImpl(repository: repository)
         let viewModel = TimelineWritingViewModel(
             useCase: useCase,
-            postId: "1234",
-            date: "2022년 3월 5일",
-            day: 1
+            id: id,
+            date: date,
+            day: day
         )
         return TimelineWritingVC(viewModel: viewModel)
     }
     
     static func makeSideMenuVC() -> SideMenuVC {
         let repository = UserRepositoryImpl(network: network)
-        //let repository = UserRepositoryMock()
+//        let repository = UserRepositoryMock()
         let useCase = SideMenuUseCaseImpl(repository: repository)
         let viewModel = SideMenuViewModel(useCase: useCase)
         return SideMenuVC(viewModel: viewModel)

--- a/iOS/traveline/Sources/Core/Extension/Date+.swift
+++ b/iOS/traveline/Sources/Core/Extension/Date+.swift
@@ -11,10 +11,11 @@ import Foundation
 extension Date {
     
     /// Date 타입을 "yyyy-MM-dd" 형식으로 변환합니다.
+    /// 
     /// - Returns: 변환된 문자열
-    func toString() -> String {
+    func toString(with format: String = "yyyy-MM-dd") -> String {
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd"
+        dateFormatter.dateFormat = format
         
         return dateFormatter.string(from: self)
     }

--- a/iOS/traveline/Sources/Core/Extension/String+.swift
+++ b/iOS/traveline/Sources/Core/Extension/String+.swift
@@ -63,4 +63,21 @@ extension String {
         dateFormatter.dateFormat = toFormat
         return dateFormatter.string(from: date)
     }
+    
+    /// 문자열을 "yyyy-MM-dd" 형식의 날짜로 변환합니다.
+    ///
+    /// - Returns: 변환된 날짜. 변환에 실패하면 nil을 반환합니다.
+    func toDate() -> Date? {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        
+        return dateFormatter.date(from: self)
+    }
+    
+    /// 문자열을 Double로 변환합니다.
+    ///
+    /// - Returns: 변환된 Double 값. 변환에 실패하면 0을 반환합니다.
+    func toDouble() -> Double {
+        return Double(self) ?? 0.0
+    }
 }

--- a/iOS/traveline/Sources/Core/Extension/UIImageView+.swift
+++ b/iOS/traveline/Sources/Core/Extension/UIImageView+.swift
@@ -24,7 +24,7 @@ extension UIImageView {
         Task {
             guard let downloadImageData = await TLImageDownloader.shared.download(key: self, urlString: urlString) else { return }
             TLImageCache.shared.store(downloadImageData, urlString: urlString)
-            image = UIImage(data: downloadImageData) 
+            image = UIImage(data: downloadImageData)
         }
     }
     

--- a/iOS/traveline/Sources/Core/Extension/UILabel+.swift
+++ b/iOS/traveline/Sources/Core/Extension/UILabel+.swift
@@ -1,0 +1,23 @@
+//
+//  UILabel+.swift
+//  traveline
+//
+//  Created by 김영인 on 2023/12/07.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import UIKit
+
+extension UILabel {
+    func setColor(to color: UIColor, range: NSRange) {
+        guard let mutableAttributedText = attributedText?.mutableCopy() as? NSMutableAttributedString else { return }
+        
+        mutableAttributedText.addAttribute(
+            .foregroundColor,
+            value: TLColor.main,
+            range: range
+        )
+        
+        attributedText = mutableAttributedText
+    }
+}

--- a/iOS/traveline/Sources/Core/Util/TagManager.swift
+++ b/iOS/traveline/Sources/Core/Util/TagManager.swift
@@ -21,7 +21,7 @@ extension TagManager {
         tags.filter { $0.type == type }.first?.title
     }
     
-    func toDTO(type: TagType) -> [String] {
+    func toDTO(type: TagType) -> [String]? {
         tags.filter { $0.type == type }.map(\.title)
     }
 }

--- a/iOS/traveline/Sources/Data/Network/API/TimelineDetailEndPoint.swift
+++ b/iOS/traveline/Sources/Data/Network/API/TimelineDetailEndPoint.swift
@@ -11,23 +11,29 @@ import Foundation
 enum TimelineDetailEndPoint {
     case specificTimeline(String)
     case createTimeline(TimelineDetailRequestDTO)
+    case fetchPlaceList(String)
 }
 
 extension TimelineDetailEndPoint: EndPoint {
     
     var path: String? {
+        let curPath = "/timelines"
+        
         switch self {
         case .specificTimeline(let id):
-            return "/timelines/\(id)"
+            return "\(curPath)/\(id)"
             
-        case .createTimeline:
-            return "/timelines"
+        case let .fetchPlaceList(keyword):
+            return "\(curPath)/map?place=\(keyword)"
+            
+        default:
+            return curPath
         }
     }
     
     var httpMethod: HTTPMethod {
         switch self {
-        case .specificTimeline:
+        case .specificTimeline, .fetchPlaceList:
             return .GET
             
         case .createTimeline:

--- a/iOS/traveline/Sources/Data/Network/API/TimelineEndPoint.swift
+++ b/iOS/traveline/Sources/Data/Network/API/TimelineEndPoint.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 enum TimelineEndPoint {
-    case fetchTimelines(FetchTimelineRequestDTO) /// 게시글의 Day N에 해당하는 모든 타임라인 반환
+    case fetchTimelines(FetchTimelineRequestDTO)
 }
 
 extension TimelineEndPoint: EndPoint {

--- a/iOS/traveline/Sources/Data/Network/DataMapping/BaseResponseDTO.swift
+++ b/iOS/traveline/Sources/Data/Network/DataMapping/BaseResponseDTO.swift
@@ -1,5 +1,5 @@
 //
-//  PostPostingsDTO.swift
+//  BaseResponseDTO.swift
 //  traveline
 //
 //  Created by 김영인 on 2023/12/03.
@@ -8,6 +8,6 @@
 
 import Foundation
 
-struct PostPostingsResponseDTO: Decodable {
+struct BaseResponseDTO: Decodable {
     let id: String
 }

--- a/iOS/traveline/Sources/Data/Network/DataMapping/TimelineDetailRequestDTO.swift
+++ b/iOS/traveline/Sources/Data/Network/DataMapping/TimelineDetailRequestDTO.swift
@@ -16,7 +16,7 @@ struct TimelineDetailRequestDTO: MultipartData {
     let coordX: Double?
     let coordY: Double?
     let date: String
-    let place: String
+    let place: String?
     let time: String
     let posting: String
 }
@@ -28,10 +28,10 @@ extension TimelineDetailRequest {
             day: day,
             description: content,
             image: image,
-            coordX: nil,
-            coordY: nil,
+            coordX: place?.latitude,
+            coordY: place?.longitude,
             date: date,
-            place: place,
+            place: place?.title,
             time: time.convertTimeFormat(from: "a hh:mm", to: "HH:mm"),
             posting: posting
         )

--- a/iOS/traveline/Sources/Data/Network/DataMapping/TimelinePlaceResponseDTO.swift
+++ b/iOS/traveline/Sources/Data/Network/DataMapping/TimelinePlaceResponseDTO.swift
@@ -1,0 +1,34 @@
+//
+//  TimelinePlaceResponseDTO.swift
+//  traveline
+//
+//  Created by 김영인 on 2023/12/07.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+typealias TimelinePlaceListResponseDTO = [TimelinePlaceResponseDTO]
+
+struct TimelinePlaceResponseDTO: Decodable {
+    let place: String
+    let x: String
+    let y: String
+    
+    enum CodingKeys: String, CodingKey {
+        case place = "place_name"
+        case x, y
+    }
+}
+
+extension TimelinePlaceListResponseDTO {
+    func toDomain() -> TimelinePlaceList {
+        self.map { dto in
+                .init(
+                    title: dto.place,
+                    latitude: dto.x.toDouble(),
+                    longitude: dto.y.toDouble()
+                )
+        }
+    }
+}

--- a/iOS/traveline/Sources/Data/Network/DataMapping/TimelineResponseDTO.swift
+++ b/iOS/traveline/Sources/Data/Network/DataMapping/TimelineResponseDTO.swift
@@ -35,8 +35,8 @@ extension TimelineListResponseDTO {
                     place: dto.place,
                     content: dto.description,
                     time: dto.time,
-                    latitude: dto.coordX ?? 0,
-                    longitude: dto.coordY ?? 0
+                    latitude: dto.coordY,
+                    longitude: dto.coordX
                 )
         }
     }

--- a/iOS/traveline/Sources/Data/Network/DataMapping/TravelRequestDTO.swift
+++ b/iOS/traveline/Sources/Data/Network/DataMapping/TravelRequestDTO.swift
@@ -18,13 +18,20 @@ extension TravelRequest {
     func toDTO() -> TravelRequestDTO {
         let tagManager = TagManager.init(tags: tags)
         
+        var costTag: String?
+        if var cost: String = tagManager.toDTO(type: .cost) {
+            costTag = cost == Literal.Tag.CostDetail.over100 ?
+            Literal.Query.CostDetail.over100 :
+            cost + Literal.Tag.CostDetail.won
+        }
+        
         return .init(
             title: title,
             location: region,
             startDate: startDate.toString(),
             endDate: endDate.toString(),
             headcount: tagManager.toDTO(type: .people),
-            budget: (tagManager.toDTO(type: .cost) ?? "0") + Literal.Tag.CostDetail.won,
+            budget: costTag,
             vehicle: tagManager.toDTO(type: .transportation),
             theme: tagManager.toDTO(type: .theme),
             withWho: tagManager.toDTO(type: .with)

--- a/iOS/traveline/Sources/Data/Network/DataMapping/UserRequestDTO.swift
+++ b/iOS/traveline/Sources/Data/Network/DataMapping/UserRequestDTO.swift
@@ -11,5 +11,4 @@ import Foundation
 struct UserRequestDTO: MultipartData {
     let name: String
     var image: Data?
-    
 }

--- a/iOS/traveline/Sources/Data/Repository/Mock/TimelineDetailRepositoryMock.swift
+++ b/iOS/traveline/Sources/Data/Repository/Mock/TimelineDetailRepositoryMock.swift
@@ -9,11 +9,9 @@
 import Foundation
 
 final class TimelineDetailRepositoryMock: TimelineDetailRepository {
-    func createTimelineDetail(with timelineRequest: TimelineDetailRequest) async throws -> TimelineDetailInfo {
+    
+    func createTimelineDetail(with timelineRequest: TimelineDetailRequest) async throws {
         try await Task.sleep(nanoseconds: 1_000_000_000)
-        
-        let mockData = TimelineDetailInfo.sample
-        return mockData
     }
     
     func fetchTimelineDetailInfo(id: String) async throws -> TimelineDetailInfo {
@@ -23,4 +21,10 @@ final class TimelineDetailRepositoryMock: TimelineDetailRepository {
         return mockData
     }
     
+    func fetchTimelinePlaces(keyword: String) async throws -> TimelinePlaceList {
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+        
+        let mockData = [TimelinePlace.init(title: "", latitude: 0, longitude: 0)]
+        return mockData
+    }
 }

--- a/iOS/traveline/Sources/Data/Repository/PostingRepositoryImpl.swift
+++ b/iOS/traveline/Sources/Data/Repository/PostingRepositoryImpl.swift
@@ -75,7 +75,7 @@ extension PostingRepositoryImpl {
     func postPostings(data: TravelRequest) async throws -> TravelID {
         let postPostingsDTO = try await network.request(
             endPoint: PostingEndPoint.createPosting(data.toDTO()),
-            type: PostPostingsResponseDTO.self
+            type: BaseResponseDTO.self
         )
         
         return TravelID(value: postPostingsDTO.id)

--- a/iOS/traveline/Sources/Data/Repository/TimelineDetailRepositoryImpl.swift
+++ b/iOS/traveline/Sources/Data/Repository/TimelineDetailRepositoryImpl.swift
@@ -17,7 +17,6 @@ final class TimelineDetailRepositoryImpl: TimelineDetailRepository {
     }
     
     func fetchTimelineDetailInfo(id: String) async throws -> TimelineDetailInfo {
-        
         let timelineDetailResponseDTO = try await network.request(
             endPoint: TimelineDetailEndPoint.specificTimeline(id),
             type: TimelineDetailResponseDTO.self
@@ -26,14 +25,20 @@ final class TimelineDetailRepositoryImpl: TimelineDetailRepository {
         return timelineDetailResponseDTO.toDomain()
     }
     
-    func createTimelineDetail(with info: TimelineDetailRequest) async throws -> TimelineDetailInfo {
-        
-        let timelineDetailResponseDTO = try await network.request(
+    func createTimelineDetail(with info: TimelineDetailRequest) async throws {
+        try await network.request(
             endPoint: TimelineDetailEndPoint.createTimeline(info.toDTO()),
-            type: TimelineDetailResponseDTO.self
+            type: BaseResponseDTO.self
+        )
+    }
+    
+    func fetchTimelinePlaces(keyword: String) async throws -> TimelinePlaceList {
+        let timelinePlaceResponseDTO = try await network.request(
+            endPoint: TimelineDetailEndPoint.fetchPlaceList(keyword),
+            type: TimelinePlaceListResponseDTO.self
         )
         
-        return timelineDetailResponseDTO.toDomain()
+        return timelinePlaceResponseDTO.toDomain()
     }
     
 }

--- a/iOS/traveline/Sources/Data/Repository/UserRepositoryImpl.swift
+++ b/iOS/traveline/Sources/Data/Repository/UserRepositoryImpl.swift
@@ -18,7 +18,6 @@ final class UserRepositoryImpl: UserRepository {
     
     func fetchUserInfo() async throws -> Profile {
         if let userResponseDTO = UserDefaultsList.userResponseDTO {
-            print(userResponseDTO)
             return userResponseDTO.toDomain()
         }
         
@@ -40,7 +39,6 @@ final class UserRepositoryImpl: UserRepository {
             type: UserResponseDTO.self
         )
         
-        print(userResponseDTO)
         UserDefaultsList.userResponseDTO = userResponseDTO
         
         return userResponseDTO.toDomain()

--- a/iOS/traveline/Sources/DesignSystem/Component/TLLabel.swift
+++ b/iOS/traveline/Sources/DesignSystem/Component/TLLabel.swift
@@ -84,19 +84,7 @@ final class TLLabel: UILabel {
         travelineColor = color
         setupAttributes()
     }
-    
-    func setColor(to color: UIColor, range: NSRange) {
-        guard let mutableAttributedText = attributedText?.mutableCopy() as? NSMutableAttributedString else { return }
-        
-        mutableAttributedText.addAttribute(
-            .foregroundColor,
-            value: TLColor.main,
-            range: range
-        )
-        
-        attributedText = mutableAttributedText
-    }
-    
+
     func setFont(to font: TLFont) {
         travelineFont = font
         setupAttributes()

--- a/iOS/traveline/Sources/DesignSystem/View/TLList/TLInfoView.swift
+++ b/iOS/traveline/Sources/DesignSystem/View/TLList/TLInfoView.swift
@@ -48,6 +48,7 @@ final class TLInfoView: UIView {
         let imageView = UIImageView()
         imageView.backgroundColor = TLColor.gray
         imageView.layer.cornerRadius = Metric.profileImageSize / 2
+        imageView.clipsToBounds = true
         return imageView
     }()
     

--- a/iOS/traveline/Sources/DesignSystem/View/TLTagList/TLTagListView.swift
+++ b/iOS/traveline/Sources/DesignSystem/View/TLTagList/TLTagListView.swift
@@ -40,7 +40,7 @@ final class TLTagListView: UIView {
     
     // MARK: - Properties
     
-    private var detailTagList: [TLTag] = .init()
+    private var detailTagList: [TLTag] = []
     private lazy var currentStackView: UIStackView = tagStackView
     private var tagType: TagType?
     private var selectedTag: TLTag?

--- a/iOS/traveline/Sources/Domain/Model/Timeline/TimelineCardInfo.swift
+++ b/iOS/traveline/Sources/Domain/Model/Timeline/TimelineCardInfo.swift
@@ -17,8 +17,8 @@ struct TimelineCardInfo: Hashable {
     let place: String
     let content: String
     let time: String
-    let latitude: Double
-    let longitude: Double
+    let latitude: Double?
+    let longitude: Double?
     
     static let empty: Self = .init(
         detailId: Literal.empty,

--- a/iOS/traveline/Sources/Domain/Model/Timeline/TimelineDetailRequest.swift
+++ b/iOS/traveline/Sources/Domain/Model/Timeline/TimelineDetailRequest.swift
@@ -7,12 +7,13 @@
 //
 
 import Foundation
+
 struct TimelineDetailRequest {
     var title: String
     var day: Int
     var time: String
     var date: String
-    var place: String
+    var place: TimelinePlace?
     var image: Data?
     var content: String
     var posting: String
@@ -22,7 +23,7 @@ struct TimelineDetailRequest {
         day: 0,
         time: Literal.empty,
         date: Literal.empty,
-        place: Literal.empty,
+        place: .emtpy,
         content: Literal.empty,
         posting: Literal.empty
     )

--- a/iOS/traveline/Sources/Domain/Model/Timeline/TimelinePlace.swift
+++ b/iOS/traveline/Sources/Domain/Model/Timeline/TimelinePlace.swift
@@ -1,0 +1,23 @@
+//
+//  TimelinePlace.swift
+//  traveline
+//
+//  Created by 김영인 on 2023/12/07.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+typealias TimelinePlaceList = [TimelinePlace]
+
+struct TimelinePlace: Hashable {
+    let title: String
+    let latitude: Double
+    let longitude: Double
+    
+    static let emtpy: Self = .init(
+        title: Literal.empty, 
+        latitude: 0.0,
+        longitude: 0.0
+    )
+}

--- a/iOS/traveline/Sources/Domain/Model/TravelID.swift
+++ b/iOS/traveline/Sources/Domain/Model/TravelID.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct TravelID: Equatable {
+struct TravelID: Equatable, Hashable {
     let value: String
     
     static let empty: Self = .init(value: "")

--- a/iOS/traveline/Sources/Domain/RepositoryInterface/TimelineDetailRepository.swift
+++ b/iOS/traveline/Sources/Domain/RepositoryInterface/TimelineDetailRepository.swift
@@ -10,5 +10,6 @@ import Foundation
 
 protocol TimelineDetailRepository {
     func fetchTimelineDetailInfo(id: String) async throws -> TimelineDetailInfo
-    func createTimelineDetail(with timelineRequest: TimelineDetailRequest) async throws -> TimelineDetailInfo
+    func createTimelineDetail(with timelineRequest: TimelineDetailRequest) async throws
+    func fetchTimelinePlaces(keyword: String) async throws -> TimelinePlaceList
 }

--- a/iOS/traveline/Sources/Domain/UseCase/TimelineUseCase.swift
+++ b/iOS/traveline/Sources/Domain/UseCase/TimelineUseCase.swift
@@ -12,6 +12,7 @@ import Combine
 protocol TimelineUseCase {
     func fetchTimelineInfo(id: TravelID) -> AnyPublisher<TimelineTravelInfo, Error>
     func fetchTimelineList(id: TravelID, day: Int) -> AnyPublisher<TimelineCardList, Error>
+    func calculateDate(from startDate: String, with day: Int) -> String?
 }
 
 final class TimelineUseCaseImpl: TimelineUseCase {
@@ -49,6 +50,14 @@ final class TimelineUseCaseImpl: TimelineUseCase {
             }
         }
         .eraseToAnyPublisher()
+    }
+    
+    func calculateDate(from startDate: String, with day: Int) -> String? {
+        guard let date = startDate.toDate(),
+              let curDate = Calendar.current.date(byAdding: .day, value: day, to: date) else { return nil }
+        
+        return curDate.toString(with: "yyyy년 MM월 dd일")
+
     }
     
 }

--- a/iOS/traveline/Sources/Domain/UseCase/TimelineWritingUseCase.swift
+++ b/iOS/traveline/Sources/Domain/UseCase/TimelineWritingUseCase.swift
@@ -10,7 +10,8 @@ import Combine
 import Foundation
 
 protocol TimelineWritingUseCase {
-    func requestCreateTimeline(with info: TimelineDetailRequest) -> AnyPublisher<TimelineDetailInfo, Error>
+    func requestCreateTimeline(with info: TimelineDetailRequest) -> AnyPublisher<Void, Error>
+    func fetchPlaceList(keyword: String) -> AnyPublisher<TimelinePlaceList, Error>
 }
 
 final class TimelineWritingUseCaseImpl: TimelineWritingUseCase {
@@ -21,18 +22,30 @@ final class TimelineWritingUseCaseImpl: TimelineWritingUseCase {
         self.repository = repository
     }
     
-    func requestCreateTimeline(with info: TimelineDetailRequest) -> AnyPublisher<TimelineDetailInfo, Error> {
+    func requestCreateTimeline(with info: TimelineDetailRequest) -> AnyPublisher<Void, Error> {
         return Future { promise in
-            Task { [weak self] in
-                guard let self else { return }
+            Task {
                 do {
-                    let timelineDetailInfo = try await self.repository.createTimelineDetail(with: info)
-                    promise(.success(timelineDetailInfo))
+                    try await self.repository.createTimelineDetail(with: info)
+                    promise(.success(Void()))
                 } catch {
                     promise(.failure(error))
                 }
             }
         }.eraseToAnyPublisher()
     }
-     
+    
+    func fetchPlaceList(keyword: String) -> AnyPublisher<TimelinePlaceList, Error> {
+        return Future { promise in
+            Task {
+                do {
+                    let placeList = try await self.repository.fetchTimelinePlaces(keyword: keyword)
+                    promise(.success(placeList))
+                } catch {
+                    promise(.failure(error))
+                }
+            }
+        }.eraseToAnyPublisher()
+    }
+    
 }

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/VC/HomeVC.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/VC/HomeVC.swift
@@ -246,8 +246,9 @@ private extension HomeVC {
     func bindListView() {
         homeListView.didSelectHomeList
             .withUnretained(self)
-            .sink { owner, _  in
-                let timelineVC = VCFactory.makeTimelineVC(id: .empty)
+            .sink { owner, idx  in
+                let id = owner.viewModel.currentState.travelList[idx].id
+                let timelineVC = VCFactory.makeTimelineVC(id: TravelID(value: id))
                 owner.navigationController?.pushViewController(
                     timelineVC,
                     animated: true

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/View/HomeListView.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/View/HomeListView.swift
@@ -60,7 +60,7 @@ final class HomeListView: UIView {
     
     private var dataSource: DataSource!
     
-    let didSelectHomeList: PassthroughSubject<Void, Never> = .init()
+    let didSelectHomeList: PassthroughSubject<Int, Never> = .init()
     let didSelectFilterType: PassthroughSubject<FilterType, Never> = .init()
     let didScrollToBottom: PassthroughSubject<Void, Never> = .init()
     
@@ -224,7 +224,7 @@ extension HomeListView {
 
 extension HomeListView: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        didSelectHomeList.send(Void())
+        didSelectHomeList.send(indexPath.row)
     }
     
     func scrollViewDidScroll(_ scrollView: UIScrollView) {

--- a/iOS/traveline/Sources/Feature/MyPageFeature/MyPostListScene/VC/MyPostListVC.swift
+++ b/iOS/traveline/Sources/Feature/MyPageFeature/MyPostListScene/VC/MyPostListVC.swift
@@ -171,7 +171,8 @@ private extension MyPostListVC {
 
 extension MyPostListVC: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let timelineVC = VCFactory.makeTimelineVC(id: .empty)
+        let id = TravelID(value: viewModel.currentState.travelList[indexPath.row].id)
+        let timelineVC = VCFactory.makeTimelineVC(id: id)
         self.navigationController?.pushViewController(timelineVC, animated: true)
     }
 }

--- a/iOS/traveline/Sources/Feature/MyPageFeature/ProfileEditingScene/VC/ProfileEditingVC.swift
+++ b/iOS/traveline/Sources/Feature/MyPageFeature/ProfileEditingScene/VC/ProfileEditingVC.swift
@@ -209,13 +209,7 @@ extension ProfileEditingVC {
     }
     
     func bind() {
-        nickNameTextField
-            .textPublisher
-            .withUnretained(self)
-            .sink { owner, text in
-                owner.viewModel.sendAction(.nicknameDidChange(text))
-            }
-            .store(in: &cancellables)
+
         
         viewModel.state
             .map(\.isCompletable)
@@ -275,7 +269,7 @@ extension ProfileEditingVC: PHPickerViewControllerDelegate {
 
 extension ProfileEditingVC: TLNavigationBarDelegate {
     func rightButtonDidTapped() {
-        viewModel.sendAction(.tapCompleteButton(imageView.image?.pngData()))
+        viewModel.sendAction(.tapCompleteButton(imageView.image?.jpegData(compressionQuality: 1)))
         self.navigationController?.popViewController(animated: true)
     }
 }

--- a/iOS/traveline/Sources/Feature/MyPageFeature/ProfileEditingScene/ViewModel/ProfileEditingViewModel.swift
+++ b/iOS/traveline/Sources/Feature/MyPageFeature/ProfileEditingScene/ViewModel/ProfileEditingViewModel.swift
@@ -85,6 +85,7 @@ final class ProfileEditingViewModel: BaseViewModel<ProfileEditingAction, Profile
         
         switch effect {
         case let .fetchProfile(profile):
+            changedNickname = profile.name
             newState.profile = profile
             
         case .error:

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineMapScene/VC/TimelineMapVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineMapScene/VC/TimelineMapVC.swift
@@ -42,15 +42,19 @@ final class TimelineMapVC: UIViewController {
     // MARK: - Functions
     
     func setMarker(by cardList: TimelineCardList, day: Int) {
-        let markerAnnotations = cardList.map {
-            TLMarkerAnnotation(
-                cardInfo: $0,
-                coordinate: .init(
-                    latitude: $0.latitude,
-                    longitude: $0.longitude
+        let markerAnnotations = cardList
+            .compactMap { card -> TLMarkerAnnotation? in
+                guard let latitude = card.latitude,
+                      let longitude = card.longitude else { return nil }
+                
+                return TLMarkerAnnotation(
+                    cardInfo: card,
+                    coordinate: .init(
+                        latitude: latitude,
+                        longitude: longitude
+                    )
                 )
-            )
-        }
+            }
         
         mapView.showAnnotations(markerAnnotations, animated: true)
         mapView.addAnnotations(markerAnnotations)
@@ -100,7 +104,7 @@ private extension TimelineMapVC {
         view.subviews.forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
         }
-
+        
         NSLayoutConstraint.activate([
             tlNavigationBar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             tlNavigationBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
@@ -122,6 +126,12 @@ private extension TimelineMapVC {
 // MARK: - MKMapViewDelegate
 
 extension TimelineMapVC: MKMapViewDelegate {
+    func mapView(_ mapView: MKMapView, didAdd views: [MKAnnotationView]) {
+        if let firstAnnotation = mapView.annotations.first {
+            mapView.selectAnnotation(firstAnnotation, animated: true)
+        }
+    }
+    
     func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
         if annotation is MKUserLocation { return nil }
         
@@ -135,7 +145,7 @@ extension TimelineMapVC: MKMapViewDelegate {
         
         annotationView?.image = TLImage.Travel.marker
         
-        if let imageHeight = annotationView?.bounds.height {
+        if let imageHeight = annotationView?.frame.height {
             annotationView?.centerOffset = .init(x: 0, y: -imageHeight / 2)
         }
         

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/View/TimelineCardView.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/View/TimelineCardView.swift
@@ -56,6 +56,7 @@ final class TimelineCardView: UIView {
         subtitleLabel.setText(to: cardInfo.place)
         contentLabel.setText(to: cardInfo.content)
         thumbnailImageView.setImage(from: cardInfo.thumbnailURL)
+        thumbnailImageView.isHidden = cardInfo.thumbnailURL == nil
     }
     
     /// 셀 재사용 시 이미지 reset

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/VC/TimelineWritingVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/VC/TimelineWritingVC.swift
@@ -377,10 +377,9 @@ extension TimelineWritingVC: PHPickerViewControllerDelegate {
         itemProvider.loadObject(ofClass: UIImage.self) { [weak self] image, _ in
             guard let self = self else { return }
             DispatchQueue.main.async {
-                guard let imageData = image as? UIImage else { return }
-                let selectedImage = imageData.downSampling()
+                guard let selectedImage = image as? UIImage else { return }
                 self.selectImageButton.setImage(selectedImage)
-                self.viewModel.sendAction(.imageDidChange(selectedImage?.jpegData(compressionQuality: 1)))
+                self.viewModel.sendAction(.imageDidChange(selectedImage.jpegData(compressionQuality: 1)))
             }
         }
     }

--- a/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/VC/TravelVC.swift
+++ b/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/VC/TravelVC.swift
@@ -302,9 +302,9 @@ extension TravelVC: UITextFieldDelegate {
 
 extension TravelVC: TLBottomSheetDelegate {
     func bottomSheetDidDisappear(data: Any) {
-        guard let region = data as? String else { return }
-        selectRegionButton.setSelectedTitle(region)
-        viewModel.sendAction(.regionSelected(region))
+        guard let region = data as? RegionFilter else { return }
+        selectRegionButton.setSelectedTitle(region.title)
+        viewModel.sendAction(.regionSelected(region.query))
     }
 }
 

--- a/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/VC/TravelVC.swift
+++ b/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/VC/TravelVC.swift
@@ -243,6 +243,7 @@ private extension TravelVC {
             .withUnretained(self)
             .sink { owner, startDate in
                 owner.selectPeriodView.endDatePicker.minimumDate = startDate
+                owner.selectPeriodView.endDatePicker.maximumDate = Calendar.current.date(byAdding: .month, value: 1, to: startDate)
             }
             .store(in: &cancellables)
         

--- a/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/View/RegionBottomSheetVC.swift
+++ b/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/View/RegionBottomSheetVC.swift
@@ -16,6 +16,7 @@ final class RegionBottomSheetVC: TLBottomSheetVC {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: makeLayout())
         
         collectionView.backgroundColor = TLColor.black
+        collectionView.showsVerticalScrollIndicator = false
         collectionView.delegate = self
         collectionView.dataSource = self
         collectionView.register(cell: RegionCVC.self)
@@ -25,7 +26,7 @@ final class RegionBottomSheetVC: TLBottomSheetVC {
     
     // MARK: - Properties
     
-    private let travelRegions: [String] = RegionFilter.allCases.map { $0.title }
+    private let travelRegions: [RegionFilter] = RegionFilter.allCases
     
     // MARK: - Life Cycle
     
@@ -56,7 +57,7 @@ private extension RegionBottomSheetVC {
     func makeLayout() -> UICollectionViewCompositionalLayout {
         let size = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0),
-            heightDimension: .estimated(47.0)
+            heightDimension: .absolute(54.0)
         )
         let item = NSCollectionLayoutItem(layoutSize: size)
         let group = NSCollectionLayoutGroup.vertical(layoutSize: size, subitems: [item])
@@ -82,7 +83,7 @@ extension RegionBottomSheetVC: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeue(cell: RegionCVC.self, for: indexPath)
-        cell.setRegion(travelRegions[indexPath.row])
+        cell.setRegion(travelRegions[indexPath.row].title)
         return cell
     }
 }

--- a/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/View/SelectTagView.swift
+++ b/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/View/SelectTagView.swift
@@ -56,7 +56,7 @@ final class SelectTagView: UIView {
     private let limitWidth: CGFloat
     
     var selectedTags: [String] {
-        tagListView.selectedTags
+        return tagListView.selectedTags
     }
     
     // MARK: - Initializer


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- feature/#278,#326

## 📚 작업한 내용
1차 QA 버그 수정
-  여행 생성 안되는 이슈 (서버 query와 이름 다른 이슈 해결)
- multipart 옵셔녈 값 추출 안되는 이슈 해결
- 프로필 이미지 업로드 안되는 이슈 해결
- 여행 일정 n개월되면 앱 터지는 이슈 - 최대 한 달로 고정
- 썸네일 이미지 없는 경우 뷰 분기
- 프로필 이미지 radius 처리

타임라인 서버 연결
- 장소 서버 연결 및 구현
- 타임라인 지도 첫 진입시 카드 선택되도록 구현

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

### Mirror
ㅎㅎ 이 아이가 제가 구현했던 방식으로는 Optional 인지 여부만 판단하고 실제 내부의 값을 못가져오더라고요 , , 
그래서 한 번 더 Mirror를 써줘서 내부 값을 받아오는 식으로 구현했습니다 ^!^

```Swift
Mirror(reflecting: multipartData).children
    .filter {
        if case Optional<Any>.some = $0.value { return true }
        return false
    }
    .map { child -> (String?, Any) in
        if let value = Mirror(reflecting: child.value).descendant("some") {
            return (child.label, value)
        }
        return child
    }
```
나머지는 같이 작업한 사항들이라 따로 코멘트는 안남기겠습니다 ~ ! !

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 관련 이슈
- Resolved: #278
- Resolved: #326
