### PR TITLE
[feat] 타임라인 상세 수정, 삭제 연결

### DIFF
--- a/iOS/traveline/Sources/Core/Enum/VCFactory.swift
+++ b/iOS/traveline/Sources/Core/Enum/VCFactory.swift
@@ -82,7 +82,8 @@ enum VCFactory {
     static func makeTimelineWritingVC(
         id: TravelID,
         date: String,
-        day: Int
+        day: Int,
+        timelineDetailInfo: TimelineDetailInfo? = nil
     ) -> TimelineWritingVC {
         let repository = TimelineDetailRepositoryImpl(network: network)
         let useCase = TimelineWritingUseCaseImpl(repository: repository)
@@ -90,7 +91,8 @@ enum VCFactory {
             useCase: useCase,
             id: id,
             date: date,
-            day: day
+            day: day,
+            timelineDetailInfo: timelineDetailInfo
         )
         return TimelineWritingVC(viewModel: viewModel)
     }

--- a/iOS/traveline/Sources/Data/Network/API/TimelineDetailEndPoint.swift
+++ b/iOS/traveline/Sources/Data/Network/API/TimelineDetailEndPoint.swift
@@ -12,6 +12,7 @@ enum TimelineDetailEndPoint {
     case specificTimeline(String)
     case createTimeline(TimelineDetailRequestDTO)
     case fetchPlaceList(String, Int)
+    case putTimeline(String, TimelineDetailRequestDTO)
     case deleteTimeline(String)
 }
 
@@ -26,6 +27,9 @@ extension TimelineDetailEndPoint: EndPoint {
             
         case let .fetchPlaceList(keyword, offset):
             return "\(curPath)/map?place=\(keyword)&offset=\(offset)"
+            
+        case .putTimeline(let id, _):
+            return "\(curPath)/\(id)"
             
         case .deleteTimeline(let id):
             return "\(curPath)/\(id)"
@@ -42,6 +46,10 @@ extension TimelineDetailEndPoint: EndPoint {
             
         case .createTimeline:
             return .POST
+            
+        case .putTimeline:
+            return .PUT
+            
         case .deleteTimeline:
             return .DELETE
         }
@@ -52,6 +60,9 @@ extension TimelineDetailEndPoint: EndPoint {
         case .createTimeline(let timelineDetail):
             return timelineDetail
             
+        case .putTimeline(_, let timelineDetail):
+            return timelineDetail
+            
         default:
             return nil
         }
@@ -59,7 +70,7 @@ extension TimelineDetailEndPoint: EndPoint {
     
     var header: HeaderType {
         switch self {
-        case .createTimeline:
+        case .createTimeline, .putTimeline:
             return .multipart
             
         default:

--- a/iOS/traveline/Sources/Data/Network/API/TimelineDetailEndPoint.swift
+++ b/iOS/traveline/Sources/Data/Network/API/TimelineDetailEndPoint.swift
@@ -12,6 +12,7 @@ enum TimelineDetailEndPoint {
     case specificTimeline(String)
     case createTimeline(TimelineDetailRequestDTO)
     case fetchPlaceList(String, Int)
+    case deleteTimeline(String)
 }
 
 extension TimelineDetailEndPoint: EndPoint {
@@ -26,6 +27,9 @@ extension TimelineDetailEndPoint: EndPoint {
         case let .fetchPlaceList(keyword, offset):
             return "\(curPath)/map?place=\(keyword)&offset=\(offset)"
             
+        case .deleteTimeline(let id):
+            return "\(curPath)/\(id)"
+            
         default:
             return curPath
         }
@@ -38,6 +42,8 @@ extension TimelineDetailEndPoint: EndPoint {
             
         case .createTimeline:
             return .POST
+        case .deleteTimeline:
+            return .DELETE
         }
     }
     

--- a/iOS/traveline/Sources/Data/Network/DataMapping/TimelineDetailResponseDTO.swift
+++ b/iOS/traveline/Sources/Data/Network/DataMapping/TimelineDetailResponseDTO.swift
@@ -19,6 +19,12 @@ struct TimelineDetailResponseDTO: Decodable {
     let date: String
     let place: String
     let time: String
+    let isOwner: Bool
+    let posting: PostingID
+}
+
+struct PostingID: Decodable {
+    let id: String
 }
 
 // MARK: - Mapping
@@ -26,6 +32,7 @@ struct TimelineDetailResponseDTO: Decodable {
 extension TimelineDetailResponseDTO {
     func toDomain() -> TimelineDetailInfo {
         return .init(
+            postingID: posting.id,
             id: id,
             title: title,
             day: day,
@@ -35,7 +42,8 @@ extension TimelineDetailResponseDTO {
             coordY: coordY,
             date: date,
             location: place,
-            time: time
+            time: time,
+            isOwner: isOwner
         )
     }
     

--- a/iOS/traveline/Sources/Data/Repository/Mock/TimelineDetailRepositoryMock.swift
+++ b/iOS/traveline/Sources/Data/Repository/Mock/TimelineDetailRepositoryMock.swift
@@ -27,6 +27,13 @@ final class TimelineDetailRepositoryMock: TimelineDetailRepository {
         let mockData = [TimelinePlace.init(title: "", address: "", latitude: 0, longitude: 0)]
         return mockData
     }
+    
+    func putTimeline(id: String, info: TimelineDetailRequest) async throws -> Bool {
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+        
+        return true
+    }
+    
     func deleteTimeline(id: String) async throws -> Bool {
         try await Task.sleep(nanoseconds: 1_000_000_000)
         

--- a/iOS/traveline/Sources/Data/Repository/Mock/TimelineDetailRepositoryMock.swift
+++ b/iOS/traveline/Sources/Data/Repository/Mock/TimelineDetailRepositoryMock.swift
@@ -27,4 +27,9 @@ final class TimelineDetailRepositoryMock: TimelineDetailRepository {
         let mockData = [TimelinePlace.init(title: "", address: "", latitude: 0, longitude: 0)]
         return mockData
     }
+    func deleteTimeline(id: String) async throws -> Bool {
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+        
+        return true
+    }
 }

--- a/iOS/traveline/Sources/Data/Repository/TimelineDetailRepositoryImpl.swift
+++ b/iOS/traveline/Sources/Data/Repository/TimelineDetailRepositoryImpl.swift
@@ -41,4 +41,10 @@ final class TimelineDetailRepositoryImpl: TimelineDetailRepository {
         return timelinePlaceResponseDTO.toDomain()
     }
     
+    func deleteTimeline(id: String) async throws -> Bool {
+        let deleteTimelineDTO = try await network.requestWithNoResult(endPoint: TimelineDetailEndPoint.deleteTimeline(id))
+        
+        return deleteTimelineDTO
+    }
+    
 }

--- a/iOS/traveline/Sources/Data/Repository/TimelineDetailRepositoryImpl.swift
+++ b/iOS/traveline/Sources/Data/Repository/TimelineDetailRepositoryImpl.swift
@@ -41,6 +41,14 @@ final class TimelineDetailRepositoryImpl: TimelineDetailRepository {
         return timelinePlaceResponseDTO.toDomain()
     }
     
+    func putTimeline(id: String, info: TimelineDetailRequest) async throws -> Bool {
+        let putTimelineDTO = try await network.requestWithNoResult(
+            endPoint: TimelineDetailEndPoint.putTimeline(id, info.toDTO())
+        )
+        
+        return putTimelineDTO
+    }
+    
     func deleteTimeline(id: String) async throws -> Bool {
         let deleteTimelineDTO = try await network.requestWithNoResult(endPoint: TimelineDetailEndPoint.deleteTimeline(id))
         

--- a/iOS/traveline/Sources/Domain/Model/Timeline/TimelineDetailInfo.swift
+++ b/iOS/traveline/Sources/Domain/Model/Timeline/TimelineDetailInfo.swift
@@ -51,8 +51,4 @@ struct TimelineDetailInfo: Hashable {
         time: "07:30",
         isOwner: false
     )
-    
-    static func == (lhs: TimelineDetailInfo, rhs: TimelineDetailInfo) -> Bool {
-        lhs.id == rhs.id
-    }
 }

--- a/iOS/traveline/Sources/Domain/Model/Timeline/TimelineDetailInfo.swift
+++ b/iOS/traveline/Sources/Domain/Model/Timeline/TimelineDetailInfo.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 struct TimelineDetailInfo: Hashable {
+    let postingID: String
     let id: String
     let title: String
     let day: Int
@@ -19,8 +20,10 @@ struct TimelineDetailInfo: Hashable {
     let date: String
     let location: String
     let time: String
+    let isOwner: Bool
     
     static let empty: TimelineDetailInfo = .init(
+        postingID: Literal.empty,
         id: Literal.empty,
         title: Literal.empty,
         day: 0,
@@ -30,10 +33,12 @@ struct TimelineDetailInfo: Hashable {
         coordY: nil,
         date: Literal.empty,
         location: Literal.empty,
-        time: Literal.empty
+        time: Literal.empty,
+        isOwner: false
     )
     
     static let sample: TimelineDetailInfo = .init(
+        postingID: "9a0396ba-4892-436a-a97c-58be59b59327",
         id: "ae12a997-159c-40d1-b3c6-62af7fd981d1",
         title: "두근두근 출발 날 😍",
         day: 1,
@@ -43,7 +48,8 @@ struct TimelineDetailInfo: Hashable {
         coordY: 100.3,
         date: "2023-08-16",
         location: "서울역",
-        time: "07:30"
+        time: "07:30",
+        isOwner: false
     )
     
     static func == (lhs: TimelineDetailInfo, rhs: TimelineDetailInfo) -> Bool {

--- a/iOS/traveline/Sources/Domain/Model/Timeline/TimelineDetailRequest.swift
+++ b/iOS/traveline/Sources/Domain/Model/Timeline/TimelineDetailRequest.swift
@@ -23,7 +23,6 @@ struct TimelineDetailRequest {
         day: 0,
         time: Literal.empty,
         date: Literal.empty,
-        place: .emtpy,
         content: Literal.empty,
         posting: Literal.empty
     )

--- a/iOS/traveline/Sources/Domain/RepositoryInterface/TimelineDetailRepository.swift
+++ b/iOS/traveline/Sources/Domain/RepositoryInterface/TimelineDetailRepository.swift
@@ -12,5 +12,6 @@ protocol TimelineDetailRepository {
     func fetchTimelineDetailInfo(id: String) async throws -> TimelineDetailInfo
     func createTimelineDetail(with timelineRequest: TimelineDetailRequest) async throws
     func fetchTimelinePlaces(keyword: String, offset: Int) async throws -> TimelinePlaceList
+    func putTimeline(id: String, info: TimelineDetailRequest) async throws -> Bool
     func deleteTimeline(id: String) async throws -> Bool
 }

--- a/iOS/traveline/Sources/Domain/RepositoryInterface/TimelineDetailRepository.swift
+++ b/iOS/traveline/Sources/Domain/RepositoryInterface/TimelineDetailRepository.swift
@@ -12,4 +12,5 @@ protocol TimelineDetailRepository {
     func fetchTimelineDetailInfo(id: String) async throws -> TimelineDetailInfo
     func createTimelineDetail(with timelineRequest: TimelineDetailRequest) async throws
     func fetchTimelinePlaces(keyword: String, offset: Int) async throws -> TimelinePlaceList
+    func deleteTimeline(id: String) async throws -> Bool
 }

--- a/iOS/traveline/Sources/Domain/UseCase/TimelineDetailUseCase.swift
+++ b/iOS/traveline/Sources/Domain/UseCase/TimelineDetailUseCase.swift
@@ -11,6 +11,7 @@ import Foundation
 
 protocol TimelineDetailUseCase {
     func fetchTimelineDetail(with id: String) -> AnyPublisher<TimelineDetailInfo, Error>
+    func deleteTimeline(id: String) -> AnyPublisher<Bool, Error>
 }
 
 final class TimelineDetailUseCaseImpl: TimelineDetailUseCase {
@@ -35,4 +36,16 @@ final class TimelineDetailUseCaseImpl: TimelineDetailUseCase {
         }.eraseToAnyPublisher()
     }
     
+    func deleteTimeline(id: String) -> AnyPublisher<Bool, Error> {
+        return Future { promise in
+            Task {
+                do {
+                    let result = try await self.repository.deleteTimeline(id: id)
+                    promise(.success(result))
+                } catch {
+                    promise(.failure(error))
+                }
+            }
+        }.eraseToAnyPublisher()
+    }
 }

--- a/iOS/traveline/Sources/Domain/UseCase/TimelineWritingUseCase.swift
+++ b/iOS/traveline/Sources/Domain/UseCase/TimelineWritingUseCase.swift
@@ -75,6 +75,7 @@ final class TimelineWritingUseCaseImpl: TimelineWritingUseCase {
             date: info.date,
             place: .init(
                 title: info.location,
+                address: Literal.empty,
                 latitude: info.coordY ?? 0.0,
                 longitude: info.coordX ?? 0.0
             ),

--- a/iOS/traveline/Sources/Domain/UseCase/TimelineWritingUseCase.swift
+++ b/iOS/traveline/Sources/Domain/UseCase/TimelineWritingUseCase.swift
@@ -12,6 +12,8 @@ import Foundation
 protocol TimelineWritingUseCase {
     func requestCreateTimeline(with info: TimelineDetailRequest) -> AnyPublisher<Void, Error>
     func fetchPlaceList(keyword: String, offset: Int) -> AnyPublisher<TimelinePlaceList, Error>
+    func putTimeline(id: String, info: TimelineDetailRequest) -> AnyPublisher<Bool, Error>
+    func toTimelineDetailRequest(from info: TimelineDetailInfo) -> TimelineDetailRequest
 }
 
 final class TimelineWritingUseCaseImpl: TimelineWritingUseCase {
@@ -52,4 +54,32 @@ final class TimelineWritingUseCaseImpl: TimelineWritingUseCase {
         }.eraseToAnyPublisher()
     }
     
+    func putTimeline(id: String, info: TimelineDetailRequest) -> AnyPublisher<Bool, Error> {
+        return Future { promise in
+            Task {
+                do {
+                    let result = try await self.repository.putTimeline(id: id, info: info)
+                    promise(.success(result))
+                } catch {
+                    promise(.failure(error))
+                }
+            }
+        }.eraseToAnyPublisher()
+    }
+    
+    func toTimelineDetailRequest(from info: TimelineDetailInfo) -> TimelineDetailRequest {
+        return .init(
+            title: info.title,
+            day: info.day,
+            time: info.time,
+            date: info.date,
+            place: .init(
+                title: info.location,
+                latitude: info.coordY ?? 0.0,
+                longitude: info.coordX ?? 0.0
+            ),
+            content: info.description,
+            posting: info.postingID
+        )
+    }
 }

--- a/iOS/traveline/Sources/Feature/TimelineDetailFeature/TimelineDetailScene/VC/TimelineDetailVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineDetailFeature/TimelineDetailScene/VC/TimelineDetailVC.swift
@@ -103,6 +103,26 @@ final class TimelineDetailVC: UIViewController {
         imageView.setImage(from: url)
     }
     
+    private func setNavigationRightButton(isOwner: Bool) {
+        var menuItems: [UIAction] = []
+        
+        if isOwner {
+            menuItems = [
+                .init(title: Literal.Action.modify, handler: { [weak self] _ in
+                    self?.viewModel.sendAction(.editTimeline)
+                }),
+                .init(title: Literal.Action.delete, attributes: .destructive, handler: {  [weak self] _ in
+                    self?.viewModel.sendAction(.deleteTimeline)
+                })
+            ]
+        }
+        
+        tlNavigationBar.addRightButton(
+            image: TLImage.Travel.more,
+            menu: .init(children: menuItems)
+        )
+    }
+    
 }
 
 // MARK: - Setup Functions
@@ -172,7 +192,6 @@ private extension TimelineDetailVC {
     }
     
     private func bind() {
-        
         viewModel.state
             .map(\.timelineDetailInfo)
             .removeDuplicates()
@@ -181,5 +200,23 @@ private extension TimelineDetailVC {
                 owner.updateUI(with: info)
             }
             .store(in: &cancellables)
+        
+        viewModel.state
+            .map(\.isOwner)
+            .withUnretained(self)
+            .sink { owner, isOwner in
+                owner.setNavigationRightButton(isOwner: isOwner)
+            }
+            .store(in: &cancellables)
+        
+        viewModel.state
+            .map(\.isDeleteCompleted)
+            .filter { $0 }
+            .withUnretained(self)
+            .sink { owner, _ in
+                owner.navigationController?.popViewController(animated: true)
+            }
+            .store(in: &cancellables)
+        
     }
 }

--- a/iOS/traveline/Sources/Feature/TimelineDetailFeature/TimelineDetailScene/VC/TimelineDetailVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineDetailFeature/TimelineDetailScene/VC/TimelineDetailVC.swift
@@ -75,11 +75,16 @@ final class TimelineDetailVC: UIViewController {
         setupAttributes()
         setupLayout()
         bind()
-        viewModel.sendAction(.viewDidLoad)
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        viewModel.sendAction(.viewWillAppear)
     }
     
     // MARK: - Functions
@@ -218,5 +223,21 @@ private extension TimelineDetailVC {
             }
             .store(in: &cancellables)
         
+        viewModel.state
+            .map(\.isEdit)
+            .filter { $0 }
+            .removeDuplicates()
+            .withUnretained(self)
+            .sink { owner, _ in
+                let timelineDetailInfo = owner.viewModel.currentState.timelineDetailInfo
+                let timelineEditVC = VCFactory.makeTimelineWritingVC(
+                    id: .init(value: timelineDetailInfo.postingID),
+                    date: timelineDetailInfo.date,
+                    day: timelineDetailInfo.day,
+                    timelineDetailInfo: timelineDetailInfo
+                )
+                owner.navigationController?.pushViewController(timelineEditVC, animated: true)
+            }
+            .store(in: &cancellables)
     }
 }

--- a/iOS/traveline/Sources/Feature/TimelineDetailFeature/TimelineDetailScene/ViewModel/TimelineDetailViewModel.swift
+++ b/iOS/traveline/Sources/Feature/TimelineDetailFeature/TimelineDetailScene/ViewModel/TimelineDetailViewModel.swift
@@ -10,17 +10,35 @@ import Combine
 import Foundation
 
 enum TimelineDetailAction: BaseAction {
-    case viewDidLoad
+    case viewWillAppear
+    case editTimeline
+    case deleteTimeline
 }
 
 enum TimelineDetailSideEffect: BaseSideEffect {
-    case loadTimelineDetail(TimelineDetailInfo)
-    case loadFailed
+    enum TimelineDetailError: LocalizedError {
+        case loadFailed
+        case deleteFailed
+        
+        var errorDescription: String? {
+            switch self {
+            case .loadFailed: "서버 통신에 실패했습니다."
+            case .deleteFailed: "타임라인 삭제에 실패했습니다."
+            }
+        }
+    }
     
+    case loadTimelineDetail(TimelineDetailInfo)
+    case timelineDetailError(TimelineDetailError)
+    case popToTimeline(Bool)
+    case showTimelineDetailEditing
 }
 
 struct TimelineDetailState: BaseState {
     var timelineDetailInfo: TimelineDetailInfo = .empty
+    var isOwner: Bool = false
+    var isDeleteCompleted: Bool = false
+    var isEdit: Bool = false
 }
 
 final class TimelineDetailViewModel: BaseViewModel<TimelineDetailAction, TimelineDetailSideEffect, TimelineDetailState> {
@@ -35,8 +53,14 @@ final class TimelineDetailViewModel: BaseViewModel<TimelineDetailAction, Timelin
     
     override func transform(action: Action) -> SideEffectPublisher {
         switch action {
-        case .viewDidLoad:
+        case .viewWillAppear:
             return loadTimelineDetailInfo()
+            
+        case .editTimeline:
+            return .just(.showTimelineDetailEditing)
+            
+        case .deleteTimeline:
+            return deleteTimeline()
         }
     }
 
@@ -46,8 +70,16 @@ final class TimelineDetailViewModel: BaseViewModel<TimelineDetailAction, Timelin
         switch effect {
         case .loadTimelineDetail(let info):
             newState.timelineDetailInfo = info
-        case .loadFailed:
-            break
+            newState.isOwner = info.isOwner
+            
+        case let .popToTimeline(isSuccess):
+            newState.isDeleteCompleted = isSuccess
+            
+        case .showTimelineDetailEditing:
+            newState.isEdit = true
+            
+        case let .timelineDetailError(error):
+            print(error)
         }
         
         return newState
@@ -60,8 +92,19 @@ private extension TimelineDetailViewModel {
             .map { info in
                 return TimelineDetailSideEffect.loadTimelineDetail(info)
             }
-            .catch { error in
-                return Just(TimelineDetailSideEffect.loadFailed)
+            .catch { _ in
+                return Just(TimelineDetailSideEffect.timelineDetailError(.loadFailed))
+            }
+            .eraseToAnyPublisher()
+    }
+    
+    func deleteTimeline() -> SideEffectPublisher {
+        return timelineDetailUseCase.deleteTimeline(id: id)
+            .map { isSuccess in
+                return .popToTimeline(isSuccess)
+            }
+            .catch { _ in
+                return Just(TimelineDetailSideEffect.timelineDetailError(.deleteFailed))
             }
             .eraseToAnyPublisher()
     }

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/View/SelectImageButton.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/View/SelectImageButton.swift
@@ -97,6 +97,11 @@ final class SelectImageButton: UIView {
         updateView()
     }
     
+    func setImage(urlString: String?) {
+        imageView.setImage(from: urlString)
+        updateView()
+    }
+    
 }
 
 // MARK: - Setup Functions

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/ViewModel/TimelineWritingViewModel.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/ViewModel/TimelineWritingViewModel.swift
@@ -70,12 +70,18 @@ final class TimelineWritingViewModel: BaseViewModel<TimelineWritingAction, Timel
         useCase: TimelineWritingUseCase,
         id: TravelID,
         date: String,
-        day: Int
+        day: Int,
+        timelineDetailInfo: TimelineDetailInfo?
     ) {
         self.useCase = useCase
         self.id = id
         self.date = date
         self.day = day
+        self.timelineID = timelineDetailInfo?.id
+        super.init()
+        
+        guard let timelineDetailInfo else { return }
+        sendAction(.configTimelineDetailInfo(timelineDetailInfo))
     }
     
     override func transform(action: TimelineWritingAction) -> SideEffectPublisher {

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/ViewModel/TimelineWritingViewModel.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/ViewModel/TimelineWritingViewModel.swift
@@ -27,11 +27,13 @@ enum TimelineWritingSideEffect: BaseSideEffect {
     enum TimelineWritingError: LocalizedError {
         case createError
         case placeError
+        case putError
         
         var errorDescription: String {
             switch self {
             case .createError: "타임라인 생성에 실패했습니다."
             case .placeError: "장소 검색에 실패했습니다."
+            case .putError: "타임라인 수정에 실패했습니다."
             }
         }
     }
@@ -230,7 +232,7 @@ private extension TimelineWritingViewModel {
             .map { isSuccess in
                 return .popToTimelineDetail(isSuccess)
             } .catch { _ in
-                return Just(SideEffect.error("failed put timeline"))
+                return Just(.error(.putError))
             }
             .eraseToAnyPublisher()
     }


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- feature/#329

## 📚 작업한 내용
### 타임라인 상세 수정, 삭제 연결
- 현재 삭제는 정상적으로 작동하고, 타임라인으로 돌아왔을 때 정상적으로 업데이트 되고 있습니다!
- 다만 지금 수정에서 아래 여러가지 문제가 발생하고 있는데요.. 더이상 수정하자면 시간이 오래 걸릴 수 있을 것 같아 일단 PR 올립니더,,,,,,
1. 지속적으로 수정 시 다운샘플링이 중복 적용 (기 공유된 사항)
2. 수정 화면에서 이미지 갤러리에서 선택 시 간헐적으로 버튼에 이미지가 업데이트 되지 않는 현상
3. 수정 화면에서 기존 이미지가 있을 때 이미지 갤러리에서 선택 시 업데이트 안되거나, 글자 입력 시 기존 이미지로 바뀌는 현상
4. 이미지만 변경했을 시 완료 버튼 활성화 되지 않음
4-1. 해당 원인은 이미지 데이터를 가져오는 시점을 완료 버튼 눌렀을 때로 변경하게 되었는데 (TimelineDetailVC에서 받아온 이미지는 String이기 때문에) 이 때문이 아닌가 싶긴합니다.
5. ~~수정 성공 후 다시 TimelineDetail 화면으로 pop 되었을 때 Detail이 업데이트 되지 않는 현상~~
- ~~해당 부분을 TimelineDetailVC의 viewWillAppear로 처리해두었고, 서버 통신도 성공하지만 뷰가 업데이트 되지 않는 것인지 서버 데이터가 변경되지 않은 것인지 확인이 안되었습니다.~~
- 해당 부분 Hashable 문제로 파악돼서 해결했습니다~!


## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
너무 많은 문제가 남아버렸네요,,,,,, 죄송함니다 😢
영상에는 반영 안됐지만 지금 수정하고 Detail로 넘어가면 수정사항 반영됩니다!


## 📸 스크린샷

https://github.com/boostcampwm2023/iOS07-traveline/assets/51712973/8841b790-1eae-4aa3-b99d-43453a2e0dbb



## 관련 이슈
- Resolved: #329 
