### PR TITLE
[refactor] 타임라인 반환 (timelines/:id) 시 isOwner 필드 추가

### DIFF
--- a/BE/src/timelines/timelines.controller.ts
+++ b/BE/src/timelines/timelines.controller.ts
@@ -162,8 +162,15 @@ export class TimelinesController {
     description: 'id에 해당하는 타임라인을 반환합니다.',
   })
   @ApiOkResponse({ schema: { example: findOne_OK } })
-  async findOne(@Param('id', ParseUUIDPipe) id: string): Promise<Timeline> {
-    return this.timelinesService.findOneWithURL(id);
+  async findOne(@Req() request, @Param('id', ParseUUIDPipe) id: string) {
+    const timeline = await this.timelinesService.findOneWithURL(id);
+    delete timeline.posting.writer.resourceId;
+    delete timeline.posting.writer.socialType;
+    delete timeline.posting.writer.allowedIp;
+    delete timeline.posting.writer.bannedIp;
+
+    const userId = request['user'].id;
+    return { ...timeline, isOwner: timeline.posting.writer.id === userId };
   }
 
   @Put(':id')

--- a/BE/src/timelines/timelines.repository.ts
+++ b/BE/src/timelines/timelines.repository.ts
@@ -15,10 +15,12 @@ export class TimelinesRepository {
   }
 
   async findOne(id: string) {
-    return this.timelineRepository.findOne({
-      where: { id },
-      relations: { posting: true },
-    });
+    return this.timelineRepository
+      .createQueryBuilder('t')
+      .leftJoinAndSelect('t.posting', 'p')
+      .leftJoinAndSelect('p.writer', 'u')
+      .where('t.id = :id', { id })
+      .getOne();
   }
 
   async findAll(posting: string, day: number) {


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- be-feature/#350-isOwner

## 📚 작업한 내용
- 타임라인 조회 시 repository 대신 queryBuilder 사용하도록 수정
- request['user']의 id 값과 writer의 id 값 비교하여 isOwner 필드 추가

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 관련 이슈
- Close: #350
