### PR TITLE
[chore] 홈 화면 노출 시 리프레시 적용

### DIFF
--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/VC/HomeVC.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/VC/HomeVC.swift
@@ -62,7 +62,6 @@ final class HomeVC: UIViewController {
         setupAttributes()
         setupLayout()
         bind()
-        viewModel.sendAction(.viewDidLoad)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -213,6 +212,7 @@ private extension HomeVC {
             .filter { $0.homeViewType == .home }
             .map(\.homeFilters)
             .removeDuplicates()
+            .dropFirst()
             .withUnretained(self)
             .sink { owner, _ in
                 owner.viewModel.sendAction(.filterChanged)

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/VC/HomeVC.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/VC/HomeVC.swift
@@ -72,6 +72,12 @@ final class HomeVC: UIViewController {
         viewModel.sendAction(.viewWillAppear)
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        viewModel.sendAction(.viewDidAppear)
+    }
+    
     // MARK: - Functions
     
     @objc private func menuButtonTapped() {

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeAction.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeAction.swift
@@ -11,6 +11,7 @@ import Foundation
 enum HomeAction: BaseAction {
     case viewDidLoad
     case viewWillAppear
+    case viewDidAppear
     case startSearch
     case searching(String)
     case searchDone(String)

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeAction.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeAction.swift
@@ -9,7 +9,6 @@
 import Foundation
 
 enum HomeAction: BaseAction {
-    case viewDidLoad
     case viewWillAppear
     case viewDidAppear
     case startSearch

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeViewModel.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/ViewModel/HomeViewModel.swift
@@ -22,8 +22,8 @@ final class HomeViewModel: BaseViewModel<HomeAction, HomeSideEffect, HomeState> 
         case .viewWillAppear:
             return .just(HomeSideEffect.showPrevious)
             
-        case .viewDidLoad:
-            return .just(HomeSideEffect.showHome)
+        case .viewDidAppear:
+            return fetchNewSearchList()
             
         case .cancelSearch:
             return Publishers.Merge(


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- feature/#333

## 📚 작업한 내용
### 홈 화면 노출 시 새로고침 적용
- 여행 작성, 수정, 삭제 후 홈 화면으로 돌아왔을 때 다시 리스트를 불러올 수 있도록 적용했습니다!
- 1페이지부터 다시 데이터를 받아오게 됩니다.
- viewDidAppear에 action이 추가됨에 따라 첫 화면 진입 시 중복해서 서버 요청 보내는 문제를 viewDidLoad action을 제거해 해결했습니다 :)

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
페이지네이션 테스트까지는 마쳤으나 다른 부분 케이스들은 모두 다 테스트해보진 못했습니다,,
아마 문제가 없을 것 같긴한데 혹시나 다른 부분에서 문제가 발생하면 바로 말씀주시면 수정하겠슴다!

## 📸 스크린샷

https://github.com/boostcampwm2023/iOS07-traveline/assets/51712973/d24502ef-07c3-4cee-8fa8-cc70511d5717


## 관련 이슈
- Resolved: #333
