### PR TITLE
[feat] 여행 관리 API 연결

### DIFF
--- a/iOS/traveline/Sources/Core/Enum/TagType.swift
+++ b/iOS/traveline/Sources/Core/Enum/TagType.swift
@@ -96,4 +96,11 @@ enum TagType: CaseIterable {
         default: false
         }
     }
+    
+    var isBasic: Bool {
+        switch self {
+        case .region, .period, .season: true
+        default: false
+        }
+    }
 }

--- a/iOS/traveline/Sources/Core/Enum/VCFactory.swift
+++ b/iOS/traveline/Sources/Core/Enum/VCFactory.swift
@@ -31,8 +31,6 @@ enum VCFactory {
     }
     
     static func makeTimelineVC(id: TravelID) -> TimelineVC {
-//        let postingRepository = PostingRepositoryMock()
-//        let timelineRepository = TimelineRepositoryMock()
         let postingRepository = PostingRepositoryImpl(network: network)
         let timelineRepository = TimelineRepositoryImpl(network: network)
         let useCase = TimelineUseCaseImpl(
@@ -47,7 +45,6 @@ enum VCFactory {
     }
     
     static func makeHomeVC() -> HomeVC {
-//        let repository = PostingRepositoryMock()
         let repository = PostingRepositoryImpl(network: network)
         let useCase = HomeUseCaseImpl(repository: repository)
         let viewModel = HomeViewModel(homeUseCase: useCase)
@@ -55,8 +52,6 @@ enum VCFactory {
     }
     
     static func makeTimelineDetailVC(with id: String) -> TimelineDetailVC {
-        // TODO: - 서버 연결 후 Rpository 변경
-//        let repository = TimelineDetailRepositoryMock()
         let repository = TimelineDetailRepositoryImpl(network: network)
         let useCase = TimelineDetailUseCaseImpl(repository: repository)
         let viewModel = TimelineDetailViewModel(timelineDetailUseCase: useCase, timelineId: id)
@@ -64,18 +59,23 @@ enum VCFactory {
     }
     
     static func makeMyPostListVC() -> MyPostListVC {
-//        let repository = PostingRepositoryMock()
         let repository = PostingRepositoryImpl(network: network)
         let useCase = MyPostListUseCaseImpl(repository: repository)
         let viewModel = MyPostListViewModel(myPostListUseCase: useCase)
         return MyPostListVC(viewModel: viewModel)
     }
     
-    static func makeTravelVC() -> TravelVC {
-//        let repository = TravelRepositoryMock()
+    static func makeTravelVC(
+        id: TravelID? = nil,
+        travelInfo: TimelineTravelInfo? = nil
+    ) -> TravelVC {
         let repository = PostingRepositoryImpl(network: network)
         let useCase = TravelUseCaseImpl(repository: repository)
-        let viewModel = TravelViewModel(travelUseCase: useCase)
+        let viewModel = TravelViewModel(
+            id: id, 
+            travelInfo: travelInfo,
+            travelUseCase: useCase
+        )
         return TravelVC(viewModel: viewModel)
     }
     
@@ -84,7 +84,6 @@ enum VCFactory {
         date: String,
         day: Int
     ) -> TimelineWritingVC {
-//        let repository = TimelineDetailRepositoryMock()
         let repository = TimelineDetailRepositoryImpl(network: network)
         let useCase = TimelineWritingUseCaseImpl(repository: repository)
         let viewModel = TimelineWritingViewModel(
@@ -98,12 +97,11 @@ enum VCFactory {
     
     static func makeSideMenuVC() -> SideMenuVC {
         let repository = UserRepositoryImpl(network: network)
-//        let repository = UserRepositoryMock()
         let useCase = SideMenuUseCaseImpl(repository: repository)
         let viewModel = SideMenuViewModel(useCase: useCase)
         return SideMenuVC(viewModel: viewModel)
     }
-  
+    
     static func makeSettingVC() -> SettingVC {
         let repository = AuthRepositoryImpl(network: network)
         let useCase = SettingUseCaseImpl(repository: repository)
@@ -117,5 +115,5 @@ enum VCFactory {
         let viewModel = ProfileEditingViewModel(useCase: useCase)
         return ProfileEditingVC(viewModel: viewModel)
     }
-  
+    
 }

--- a/iOS/traveline/Sources/Data/Network/API/PostingEndPoint.swift
+++ b/iOS/traveline/Sources/Data/Network/API/PostingEndPoint.swift
@@ -12,6 +12,7 @@ enum PostingEndPoint {
     case postingList(SearchQuery)
     case myPostingList
     case createPosting(TravelRequestDTO) /// 게시글 생성
+    case putPosting(String, TravelRequestDTO) /// 게시글 수정
     case fetchPostingInfo(String) /// 특정 게시글 반환
     case specificPosting
     case postingTitleList(String)
@@ -25,12 +26,19 @@ extension PostingEndPoint: EndPoint {
         switch self {
         case .myPostingList: 
             return "/postings/mine"
+            
         case let .postingList(searchQuery):
             return curPath + searchQuery.makeQuery()
+            
+        case let .putPosting(id, _):
+            return "\(curPath)/\(id)"
+            
         case let .fetchPostingInfo(id):
             return "\(curPath)/\(id)"
+            
         case let .postingTitleList(keyword):
             return "\(curPath)/titles?keyword=\(keyword)"
+            
         default:
             return curPath
         }
@@ -40,6 +48,10 @@ extension PostingEndPoint: EndPoint {
         switch self {
         case .createPosting:
             return .POST
+            
+        case .putPosting:
+            return .PUT
+            
         default:
             return .GET
         }
@@ -49,6 +61,10 @@ extension PostingEndPoint: EndPoint {
         switch self {
         case let .createPosting(travel):
             return travel
+            
+        case let .putPosting(_, travel):
+            return travel
+            
         default:
             return nil
         }

--- a/iOS/traveline/Sources/Data/Network/API/PostingEndPoint.swift
+++ b/iOS/traveline/Sources/Data/Network/API/PostingEndPoint.swift
@@ -11,9 +11,10 @@ import Foundation
 enum PostingEndPoint {
     case postingList(SearchQuery)
     case myPostingList
-    case createPosting(TravelRequestDTO) /// 게시글 생성
-    case putPosting(String, TravelRequestDTO) /// 게시글 수정
-    case fetchPostingInfo(String) /// 특정 게시글 반환
+    case createPosting(TravelRequestDTO) /// 여행 생성
+    case putPosting(String, TravelRequestDTO) /// 여행 수정
+    case deletePosting(String) /// 여행 삭제
+    case fetchPostingInfo(String) /// 특정 여행 반환
     case specificPosting
     case postingTitleList(String)
 }
@@ -24,16 +25,15 @@ extension PostingEndPoint: EndPoint {
         let curPath: String = "/postings"
         
         switch self {
-        case .myPostingList: 
+        case .myPostingList:
             return "/postings/mine"
             
         case let .postingList(searchQuery):
             return curPath + searchQuery.makeQuery()
             
-        case let .putPosting(id, _):
-            return "\(curPath)/\(id)"
-            
-        case let .fetchPostingInfo(id):
+        case let .putPosting(id, _),
+            let .deletePosting(id),
+            let .fetchPostingInfo(id):
             return "\(curPath)/\(id)"
             
         case let .postingTitleList(keyword):
@@ -52,6 +52,9 @@ extension PostingEndPoint: EndPoint {
         case .putPosting:
             return .PUT
             
+        case .deletePosting:
+            return .DELETE
+            
         default:
             return .GET
         }
@@ -59,10 +62,8 @@ extension PostingEndPoint: EndPoint {
     
     var body: Encodable? {
         switch self {
-        case let .createPosting(travel):
-            return travel
-            
-        case let .putPosting(_, travel):
+        case let .createPosting(travel),
+            let .putPosting(_, travel):
             return travel
             
         default:

--- a/iOS/traveline/Sources/Data/Network/API/PostingEndPoint.swift
+++ b/iOS/traveline/Sources/Data/Network/API/PostingEndPoint.swift
@@ -15,6 +15,7 @@ enum PostingEndPoint {
     case putPosting(String, TravelRequestDTO) /// 여행 수정
     case deletePosting(String) /// 여행 삭제
     case postReport(String) /// 여행 신고
+    case postLike(String) /// 여행 좋아요
     case fetchPostingInfo(String) /// 특정 여행 반환
     case specificPosting
     case postingTitleList(String)
@@ -38,6 +39,9 @@ extension PostingEndPoint: EndPoint {
             let .postReport(id):
             return "\(curPath)/\(id)"
             
+        case let .postLike(id):
+            return "\(curPath)/\(id)/like"
+            
         case let .postingTitleList(keyword):
             return "\(curPath)/titles?keyword=\(keyword)"
             
@@ -48,7 +52,7 @@ extension PostingEndPoint: EndPoint {
     
     var httpMethod: HTTPMethod {
         switch self {
-        case .createPosting, .postReport:
+        case .createPosting, .postReport, .postLike:
             return .POST
             
         case .putPosting:

--- a/iOS/traveline/Sources/Data/Network/API/PostingEndPoint.swift
+++ b/iOS/traveline/Sources/Data/Network/API/PostingEndPoint.swift
@@ -14,6 +14,7 @@ enum PostingEndPoint {
     case createPosting(TravelRequestDTO) /// 여행 생성
     case putPosting(String, TravelRequestDTO) /// 여행 수정
     case deletePosting(String) /// 여행 삭제
+    case postReport(String) /// 여행 신고
     case fetchPostingInfo(String) /// 특정 여행 반환
     case specificPosting
     case postingTitleList(String)
@@ -33,7 +34,8 @@ extension PostingEndPoint: EndPoint {
             
         case let .putPosting(id, _),
             let .deletePosting(id),
-            let .fetchPostingInfo(id):
+            let .fetchPostingInfo(id),
+            let .postReport(id):
             return "\(curPath)/\(id)"
             
         case let .postingTitleList(keyword):
@@ -46,7 +48,7 @@ extension PostingEndPoint: EndPoint {
     
     var httpMethod: HTTPMethod {
         switch self {
-        case .createPosting:
+        case .createPosting, .postReport:
             return .POST
             
         case .putPosting:

--- a/iOS/traveline/Sources/Data/Network/Base/NetworkManager.swift
+++ b/iOS/traveline/Sources/Data/Network/Base/NetworkManager.swift
@@ -101,6 +101,7 @@ private extension NetworkManager {
     
     func makeURLRequest(endPoint: EndPoint) throws -> URLRequest {
         os_log("url: \(endPoint.baseURL ?? "empty")\(endPoint.path ?? "empty")")
+        os_log("httpMethod: \(endPoint.httpMethod.rawValue)")
         
         guard let baseURL = endPoint.baseURL,
               let path = endPoint.path,

--- a/iOS/traveline/Sources/Data/Network/DataMapping/PostingDetailResponseDTO.swift
+++ b/iOS/traveline/Sources/Data/Network/DataMapping/PostingDetailResponseDTO.swift
@@ -42,7 +42,8 @@ extension PostingDetailResponseDTO {
             isLiked: isLiked, 
             isOwner: isOwner,
             tags: toTags(),
-            days: days
+            days: days,
+            day: 1
         )
     }
     

--- a/iOS/traveline/Sources/Data/Repository/Mock/PostingRepositoryMock.swift
+++ b/iOS/traveline/Sources/Data/Repository/Mock/PostingRepositoryMock.swift
@@ -78,10 +78,17 @@ extension PostingRepositoryMock {
         return TravelID(value: "id")
     }
     
+    func deletePostings(id: TravelID) async throws -> Bool {
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+        
+        return true
+    }
+    
     func fetchTimelineInfo(id: TravelID) async throws -> TimelineTravelInfo {
         try await Task.sleep(nanoseconds: 1_000_000_000)
         
         let mockData = TimelineSample.makeTravelInfo()
         return mockData
     }
+    
 }

--- a/iOS/traveline/Sources/Data/Repository/Mock/PostingRepositoryMock.swift
+++ b/iOS/traveline/Sources/Data/Repository/Mock/PostingRepositoryMock.swift
@@ -66,19 +66,25 @@ final class PostingRepositoryMock: PostingRepository {
 
 extension PostingRepositoryMock {
     
-    func postPostings(data: TravelRequest) async throws -> TravelID {
+    func postPosting(data: TravelRequest) async throws -> TravelID {
         try await Task.sleep(nanoseconds: 1_000_000_000)
         
         return TravelID(value: "id")
     }
     
-    func putPostings(id: TravelID, data: TravelRequest) async throws -> TravelID {
+    func putPosting(id: TravelID, data: TravelRequest) async throws -> TravelID {
         try await Task.sleep(nanoseconds: 1_000_000_000)
         
         return TravelID(value: "id")
     }
     
-    func deletePostings(id: TravelID) async throws -> Bool {
+    func deletePosting(id: TravelID) async throws -> Bool {
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+        
+        return true
+    }
+    
+    func postReport(id: TravelID) async throws -> Bool {
         try await Task.sleep(nanoseconds: 1_000_000_000)
         
         return true

--- a/iOS/traveline/Sources/Data/Repository/Mock/PostingRepositoryMock.swift
+++ b/iOS/traveline/Sources/Data/Repository/Mock/PostingRepositoryMock.swift
@@ -90,6 +90,12 @@ extension PostingRepositoryMock {
         return true
     }
     
+    func postLike(id: TravelID) async throws -> Bool {
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+        
+        return true
+    }
+    
     func fetchTimelineInfo(id: TravelID) async throws -> TimelineTravelInfo {
         try await Task.sleep(nanoseconds: 1_000_000_000)
         

--- a/iOS/traveline/Sources/Data/Repository/Mock/PostingRepositoryMock.swift
+++ b/iOS/traveline/Sources/Data/Repository/Mock/PostingRepositoryMock.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 final class PostingRepositoryMock: PostingRepository {
+
     func fetchMyPostingList() async throws -> TravelList {
         try await Task.sleep(nanoseconds: 1_000_000_000)
         
@@ -66,6 +67,12 @@ final class PostingRepositoryMock: PostingRepository {
 extension PostingRepositoryMock {
     
     func postPostings(data: TravelRequest) async throws -> TravelID {
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+        
+        return TravelID(value: "id")
+    }
+    
+    func putPostings(id: TravelID, data: TravelRequest) async throws -> TravelID {
         try await Task.sleep(nanoseconds: 1_000_000_000)
         
         return TravelID(value: "id")

--- a/iOS/traveline/Sources/Data/Repository/PostingRepositoryImpl.swift
+++ b/iOS/traveline/Sources/Data/Repository/PostingRepositoryImpl.swift
@@ -101,4 +101,11 @@ extension PostingRepositoryImpl {
         
         return TravelID(value: postPostingsDTO.id)
     }
+    
+    func deletePostings(id: TravelID) async throws -> Bool {
+        let postPostingsDTO = try await network.requestWithNoResult(endPoint: PostingEndPoint.deletePosting(id.value))
+        
+        return postPostingsDTO
+    }
+    
 }

--- a/iOS/traveline/Sources/Data/Repository/PostingRepositoryImpl.swift
+++ b/iOS/traveline/Sources/Data/Repository/PostingRepositoryImpl.swift
@@ -72,7 +72,7 @@ final class PostingRepositoryImpl: PostingRepository {
 
 extension PostingRepositoryImpl {
     
-    func postPostings(data: TravelRequest) async throws -> TravelID {
+    func postPosting(data: TravelRequest) async throws -> TravelID {
         let postPostingsDTO = try await network.request(
             endPoint: PostingEndPoint.createPosting(data.toDTO()),
             type: BaseResponseDTO.self
@@ -90,7 +90,7 @@ extension PostingRepositoryImpl {
         return response.toDomain()
     }
     
-    func putPostings(id: TravelID, data: TravelRequest) async throws -> TravelID {
+    func putPosting(id: TravelID, data: TravelRequest) async throws -> TravelID {
         let postPostingsDTO = try await network.request(
             endPoint: PostingEndPoint.putPosting(
                 id.value,
@@ -102,10 +102,15 @@ extension PostingRepositoryImpl {
         return TravelID(value: postPostingsDTO.id)
     }
     
-    func deletePostings(id: TravelID) async throws -> Bool {
-        let postPostingsDTO = try await network.requestWithNoResult(endPoint: PostingEndPoint.deletePosting(id.value))
+    func deletePosting(id: TravelID) async throws -> Bool {
+        let deletePostingsDTO = try await network.requestWithNoResult(endPoint: PostingEndPoint.deletePosting(id.value))
         
-        return postPostingsDTO
+        return deletePostingsDTO
     }
     
+    func postReport(id: TravelID) async throws -> Bool {
+        let postReportDTO = try await network.requestWithNoResult(endPoint: PostingEndPoint.postReport(id.value))
+        
+        return postReportDTO
+    }
 }

--- a/iOS/traveline/Sources/Data/Repository/PostingRepositoryImpl.swift
+++ b/iOS/traveline/Sources/Data/Repository/PostingRepositoryImpl.swift
@@ -113,4 +113,10 @@ extension PostingRepositoryImpl {
         
         return postReportDTO
     }
+    
+    func postLike(id: TravelID) async throws -> Bool {
+        let postLikeDTO = try await network.requestWithNoResult(endPoint: PostingEndPoint.postLike(id.value))
+        
+        return postLikeDTO
+    }
 }

--- a/iOS/traveline/Sources/Data/Repository/PostingRepositoryImpl.swift
+++ b/iOS/traveline/Sources/Data/Repository/PostingRepositoryImpl.swift
@@ -89,4 +89,16 @@ extension PostingRepositoryImpl {
         
         return response.toDomain()
     }
+    
+    func putPostings(id: TravelID, data: TravelRequest) async throws -> TravelID {
+        let postPostingsDTO = try await network.request(
+            endPoint: PostingEndPoint.putPosting(
+                id.value,
+                data.toDTO()
+            ),
+            type: BaseResponseDTO.self
+        )
+        
+        return TravelID(value: postPostingsDTO.id)
+    }
 }

--- a/iOS/traveline/Sources/DesignSystem/View/TLTagList/TLTagListView.swift
+++ b/iOS/traveline/Sources/DesignSystem/View/TLTagList/TLTagListView.swift
@@ -8,6 +8,13 @@
 
 import UIKit
 
+/*
+ 여행 생성 화면에서 태그 제목 및 태그 버튼들을 가지는 뷰입니다.
+ ----
+ 인원
+ [1인] [2인] [3인] [4인] [5인 이상]
+ */
+
 final class TLTagListView: UIView {
     
     private enum Metric {
@@ -135,6 +142,13 @@ final class TLTagListView: UIView {
             .forEach {
                 $0.removeFromSuperview()
             }
+    }
+    
+    func setSelectedTag(_ name: String) {
+        detailTagList.filter { $0.name == name }.forEach {
+            $0.isSelected.toggle()
+            selectedTag = $0
+        }
     }
 }
 

--- a/iOS/traveline/Sources/Domain/Model/Filter/FilterDetail/RegionFilter.swift
+++ b/iOS/traveline/Sources/Domain/Model/Filter/FilterDetail/RegionFilter.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 enum RegionFilter: DetailFilterType {
+    case none
     case seoul
     case busan
     case daegu
@@ -63,6 +64,8 @@ enum RegionFilter: DetailFilterType {
             return Literal.Filter.RegionDetail.gyeongnam
         case .jeju:
             return Literal.Filter.RegionDetail.jeju
+        default:
+            return Literal.empty
         }
     }
     
@@ -102,6 +105,8 @@ enum RegionFilter: DetailFilterType {
             return Literal.Query.RegionDetail.gyeongnam
         case .jeju:
             return Literal.Query.RegionDetail.jeju
+        default:
+            return Literal.empty
         }
     }
 }

--- a/iOS/traveline/Sources/Domain/Model/Tag.swift
+++ b/iOS/traveline/Sources/Domain/Model/Tag.swift
@@ -15,4 +15,8 @@ struct Tag: Hashable {
     static func makeDefaultTag(_ type: TagType) -> Self {
         .init(title: type.title, type: type)
     }
+    
+    func toRegionFilter() -> RegionFilter? {
+        return RegionFilter.allCases.first { $0.title == title }
+    }
 }

--- a/iOS/traveline/Sources/Domain/Model/Timeline/TimelineSample.swift
+++ b/iOS/traveline/Sources/Domain/Model/Timeline/TimelineSample.swift
@@ -26,7 +26,8 @@ enum TimelineSample {
                 .init(title: "액티비티", type: .theme),
                 .init(title: "효도", type: .theme)
             ],
-            days: ["01 일", "02 월", "03 화"]
+            days: ["01 일", "02 월", "03 화"],
+            day: 1
         )
     }
     

--- a/iOS/traveline/Sources/Domain/Model/Timeline/TimelineTravelInfo.swift
+++ b/iOS/traveline/Sources/Domain/Model/Timeline/TimelineTravelInfo.swift
@@ -16,6 +16,7 @@ struct TimelineTravelInfo: Hashable {
     let isOwner: Bool
     let tags: [Tag]
     let days: [String]
+    var day: Int
     
     static let empty: Self = .init(
         travelTitle: Literal.empty,
@@ -24,6 +25,7 @@ struct TimelineTravelInfo: Hashable {
         isLiked: false,
         isOwner: false,
         tags: [],
-        days: []
+        days: [],
+        day: 1
     )
 }

--- a/iOS/traveline/Sources/Domain/Model/Travel/TravelEditableInfo.swift
+++ b/iOS/traveline/Sources/Domain/Model/Travel/TravelEditableInfo.swift
@@ -1,0 +1,25 @@
+//
+//  TravelEditableInfo.swift
+//  traveline
+//
+//  Created by 김영인 on 2023/12/10.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+struct TravelEditableInfo: Hashable {
+    let travelTitle: String
+    let region: RegionFilter?
+    let startDate: Date?
+    let endDate: Date?
+    let tags: [Tag]
+    
+    static let empty: Self = .init(
+        travelTitle: Literal.empty,
+        region: nil,
+        startDate: .now,
+        endDate: .now,
+        tags: []
+    )
+}

--- a/iOS/traveline/Sources/Domain/RepositoryInterface/PostingRepository.swift
+++ b/iOS/traveline/Sources/Domain/RepositoryInterface/PostingRepository.swift
@@ -19,4 +19,5 @@ protocol PostingRepository {
     func fetchTimelineInfo(id: TravelID) async throws -> TimelineTravelInfo
     func postPostings(data: TravelRequest) async throws -> TravelID
     func putPostings(id: TravelID, data: TravelRequest) async throws -> TravelID
+    func deletePostings(id: TravelID) async throws -> Bool
 }

--- a/iOS/traveline/Sources/Domain/RepositoryInterface/PostingRepository.swift
+++ b/iOS/traveline/Sources/Domain/RepositoryInterface/PostingRepository.swift
@@ -16,8 +16,7 @@ protocol PostingRepository {
     func saveRecentKeywordList(_ keywordList: [String])
     func deleteRecentKeyword(_ keyword: String)
     func fetchPostingTitleList(_ keyword: String) async throws -> SearchKeywordList
-    
-    /// Timeline
     func fetchTimelineInfo(id: TravelID) async throws -> TimelineTravelInfo
     func postPostings(data: TravelRequest) async throws -> TravelID
+    func putPostings(id: TravelID, data: TravelRequest) async throws -> TravelID
 }

--- a/iOS/traveline/Sources/Domain/RepositoryInterface/PostingRepository.swift
+++ b/iOS/traveline/Sources/Domain/RepositoryInterface/PostingRepository.swift
@@ -17,7 +17,8 @@ protocol PostingRepository {
     func deleteRecentKeyword(_ keyword: String)
     func fetchPostingTitleList(_ keyword: String) async throws -> SearchKeywordList
     func fetchTimelineInfo(id: TravelID) async throws -> TimelineTravelInfo
-    func postPostings(data: TravelRequest) async throws -> TravelID
-    func putPostings(id: TravelID, data: TravelRequest) async throws -> TravelID
-    func deletePostings(id: TravelID) async throws -> Bool
+    func postPosting(data: TravelRequest) async throws -> TravelID
+    func putPosting(id: TravelID, data: TravelRequest) async throws -> TravelID
+    func deletePosting(id: TravelID) async throws -> Bool
+    func postReport(id: TravelID) async throws -> Bool
 }

--- a/iOS/traveline/Sources/Domain/RepositoryInterface/PostingRepository.swift
+++ b/iOS/traveline/Sources/Domain/RepositoryInterface/PostingRepository.swift
@@ -21,4 +21,5 @@ protocol PostingRepository {
     func putPosting(id: TravelID, data: TravelRequest) async throws -> TravelID
     func deletePosting(id: TravelID) async throws -> Bool
     func postReport(id: TravelID) async throws -> Bool
+    func postLike(id: TravelID) async throws -> Bool
 }

--- a/iOS/traveline/Sources/Domain/UseCase/TimelineUseCase.swift
+++ b/iOS/traveline/Sources/Domain/UseCase/TimelineUseCase.swift
@@ -14,6 +14,7 @@ protocol TimelineUseCase {
     func fetchTimelineList(id: TravelID, day: Int) -> AnyPublisher<TimelineCardList, Error>
     func calculateDate(from startDate: String, with day: Int) -> String?
     func deleteTravel(id: TravelID) -> AnyPublisher<Bool, Error>
+    func reportTravel(id: TravelID) -> AnyPublisher<Bool, Error>
 }
 
 final class TimelineUseCaseImpl: TimelineUseCase {
@@ -65,8 +66,21 @@ final class TimelineUseCaseImpl: TimelineUseCase {
         return Future { promise in
             Task {
                 do {
-                    let id = try await self.postingRepository.deletePostings(id: id)
-                    promise(.success(true))
+                    let result = try await self.postingRepository.deletePosting(id: id)
+                    promise(.success(result))
+                } catch {
+                    promise(.failure(error))
+                }
+            }
+        }.eraseToAnyPublisher()
+    }
+    
+    func reportTravel(id: TravelID) -> AnyPublisher<Bool, Error> {
+        return Future { promise in
+            Task {
+                do {
+                    let result = try await self.postingRepository.postReport(id: id)
+                    promise(.success(result))
                 } catch {
                     promise(.failure(error))
                 }

--- a/iOS/traveline/Sources/Domain/UseCase/TimelineUseCase.swift
+++ b/iOS/traveline/Sources/Domain/UseCase/TimelineUseCase.swift
@@ -15,6 +15,7 @@ protocol TimelineUseCase {
     func calculateDate(from startDate: String, with day: Int) -> String?
     func deleteTravel(id: TravelID) -> AnyPublisher<Bool, Error>
     func reportTravel(id: TravelID) -> AnyPublisher<Bool, Error>
+    func likeTravel(id: TravelID) -> AnyPublisher<Bool, Error>
 }
 
 final class TimelineUseCaseImpl: TimelineUseCase {
@@ -87,4 +88,18 @@ final class TimelineUseCaseImpl: TimelineUseCase {
             }
         }.eraseToAnyPublisher()
     }
+    
+    func likeTravel(id: TravelID) -> AnyPublisher<Bool, Error> {
+        return Future { promise in
+            Task {
+                do {
+                    let result = try await self.postingRepository.postLike(id: id)
+                    promise(.success(result))
+                } catch {
+                    promise(.failure(error))
+                }
+            }
+        }.eraseToAnyPublisher()
+    }
+    
 }

--- a/iOS/traveline/Sources/Domain/UseCase/TimelineUseCase.swift
+++ b/iOS/traveline/Sources/Domain/UseCase/TimelineUseCase.swift
@@ -13,6 +13,7 @@ protocol TimelineUseCase {
     func fetchTimelineInfo(id: TravelID) -> AnyPublisher<TimelineTravelInfo, Error>
     func fetchTimelineList(id: TravelID, day: Int) -> AnyPublisher<TimelineCardList, Error>
     func calculateDate(from startDate: String, with day: Int) -> String?
+    func deleteTravel(id: TravelID) -> AnyPublisher<Bool, Error>
 }
 
 final class TimelineUseCaseImpl: TimelineUseCase {
@@ -60,4 +61,16 @@ final class TimelineUseCaseImpl: TimelineUseCase {
 
     }
     
+    func deleteTravel(id: TravelID) -> AnyPublisher<Bool, Error> {
+        return Future { promise in
+            Task {
+                do {
+                    let id = try await self.postingRepository.deletePostings(id: id)
+                    promise(.success(true))
+                } catch {
+                    promise(.failure(error))
+                }
+            }
+        }.eraseToAnyPublisher()
+    }
 }

--- a/iOS/traveline/Sources/Domain/UseCase/TravelUseCase.swift
+++ b/iOS/traveline/Sources/Domain/UseCase/TravelUseCase.swift
@@ -47,7 +47,7 @@ final class TravelUseCaseImpl: TravelUseCase {
         return Future { promise in
             Task {
                 do {
-                    let id = try await self.repository.postPostings(data: data)
+                    let id = try await self.repository.postPosting(data: data)
                     promise(.success(id))
                 } catch {
                     promise(.failure(error))
@@ -60,7 +60,7 @@ final class TravelUseCaseImpl: TravelUseCase {
         return Future { promise in
             Task {
                 do {
-                    let id = try await self.repository.putPostings(
+                    let id = try await self.repository.putPosting(
                         id: id,
                         data: data
                     )

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/VC/HomeVC.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/VC/HomeVC.swift
@@ -227,7 +227,7 @@ private extension HomeVC {
             .dropFirst()
             .removeDuplicates()
             .withUnretained(self)
-            .sink { owner, filters in
+            .sink { owner, _ in
                 owner.viewModel.sendAction(.filterChanged)
             }
             .store(in: &cancellables)

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/VC/TimelineVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/VC/TimelineVC.swift
@@ -127,8 +127,8 @@ final class TimelineVC: UIViewController {
             ]
         } else {
             menuItems = [
-                .init(title: Literal.Action.report, attributes: .destructive, handler: { _ in
-                    // TODO: - 신고하기 연결
+                .init(title: Literal.Action.report, attributes: .destructive, handler: { [weak self] _ in
+                    self?.viewModel.sendAction(.reportTravel)
                 })
             ]
         }

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/VC/TimelineVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/VC/TimelineVC.swift
@@ -380,7 +380,7 @@ extension TimelineVC {
         
         dataSource.apply(snapshot)
         snapshot.reloadSections([.timeline])
-        dataSource.apply(snapshot)
+        dataSource.apply(snapshot, animatingDifferences: false)
     }
     
     func setupData(list: TimelineCardList) {
@@ -388,7 +388,7 @@ extension TimelineVC {
         snapshot.deleteItems(snapshot.itemIdentifiers(inSection: .timeline))
         list.forEach { snapshot.appendItems([.timelineItem($0)], toSection: .timeline) }
         
-        dataSource.apply(snapshot)
+        dataSource.apply(snapshot, animatingDifferences: false)
     }
     
 }

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/VC/TimelineVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/VC/TimelineVC.swift
@@ -121,8 +121,8 @@ final class TimelineVC: UIViewController {
                 .init(title: Literal.Action.modify, handler: { [weak self] _ in
                     self?.viewModel.sendAction(.editTravel)
                 }),
-                .init(title: Literal.Action.delete, attributes: .destructive, handler: { _ in
-                    // TODO: - 삭제하기 연결
+                .init(title: Literal.Action.delete, attributes: .destructive, handler: {  [weak self] _ in
+                    self?.viewModel.sendAction(.deleteTravel)
                 })
             ]
         } else {
@@ -233,6 +233,15 @@ private extension TimelineVC {
                     travelInfo: owner.viewModel.currentState.travelInfo
                 )
                 owner.navigationController?.pushViewController(travelEditVC, animated: true)
+            }
+            .store(in: &cancellables)
+        
+        viewModel.state
+            .map(\.deleteCompleted)
+            .filter { $0 }
+            .withUnretained(self)
+            .sink { owner, _ in
+                owner.navigationController?.popViewController(animated: true)
             }
             .store(in: &cancellables)
     }

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/VC/TimelineVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/VC/TimelineVC.swift
@@ -195,6 +195,7 @@ private extension TimelineVC {
         
         viewModel.state
             .map(\.timelineCardList)
+            .removeDuplicates()
             .withUnretained(self)
             .sink { owner, cardlist in
                 owner.setupData(list: cardlist)
@@ -289,7 +290,7 @@ extension TimelineVC {
             
             if let model = self?.dataSource.itemIdentifier(for: [0, 0]),
                case let .travelInfoItem(info) = model {
-                header.setData(days: info.days)
+                header.setData(info: info)
             }
             
             return header
@@ -370,7 +371,7 @@ extension TimelineVC {
         var snapshot = Snapshot()
         snapshot.appendSections([.travelInfo, .timeline])
         
-        dataSource.apply(snapshot)
+        dataSource.apply(snapshot, animatingDifferences: false)
     }
     
     func setupData(info: TimelineTravelInfo) {
@@ -378,7 +379,7 @@ extension TimelineVC {
         snapshot.deleteItems(snapshot.itemIdentifiers(inSection: .travelInfo))
         snapshot.appendItems([.travelInfoItem(info)], toSection: .travelInfo)
         
-        dataSource.apply(snapshot)
+        dataSource.apply(snapshot, animatingDifferences: false)
         snapshot.reloadSections([.timeline])
         dataSource.apply(snapshot, animatingDifferences: false)
     }
@@ -388,7 +389,7 @@ extension TimelineVC {
         snapshot.deleteItems(snapshot.itemIdentifiers(inSection: .timeline))
         list.forEach { snapshot.appendItems([.timelineItem($0)], toSection: .timeline) }
         
-        dataSource.apply(snapshot, animatingDifferences: false)
+        dataSource.apply(snapshot)
     }
     
 }

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/VC/TimelineVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/VC/TimelineVC.swift
@@ -92,6 +92,12 @@ final class TimelineVC: UIViewController {
         super.viewWillAppear(animated)
         
         navigationController?.navigationBar.isHidden = true
+        viewModel.sendAction(.viewWillAppear)
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
         viewModel.sendAction(.enterToTimeline)
     }
     
@@ -112,8 +118,8 @@ final class TimelineVC: UIViewController {
         
         if isOwner {
             menuItems = [
-                .init(title: Literal.Action.modify, handler: { _ in
-                    // TODO: - 수정하기 연결
+                .init(title: Literal.Action.modify, handler: { [weak self] _ in
+                    self?.viewModel.sendAction(.editTravel)
                 }),
                 .init(title: Literal.Action.delete, attributes: .destructive, handler: { _ in
                     // TODO: - 삭제하기 연결
@@ -214,6 +220,19 @@ private extension TimelineVC {
                     day: info.day
                 )
                 owner.navigationController?.pushViewController(vc, animated: true)
+            }
+            .store(in: &cancellables)
+        
+        viewModel.state
+            .map(\.isEdit)
+            .filter { $0 }
+            .withUnretained(self)
+            .sink { owner, _ in
+                let travelEditVC = VCFactory.makeTravelVC(
+                    id: owner.viewModel.id,
+                    travelInfo: owner.viewModel.currentState.travelInfo
+                )
+                owner.navigationController?.pushViewController(travelEditVC, animated: true)
             }
             .store(in: &cancellables)
     }

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/View/TimelineDateHeaderView.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/View/TimelineDateHeaderView.swift
@@ -110,7 +110,6 @@ final class TimelineDateHeaderView: UICollectionReusableView {
         setupAttributes()
         setupLayout()
         setupDataSource()
-        setDate()
     }
     
     required init?(coder: NSCoder) {
@@ -119,22 +118,19 @@ final class TimelineDateHeaderView: UICollectionReusableView {
     
     // MARK: - Functions
     
-    func setData(days: [String]) {
+    func setData(info: TimelineTravelInfo) {
         var snapshot = Snapshot()
         snapshot.appendSections([.days])
-        snapshot.appendItems(days)
+        snapshot.appendItems(info.days)
         
         dataSource.apply(snapshot)
         
         dateCollectionView.selectItem(
-            at: .init(item: 0, section: 0),
+            at: .init(item: info.day - 1, section: 0),
             animated: true,
             scrollPosition: .left
         )
-    }
-    
-    private func setDate(to day: Int = 1) {
-        dayLabel.setText(to: "Day \(day)")
+        dayLabel.setText(to: "Day \(info.day)")
     }
     
     @objc private func mapViewButtonPressed() {
@@ -199,7 +195,6 @@ private extension TimelineDateHeaderView {
 extension TimelineDateHeaderView: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let day = indexPath.row + 1
-        setDate(to: day)
         delegate?.changeDay(to: day)
     }
 }

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/View/TravelInfoCVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/View/TravelInfoCVC.swift
@@ -17,7 +17,7 @@ final class TravelInfoCVC: UICollectionViewCell {
     private enum Metric {
         static let verticalInset: CGFloat = 16.0
         static let horizontalInset: CGFloat = 16.0
-        static let likeButtonWidth: CGFloat = 24.0
+        static let likeButtonWidth: CGFloat = 34.0
         static let dateTopInset: CGFloat = 8.0
         static let tagTopInset: CGFloat = 14.0
     }
@@ -43,6 +43,7 @@ final class TravelInfoCVC: UICollectionViewCell {
         
         button.setImage(TLImage.Common.like, for: .normal)
         button.setImage(TLImage.Common.likeSelected, for: .selected)
+        button.imageView?.contentMode = .scaleAspectFit
         
         return button
     }()

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/ViewModel/TimelineViewModel.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/ViewModel/TimelineViewModel.swift
@@ -142,6 +142,7 @@ final class TimelineViewModel: BaseViewModel<TimelineAction, TimelineSideEffect,
             
         case let .removeRegacyCards(day):
             newState.day = day
+            newState.travelInfo.day = day
             newState.timelineCardList.removeAll()
             sendAction(.fetchTimelineCard(day))
             

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/ViewModel/TimelineViewModel.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/ViewModel/TimelineViewModel.swift
@@ -18,6 +18,7 @@ enum TimelineAction: BaseAction {
     case createPostingButtonPressed
     case editTravel
     case deleteTravel
+    case reportTravel
 }
 
 enum TimelineSideEffect: BaseSideEffect {
@@ -104,6 +105,9 @@ final class TimelineViewModel: BaseViewModel<TimelineAction, TimelineSideEffect,
             
         case .deleteTravel:
             return deleteTravel()
+            
+        case .reportTravel:
+            return reportTravel()
         }
     }
     
@@ -209,4 +213,14 @@ private extension TimelineViewModel {
             .eraseToAnyPublisher()
     }
     
+    func reportTravel() -> SideEffectPublisher {
+        return timelineUseCase.reportTravel(id: id)
+            .map { _ in
+                return TimelineSideEffect.popToHome
+            }
+            .catch { _ in
+                return Just(TimelineSideEffect.timelineError(.deleteFailed))
+            }
+            .eraseToAnyPublisher()
+    }
 }

--- a/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/View/RegionBottomSheetVC.swift
+++ b/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/View/RegionBottomSheetVC.swift
@@ -26,7 +26,7 @@ final class RegionBottomSheetVC: TLBottomSheetVC {
     
     // MARK: - Properties
     
-    private let travelRegions: [RegionFilter] = RegionFilter.allCases
+    private let travelRegions: [RegionFilter] = RegionFilter.allCases.filter { $0 != .none }
     
     // MARK: - Life Cycle
     
@@ -35,7 +35,6 @@ final class RegionBottomSheetVC: TLBottomSheetVC {
         
         setupLayout()
     }
-    
 }
 
 // MARK: - Setup Functions

--- a/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/View/SelectTagView.swift
+++ b/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/View/SelectTagView.swift
@@ -52,7 +52,7 @@ final class SelectTagView: UIView {
     
     // MARK: - Properties
     
-    private let tagType: TagType
+    private(set) var tagType: TagType
     private let limitWidth: CGFloat
     
     var selectedTags: [String] {
@@ -73,6 +73,12 @@ final class SelectTagView: UIView {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Functions
+    
+    func setSelectedTag(tag: Tag) {
+        tagListView.setSelectedTag(tag.title)
     }
 
 }

--- a/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/ViewModel/TravelViewModel.swift
+++ b/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/ViewModel/TravelViewModel.swift
@@ -10,6 +10,7 @@ import Combine
 import Foundation
 
 enum TravelAction: BaseAction {
+    case configTravelInfo(TimelineTravelInfo)
     case titleEdited(String)
     case regionSelected(String)
     case startDateSelected(Date)
@@ -18,6 +19,7 @@ enum TravelAction: BaseAction {
 }
 
 enum TravelSideEffect: BaseSideEffect {
+    case showTravelInfo(TravelEditableInfo)
     case saveTitle(String)
     case saveRegion(String)
     case saveStartDate(Date)
@@ -35,6 +37,7 @@ struct TravelState: BaseState {
     var titleValidation: TitleValidation?
     var travelID: TravelID?
     var errorMsg: String?
+    var travelInfo: TravelEditableInfo?
     
     var isValidTitle: Bool {
         titleValidation == .valid
@@ -47,43 +50,74 @@ struct TravelState: BaseState {
     var canPost: Bool {
         isValidTitle && !region.isEmpty && isValidDate
     }
+    
+    var isEdit: Bool {
+        travelInfo != nil
+    }
 }
 
 final class TravelViewModel: BaseViewModel<TravelAction, TravelSideEffect, TravelState> {
     
+    private let id: TravelID?
     private let travelUseCase: TravelUseCase
     
-    init(travelUseCase: TravelUseCase) {
+    init(
+        id: TravelID?,
+        travelInfo: TimelineTravelInfo?,
+        travelUseCase: TravelUseCase
+    ) {
+        self.id = id
         self.travelUseCase = travelUseCase
+        super.init()
+        
+        guard let travelInfo else { return }
+        self.sendAction(.configTravelInfo(travelInfo))
     }
     
     // MARK: - Transform
     
     override func transform(action: TravelAction) -> SideEffectPublisher {
         switch action {
+        case let .configTravelInfo(travelInfo):
+            return toTravelEditableInfo(travelInfo)
+            
         case let .titleEdited(title):
-            validate(title: title)
+            return validate(title: title)
             
         case let .regionSelected(region):
-            Just(TravelSideEffect.saveRegion(region)).eraseToAnyPublisher()
+            return .just(TravelSideEffect.saveRegion(region))
             
         case let .startDateSelected(startDate):
-            Just(TravelSideEffect.saveStartDate(startDate)).eraseToAnyPublisher()
+            return .just(TravelSideEffect.saveStartDate(startDate))
             
         case let .endDateSelected(endDate):
-            Just(TravelSideEffect.saveEndDate(endDate)).eraseToAnyPublisher()
+            return .just(TravelSideEffect.saveEndDate(endDate))
             
         case let .donePressed(tags):
-            postTravel(tags)
+            return postTravel(tags)
         }
     }
     
     // MARK: - ReduceState
     
     override func reduceState(state: TravelState, effect: TravelSideEffect) -> TravelState {
+        
         var newState = state
         
         switch effect {
+        case let .showTravelInfo(travelInfo):
+            newState.travelInfo = travelInfo
+            
+            guard let region = travelInfo.region,
+                  let startDate = travelInfo.startDate,
+                  let endDate = travelInfo.endDate else { return newState }
+            
+            newState.titleValidation = .valid
+            newState.titleText = travelInfo.travelTitle
+            newState.region = region.title
+            newState.startDate = startDate
+            newState.endDate = endDate
+            
         case let .saveTitle(title):
             newState.titleText = title
             
@@ -127,6 +161,12 @@ private extension TravelViewModel {
 // MARK: - UseCase
 
 private extension TravelViewModel {
+    
+    func toTravelEditableInfo(_ travelInfo: TimelineTravelInfo) -> SideEffectPublisher {
+        let travelEditableInfo = travelUseCase.toEditable(info: travelInfo)
+        return .just(TravelSideEffect.showTravelInfo(travelEditableInfo))
+    }
+    
     func postTravel(_ tags: [Tag]) -> SideEffectPublisher {
         let travelReqeust = TravelRequest(
             title: currentState.titleText,
@@ -136,12 +176,25 @@ private extension TravelViewModel {
             tags: tags
         )
         
+        if currentState.isEdit {
+            guard let id = id else { return Empty().eraseToAnyPublisher() }
+            
+            return travelUseCase.putTravel(id: id, data: travelReqeust)
+                .map { id in
+                    TravelSideEffect.postTravel(id)
+                }
+                .catch { _ in
+                    Just(TravelSideEffect.error("여행 수정에 실패했습니다."))
+                }
+                .eraseToAnyPublisher()
+        }
+        
         return travelUseCase.createTravel(data: travelReqeust)
             .map { id in
                 TravelSideEffect.postTravel(id)
             }
             .catch { _ in
-                Just(TravelSideEffect.error("postTravel에 실패했습니다."))
+                Just(TravelSideEffect.error("여행 생성에 실패했습니다."))
             }
             .eraseToAnyPublisher()
     }


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- feature/#279

## 📚 작업한 내용
- 여행 수정 API
- 여행 삭제 API
- 여행 신고 API
- 여행 좋아요 API

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

### 좋아요시 하단 카드리스트 업데이트되는 이슈
업데이트하는 모델을 info 전체로 하여 내부에 day 필드를 추가해뒀습니다.
ViewModel에서 해당 day를 관리하게 되고, 바뀔 때마다 헤더가 업데이트됩니다.

기존에 깜빡거리는 이슈는 animating을 false로 줘서 해결했습니다.
하단 카드 리스트는 개인적으로 좀 애니메이션이 있는 게 예뻐서 추가했는데 다른 의견 있으면 말해주십쇼 ^~^

### 여행 수정
여행 수정 시, TravelVC에 해당 TravelInfo를 넘겨주는 방식으로 구현했습니다.
먼저 수정하기라는 뷰가 Info를 서버에서 받아온 후 활성화 되기 때문에 다시 API 콜 하지 않고, 넘겨주는 방식을 선택했습니다.

- 여행 작성: makeTravelVC()
- 여행 수정: makeTravelVC(info: 값)

이런 방식으로 두 가지 분기처리를 했습니다.

### 여행 수정 [완료] 버튼 활성화 시점
사실 수정해도 전이랑 내용이 같다면 완료 버튼이 활성화되지 않아야 하지만
현재 그것까지 고려하기 힘들것 같아. . 일단 수정의 경우 처음 수정하기 전까지는 무조건 [완료] 버튼이 비활성화 되도록 처리했습니다.
dropFirst()를 사용했습니다.


## 📸 스크린샷
https://github.com/boostcampwm2023/iOS07-traveline/assets/74968390/79336191-fb3e-4c72-a926-ca592993038c


## 관련 이슈
- Resolved: #279
