### PR TITLE
[chore] image URL 반환 시 image Path 필드도 함께 반환하게 함

### DIFF
--- a/BE/src/postings/postings.service.ts
+++ b/BE/src/postings/postings.service.ts
@@ -205,6 +205,7 @@ export class PostingsService {
       thumbnail: posting.p_thumbnail
         ? await this.storageService.getImageUrl(posting.p_thumbnail)
         : null,
+      thumbnailPath: posting.p_thumbnail,
       period: posting.p_period,
       headcount: posting.p_headcount,
       budget: posting.p_budget,
@@ -219,6 +220,7 @@ export class PostingsService {
         avatar: posting.u_avatar
           ? await this.storageService.getImageUrl(posting.u_avatar)
           : null,
+        avatarPath: posting.u_avatar,
       },
       likeds: posting.likeds,
       reports: posting.reports,

--- a/BE/src/timelines/timelines.service.ts
+++ b/BE/src/timelines/timelines.service.ts
@@ -68,6 +68,7 @@ export class TimelinesService {
         return {
           ...timeline,
           image: imageUrl,
+          imagePath: timeline.image,
         };
       })
     );
@@ -75,12 +76,13 @@ export class TimelinesService {
 
   async findOneWithURL(id: string) {
     const timeline = await this.findOne(id);
+    const imagePath = timeline.image;
 
-    if (timeline.image) {
-      timeline.image = await this.storageService.getImageUrl(timeline.image);
+    if (imagePath) {
+      timeline.image = await this.storageService.getImageUrl(imagePath);
     }
 
-    return timeline;
+    return { ...timeline, imagePath };
   }
 
   @Transactional()


### PR DESCRIPTION
thumbnailPath, imagePath, avatarPath

## 🌎 PR 요약

🌱 작업한 브랜치
- be-feature/#364-imagePath

## 📚 작업한 내용
- 이미지 path 필드 추가
    - thumbnailPath
    - iamgePath
    - avatarPath

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

- UsersService에서 사용자 정보를 반환할 때도 avatarPath를 반환하려고 했지만, 반환 DTO에 avatarPath가 없어서 해당 필드를 함께 반환하려면
    - UserInfoDto에 avatarPath를 추가하거나
    - 해당 메서드의 반환 타입에서 UserInfoDto를 지우거나
    - 해야 하는데 둘 다 제가 섣불리 건드리긴 좀 그러하여 ㅎㅎ... 사용자 정보 반환 쪽은 수정 안 했습니다.
    - 혹시 필요하다면 수정해주시면 될 것 같아요!

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 관련 이슈
- Close: #364
