### PR TITLE
[fix] 프로필 아이디 수정 안되던 이슈 해결

### DIFF
--- a/iOS/traveline/Sources/Feature/MyPageFeature/ProfileEditingScene/VC/ProfileEditingVC.swift
+++ b/iOS/traveline/Sources/Feature/MyPageFeature/ProfileEditingScene/VC/ProfileEditingVC.swift
@@ -158,6 +158,15 @@ extension ProfileEditingVC {
         tlNavigationBar.delegate = self
         
         imageEditButton.addTarget(self, action: #selector(imageEditButtonTapped), for: .touchUpInside)
+        
+        nickNameTextField
+            .textPublisher
+            .withUnretained(self)
+            .sink { owner, text in
+                owner.viewModel.sendAction(.nicknameDidChange(text))
+            }
+            .store(in: &cancellables)
+        
     }
     
     private func setupLayout() {
@@ -209,8 +218,6 @@ extension ProfileEditingVC {
     }
     
     func bind() {
-
-        
         viewModel.state
             .map(\.isCompletable)
             .removeDuplicates()
@@ -236,7 +243,6 @@ extension ProfileEditingVC {
             .sink { owner, profile in
                 owner.nickNameTextField.text = profile.name
                 owner.imageView.setImage(from: profile.imageURL)
-                
             }
             .store(in: &cancellables)
     }


### PR DESCRIPTION
## 🌎 PR 요약
프로필 아이디가 변경되지않던 이슈를 해결했어요.

🌱 작업한 브랜치
- feature/#345

## 📚 작업한 내용
프로필 수정화면에서 아이디가 변경되지않던 이슈 해결

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
확인해보니 키보드 입력 시 뷰모델로 액션을 보내주는 부분이 지워져있었읍니다..

이 커밋 때 지워진 것 같고, 이제 다시 잘 동작합니다 :)

https://github.com/boostcampwm2023/iOS07-traveline/commit/907ceec410c8ab91abb8857b03c478d78f023280


<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 관련 이슈
- Resolved: #345
