### PR TITLE
[feat] 타임라인 장소 검색 추가 구현

### DIFF
--- a/iOS/traveline/Sources/Core/Extension/String+.swift
+++ b/iOS/traveline/Sources/Core/Extension/String+.swift
@@ -35,7 +35,7 @@ extension String {
     /// - Parameter searchString: 찾을 단어
     /// - Returns: 공통 부분의 범위
     func findCommonWordRange(_ searchString: String) -> NSRange {
-        guard let range = self.range(of: searchString) else { return .init() }
+        guard let range = self.lowercased().range(of: searchString.lowercased()) else { return .init() }
         
         return NSRange(range, in: self)
     }

--- a/iOS/traveline/Sources/Data/Network/API/TimelineDetailEndPoint.swift
+++ b/iOS/traveline/Sources/Data/Network/API/TimelineDetailEndPoint.swift
@@ -11,7 +11,7 @@ import Foundation
 enum TimelineDetailEndPoint {
     case specificTimeline(String)
     case createTimeline(TimelineDetailRequestDTO)
-    case fetchPlaceList(String)
+    case fetchPlaceList(String, Int)
 }
 
 extension TimelineDetailEndPoint: EndPoint {
@@ -23,8 +23,8 @@ extension TimelineDetailEndPoint: EndPoint {
         case .specificTimeline(let id):
             return "\(curPath)/\(id)"
             
-        case let .fetchPlaceList(keyword):
-            return "\(curPath)/map?place=\(keyword)"
+        case let .fetchPlaceList(keyword, offset):
+            return "\(curPath)/map?place=\(keyword)&offset=\(offset)"
             
         default:
             return curPath

--- a/iOS/traveline/Sources/Data/Network/DataMapping/TimelinePlaceResponseDTO.swift
+++ b/iOS/traveline/Sources/Data/Network/DataMapping/TimelinePlaceResponseDTO.swift
@@ -12,11 +12,13 @@ typealias TimelinePlaceListResponseDTO = [TimelinePlaceResponseDTO]
 
 struct TimelinePlaceResponseDTO: Decodable {
     let place: String
+    let address: String
     let x: String
     let y: String
     
     enum CodingKeys: String, CodingKey {
         case place = "place_name"
+        case address = "address_name"
         case x, y
     }
 }
@@ -26,6 +28,7 @@ extension TimelinePlaceListResponseDTO {
         self.map { dto in
                 .init(
                     title: dto.place,
+                    address: dto.address,
                     latitude: dto.x.toDouble(),
                     longitude: dto.y.toDouble()
                 )

--- a/iOS/traveline/Sources/Data/Repository/Mock/TimelineDetailRepositoryMock.swift
+++ b/iOS/traveline/Sources/Data/Repository/Mock/TimelineDetailRepositoryMock.swift
@@ -21,7 +21,7 @@ final class TimelineDetailRepositoryMock: TimelineDetailRepository {
         return mockData
     }
     
-    func fetchTimelinePlaces(keyword: String) async throws -> TimelinePlaceList {
+    func fetchTimelinePlaces(keyword: String, offset: Int) async throws -> TimelinePlaceList {
         try await Task.sleep(nanoseconds: 1_000_000_000)
         
         let mockData = [TimelinePlace.init(title: "", address: "", latitude: 0, longitude: 0)]

--- a/iOS/traveline/Sources/Data/Repository/Mock/TimelineDetailRepositoryMock.swift
+++ b/iOS/traveline/Sources/Data/Repository/Mock/TimelineDetailRepositoryMock.swift
@@ -24,7 +24,7 @@ final class TimelineDetailRepositoryMock: TimelineDetailRepository {
     func fetchTimelinePlaces(keyword: String) async throws -> TimelinePlaceList {
         try await Task.sleep(nanoseconds: 1_000_000_000)
         
-        let mockData = [TimelinePlace.init(title: "", latitude: 0, longitude: 0)]
+        let mockData = [TimelinePlace.init(title: "", address: "", latitude: 0, longitude: 0)]
         return mockData
     }
 }

--- a/iOS/traveline/Sources/Data/Repository/TimelineDetailRepositoryImpl.swift
+++ b/iOS/traveline/Sources/Data/Repository/TimelineDetailRepositoryImpl.swift
@@ -32,9 +32,9 @@ final class TimelineDetailRepositoryImpl: TimelineDetailRepository {
         )
     }
     
-    func fetchTimelinePlaces(keyword: String) async throws -> TimelinePlaceList {
+    func fetchTimelinePlaces(keyword: String, offset: Int) async throws -> TimelinePlaceList {
         let timelinePlaceResponseDTO = try await network.request(
-            endPoint: TimelineDetailEndPoint.fetchPlaceList(keyword),
+            endPoint: TimelineDetailEndPoint.fetchPlaceList(keyword, offset),
             type: TimelinePlaceListResponseDTO.self
         )
         

--- a/iOS/traveline/Sources/Domain/Model/Timeline/TimelinePlace.swift
+++ b/iOS/traveline/Sources/Domain/Model/Timeline/TimelinePlace.swift
@@ -12,11 +12,13 @@ typealias TimelinePlaceList = [TimelinePlace]
 
 struct TimelinePlace: Hashable {
     let title: String
+    let address: String
     let latitude: Double
     let longitude: Double
     
     static let emtpy: Self = .init(
         title: Literal.empty, 
+        address: Literal.empty,
         latitude: 0.0,
         longitude: 0.0
     )

--- a/iOS/traveline/Sources/Domain/RepositoryInterface/TimelineDetailRepository.swift
+++ b/iOS/traveline/Sources/Domain/RepositoryInterface/TimelineDetailRepository.swift
@@ -11,5 +11,5 @@ import Foundation
 protocol TimelineDetailRepository {
     func fetchTimelineDetailInfo(id: String) async throws -> TimelineDetailInfo
     func createTimelineDetail(with timelineRequest: TimelineDetailRequest) async throws
-    func fetchTimelinePlaces(keyword: String) async throws -> TimelinePlaceList
+    func fetchTimelinePlaces(keyword: String, offset: Int) async throws -> TimelinePlaceList
 }

--- a/iOS/traveline/Sources/Domain/UseCase/TimelineWritingUseCase.swift
+++ b/iOS/traveline/Sources/Domain/UseCase/TimelineWritingUseCase.swift
@@ -11,7 +11,7 @@ import Foundation
 
 protocol TimelineWritingUseCase {
     func requestCreateTimeline(with info: TimelineDetailRequest) -> AnyPublisher<Void, Error>
-    func fetchPlaceList(keyword: String) -> AnyPublisher<TimelinePlaceList, Error>
+    func fetchPlaceList(keyword: String, offset: Int) -> AnyPublisher<TimelinePlaceList, Error>
 }
 
 final class TimelineWritingUseCaseImpl: TimelineWritingUseCase {
@@ -35,11 +35,15 @@ final class TimelineWritingUseCaseImpl: TimelineWritingUseCase {
         }.eraseToAnyPublisher()
     }
     
-    func fetchPlaceList(keyword: String) -> AnyPublisher<TimelinePlaceList, Error> {
+    func fetchPlaceList(keyword: String, offset: Int) -> AnyPublisher<TimelinePlaceList, Error> {
+        if keyword.isEmpty {
+            return .just([]).setFailureType(to: Error.self).eraseToAnyPublisher()
+        }
+        
         return Future { promise in
             Task {
                 do {
-                    let placeList = try await self.repository.fetchTimelinePlaces(keyword: keyword)
+                    let placeList = try await self.repository.fetchTimelinePlaces(keyword: keyword, offset: offset)
                     promise(.success(placeList))
                 } catch {
                     promise(.failure(error))

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/VC/LocationSearchVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/VC/LocationSearchVC.swift
@@ -20,6 +20,7 @@ final class LocationSearchVC: UIViewController {
         static let topInset: CGFloat = 27
         static let margin: CGFloat = 16
         static let contentHeight: CGFloat = 52
+        static let placeHeight: CGFloat = 65
     }
     
     private enum Constants {
@@ -56,6 +57,7 @@ final class LocationSearchVC: UIViewController {
         let tableView = UITableView()
         tableView.backgroundColor = TLColor.black
         tableView.keyboardDismissMode = .onDrag
+        tableView.register(PlaceTVC.self, forCellReuseIdentifier: PlaceTVC.identifier)
         
         return tableView
     }()
@@ -100,6 +102,7 @@ private extension LocationSearchVC {
         searchBar.delegate = self
         tableView.delegate = self
         tableView.dataSource = self
+        tableView.rowHeight = Metric.placeHeight
         
         closeButton.addTarget(
             self,
@@ -181,20 +184,14 @@ extension LocationSearchVC: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = UITableViewCell(style: .default, reuseIdentifier: .none)
-        let text = results[indexPath.row].title
-        cell.backgroundColor = TLColor.black
-        cell.textLabel?.text = text
-        cell.textLabel?.setColor(
-            to: TLColor.main,
-            range: text.findCommonWordRange(keyword)
-        )
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: PlaceTVC.identifier) as? PlaceTVC else { return UITableViewCell() }
+        
+        let title = results[indexPath.row].title
+        let address = results[indexPath.row].address
+        
+        cell.setData(place: title, address: address, keyword: keyword)
         
         return cell
-    }
-    
-    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return Metric.contentHeight
     }
     
 }

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/VC/LocationSearchVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/VC/LocationSearchVC.swift
@@ -68,7 +68,6 @@ final class LocationSearchVC: UIViewController {
     private var keyword: String = ""
     weak var delegate: LocationSearchDelegate?
     
-    private var isPaging: Bool = true
     let didScrollToBottom: PassthroughSubject<Void, Never> = .init()
     
     // MARK: - Life Cycle

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/VC/LocationSearchVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/VC/LocationSearchVC.swift
@@ -68,6 +68,9 @@ final class LocationSearchVC: UIViewController {
     private var keyword: String = ""
     weak var delegate: LocationSearchDelegate?
     
+    private var isPaging: Bool = true
+    let didScrollToBottom: PassthroughSubject<Void, Never> = .init()
+    
     // MARK: - Life Cycle
     
     override func viewDidLoad() {
@@ -148,7 +151,7 @@ private extension LocationSearchVC {
             searchBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             searchBar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             searchBar.heightAnchor.constraint(equalToConstant: Metric.contentHeight),
-           
+            
             tableView.topAnchor.constraint(equalTo: searchBar.bottomAnchor, constant: Metric.topInset),
             tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
@@ -177,7 +180,7 @@ extension LocationSearchVC: UITableViewDelegate {
 }
 
 // MARK: - UITableViewDataSource extension
-                            
+
 extension LocationSearchVC: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return results.count
@@ -192,6 +195,12 @@ extension LocationSearchVC: UITableViewDataSource {
         cell.setData(place: title, address: address, keyword: keyword)
         
         return cell
+    }
+    
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        if scrollView.contentOffset.y > scrollView.contentSize.height - scrollView.bounds.size.height {
+            didScrollToBottom.send(Void())
+        }
     }
     
 }

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/VC/TimelineWritingVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/VC/TimelineWritingVC.swift
@@ -286,6 +286,14 @@ private extension TimelineWritingVC {
             }
             .store(in: &cancellables)
         
+        locationSearchVC.didScrollToBottom
+            .throttle(for: 1.0, scheduler: RunLoop.main, latest: true)
+            .withUnretained(self)
+            .sink { owner, _ in
+                owner.viewModel.sendAction(.placeDidScrollToBottom)
+            }
+            .store(in: &cancellables)
+        
         viewModel.state
             .map(\.text)
             .filter { !$0.isEmpty }
@@ -314,7 +322,7 @@ private extension TimelineWritingVC {
             .store(in: &cancellables)
         
         viewModel.state
-            .compactMap(\.timelinePlaceList)
+            .map(\.timelinePlaceList)
             .removeDuplicates()
             .withUnretained(self)
             .sink { owner, list in

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/View/PlaceTVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/View/PlaceTVC.swift
@@ -1,0 +1,73 @@
+//
+//  PlaceTVC.swift
+//  traveline
+//
+//  Created by 김영인 on 2023/12/11.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import UIKit
+
+final class PlaceTVC: UITableViewCell {
+    
+    static let identifier = String(describing: type(of: PlaceTVC.self))
+    
+    private enum Metric {
+        static let inset: CGFloat = 16
+        static let spacing: CGFloat = 6
+    }
+    
+    // MARK: - UI Components
+    
+    private let placeStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.alignment = .leading
+        stackView.spacing = Metric.spacing
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+    
+    private let titleLabel: TLLabel = .init(font: .subtitle2, color: TLColor.white)
+    private let subtitleLabel: TLLabel = .init(font: .body3, color: TLColor.white)
+    
+    // MARK: - Initializer
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        
+        setupLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func setData(place: String, address: String, keyword: String) {
+        titleLabel.setText(to: place)
+        subtitleLabel.setText(to: address)
+        titleLabel.setColor(
+            to: TLColor.main,
+            range: place.findCommonWordRange(keyword)
+        )
+    }
+}
+
+// MARK: - Setup Functions
+
+extension PlaceTVC {
+    func setupLayout() {
+        placeStackView.addArrangedSubviews(titleLabel, subtitleLabel)
+        
+        placeStackView.arrangedSubviews.forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+        
+        addSubview(placeStackView)
+        
+        NSLayoutConstraint.activate([
+            placeStackView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            placeStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Metric.inset)
+        ])
+    }
+}


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- feature/#334

## 📚 작업한 내용
- 장소 검색에 주소 필드 추가
- 검색 결과 페이지네이션 구현
- 대소문자 관계없이 같은 문자열로 인식하도록 수정

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

### PlaceTVC 추가
기존에 기본 cell을 사용하고 있었는데 주소 라벨이 추가됨에 따라 새로운 cell인 PlaceTVC를 생성했습니다.

![image](https://github.com/boostcampwm2023/iOS07-traveline/assets/74968390/52a07801-f834-4c47-bfaa-9249baac0999)

### 페이지네이션 구현
offset 파라미터를 추가하는 방향으로 전체적으로 수정했습니다.
장소 검색 가장 아래 페이지에 닿으면 didScrollToBottom를 방출하고, WritingVC에선 이를 구독해서 offset을 변경시켜줍니다.
이 때, throttle(1초)를 걸어둬서 1초내로 오는 응답(didScrollToBottom)에 대해선 처리하지 않도록 했습니다.

### "" 키워드로 검색하면 500에러 뜨는 이슈
현재 place에 빈값을 보내면 500에러가 뜨는데요.
""키워드인 경우에 결과 리스트를 아예 비워야 하므로 해당 로직을 TimelineWritingUseCase에 추가해뒀습니다 !

## 📸 스크린샷
![Simulator Screen Recording - iPhone SE (3rd generation) - 2023-12-11 at 23 04 16](https://github.com/boostcampwm2023/iOS07-traveline/assets/74968390/9c177b78-1db9-416b-9701-fdba94521856)


## 관련 이슈
- Resolved: #334
