### PR TITLE
[refactor] Future-Task 개선

### DIFF
--- a/iOS/traveline/Sources/Core/Extension/Future+.swift
+++ b/iOS/traveline/Sources/Core/Extension/Future+.swift
@@ -1,0 +1,42 @@
+//
+//  Future+.swift
+//  traveline
+//
+//  Created by 김태현 on 12/14/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Combine
+import Foundation
+
+extension Future where Failure == Error {
+    
+    /// async 응답 결과를 Future publisher로 변환합니다.
+    /// - Parameter asyncFulfill: 변환할 async 응답
+    convenience init(_ asyncFulfill: @escaping () async throws -> Output) {
+        self.init { promise in
+            Task {
+                do {
+                    let result = try await asyncFulfill()
+                    promise(.success(result))
+                } catch {
+                    promise(.failure(error))
+                }
+            }
+        }
+    }
+}
+
+extension Future where Failure == Never {
+    
+    /// async 응답 결과를 Future publisher로 변환합니다.
+    /// - Parameter asyncFulfill: 변환할 async 응답
+    convenience init(_ asyncFulfill: @escaping () async -> Output) {
+        self.init { promise in
+            Task {
+                let result = await asyncFulfill()
+                promise(.success(result))
+            }
+        }
+    }
+}

--- a/iOS/traveline/Sources/Domain/UseCase/AutoLoginUseCase.swift
+++ b/iOS/traveline/Sources/Domain/UseCase/AutoLoginUseCase.swift
@@ -22,16 +22,11 @@ final class AutoLoginUseCaseImpl: AutoLoginUseCase {
     }
     
     func requestLogin() -> AnyPublisher<Bool, Error> {
-        return Future { promise in
-            Task {
-                do {
-                    let accessToken = try await self.repository.refresh()
-                    KeychainList.accessToken = accessToken
-                    promise(.success(true))
-                } catch {
-                    promise(.failure(error))
-                }
-            }
+        return Future {
+            let accessToken = try await self.repository.refresh()
+            KeychainList.accessToken = accessToken
+            return true
         }.eraseToAnyPublisher()
     }
+    
 }

--- a/iOS/traveline/Sources/Domain/UseCase/HomeUseCase.swift
+++ b/iOS/traveline/Sources/Domain/UseCase/HomeUseCase.swift
@@ -26,16 +26,9 @@ final class HomeUseCaseImpl: HomeUseCase {
     }
     
     func fetchSearchList(with query: SearchQuery) -> AnyPublisher<TravelList, Error> {
-        return Future { promise in
-            Task { [weak self] in
-                guard let self else { return }
-                do {
-                    let travelList = try await self.repository.fetchPostingList(with: query)
-                    promise(.success(travelList))
-                } catch {
-                    promise(.failure(error))
-                }
-            }
+        return Future {
+            let travelList = try await self.repository.fetchPostingList(with: query)
+            return travelList
         }.eraseToAnyPublisher()
     }
     
@@ -68,16 +61,9 @@ final class HomeUseCaseImpl: HomeUseCase {
     }
     
     func fetchRelatedKeyword(_ keyword: String) -> AnyPublisher<SearchKeywordList, Error> {
-        return Future { promise in
-            Task { [weak self] in
-                guard let self else { return }
-                do {
-                    let relatedKeyword = try await self.repository.fetchPostingTitleList(keyword)
-                    promise(.success(relatedKeyword))
-                } catch {
-                    promise(.failure(error))
-                }
-            }
+        return Future {
+            let relatedKeyword = try await self.repository.fetchPostingTitleList(keyword)
+            return relatedKeyword
         }.eraseToAnyPublisher()
     }
     

--- a/iOS/traveline/Sources/Domain/UseCase/LoginUseCase.swift
+++ b/iOS/traveline/Sources/Domain/UseCase/LoginUseCase.swift
@@ -22,17 +22,12 @@ final class LoginUseCaseImpl: LoginUseCase {
     }
     
     func requestLogin(with info: AppleLoginRequest) -> AnyPublisher<Bool, Error> {
-        return Future { promise in
-            Task {
-                do {
-                    let tlToken = try await self.repository.appleLogin(with: info)
-                    KeychainList.accessToken = tlToken.accessToken
-                    KeychainList.refreshToken = tlToken.refreshToken
-                    promise(.success(true))
-                } catch {
-                    promise(.failure(error))
-                }
-            }
+        return Future {
+            let tlToken = try await self.repository.appleLogin(with: info)
+            KeychainList.accessToken = tlToken.accessToken
+            KeychainList.refreshToken = tlToken.refreshToken
+            return true
         }.eraseToAnyPublisher()
     }
+    
 }

--- a/iOS/traveline/Sources/Domain/UseCase/MyPostingListUseCase.swift
+++ b/iOS/traveline/Sources/Domain/UseCase/MyPostingListUseCase.swift
@@ -22,16 +22,9 @@ final class MyPostListUseCaseImpl: MyPostListUseCase {
     }
     
     func fetchMyPostList() -> AnyPublisher<TravelList, Error> {
-        return Future { promise in
-            Task { [weak self] in
-                guard let self else { return }
-                do {
-                    let travelList = try await self.repository.fetchMyPostingList()
-                    promise(.success(travelList))
-                } catch {
-                    promise(.failure(error))
-                }
-            }
+        return Future {
+            let travelList = try await self.repository.fetchMyPostingList()
+            return travelList
         }.eraseToAnyPublisher()
     }
     

--- a/iOS/traveline/Sources/Domain/UseCase/SettingUseCase.swift
+++ b/iOS/traveline/Sources/Domain/UseCase/SettingUseCase.swift
@@ -31,17 +31,11 @@ final class SettingUseCaseImpl: SettingUseCase {
         return repository.requestAppleId()
     }
     
-    func requestWithdrawal(_ reqeust: WithdrawRequest) -> AnyPublisher<Bool, Error> {
-        return Future<Bool, Error> { promise in
-            Task {
-                do {
-                    let result = try await self.repository.withdrawal(reqeust)
-                    KeychainList.allClear()
-                    promise(.success(result))
-                } catch {
-                    promise(.failure(error))
-                }
-            }
+    func requestWithdrawal(_ request: WithdrawRequest) -> AnyPublisher<Bool, Error> {
+        return Future {
+            let result = try await self.repository.withdrawal(request)
+            KeychainList.allClear()
+            return result
         }.eraseToAnyPublisher()
     }
     

--- a/iOS/traveline/Sources/Domain/UseCase/SideMenuUseCase.swift
+++ b/iOS/traveline/Sources/Domain/UseCase/SideMenuUseCase.swift
@@ -22,15 +22,9 @@ final class SideMenuUseCaseImpl: SideMenuUseCase {
     }
     
     func fetchProfile() -> AnyPublisher<Profile, Error> {
-        return Future { promise in
-            Task {
-                do {
-                    let profile = try await self.repository.fetchUserInfo()
-                    promise(.success(profile))
-                } catch {
-                    promise(.failure(error))
-                }
-            }
+        return Future {
+            let profile = try await self.repository.fetchUserInfo()
+            return profile
         }.eraseToAnyPublisher()
     }
     

--- a/iOS/traveline/Sources/Domain/UseCase/TimelineDetailUseCase.swift
+++ b/iOS/traveline/Sources/Domain/UseCase/TimelineDetailUseCase.swift
@@ -23,29 +23,17 @@ final class TimelineDetailUseCaseImpl: TimelineDetailUseCase {
     }
     
     func fetchTimelineDetail(with id: String) -> AnyPublisher<TimelineDetailInfo, Error> {
-        return Future { promise in
-            Task { [weak self] in
-                guard let self else { return }
-                do {
-                    let detailInfo = try await self.repository.fetchTimelineDetailInfo(id: id)
-                    promise(.success(detailInfo))
-                } catch {
-                    promise(.failure(error))
-                }
-            }
+        return Future {
+            let detailInfo = try await self.repository.fetchTimelineDetailInfo(id: id)
+            return detailInfo
         }.eraseToAnyPublisher()
     }
     
     func deleteTimeline(id: String) -> AnyPublisher<Bool, Error> {
-        return Future { promise in
-            Task {
-                do {
-                    let result = try await self.repository.deleteTimeline(id: id)
-                    promise(.success(result))
-                } catch {
-                    promise(.failure(error))
-                }
-            }
+        return Future {
+            let result = try await self.repository.deleteTimeline(id: id)
+            return result
         }.eraseToAnyPublisher()
     }
+    
 }

--- a/iOS/traveline/Sources/Domain/UseCase/TimelineUseCase.swift
+++ b/iOS/traveline/Sources/Domain/UseCase/TimelineUseCase.swift
@@ -29,30 +29,17 @@ final class TimelineUseCaseImpl: TimelineUseCase {
     }
 
     func fetchTimelineInfo(id: TravelID) -> AnyPublisher<TimelineTravelInfo, Error> {
-        return Future { promise in
-            Task {
-                do {
-                    let travelInfo = try await self.postingRepository.fetchTimelineInfo(id: id)
-                    promise(.success(travelInfo))
-                } catch {
-                    promise(.failure(error))
-                }
-            }
+        return Future {
+            let travelInfo = try await self.postingRepository.fetchTimelineInfo(id: id)
+            return travelInfo
         }.eraseToAnyPublisher()
     }
     
     func fetchTimelineList(id: TravelID, day: Int) -> AnyPublisher<TimelineCardList, Error> {
-        return Future { promise in
-            Task {
-                do {
-                    let timelineList = try await self.timelineRepository.fetchTimelineList(id: id, day: day)
-                    promise(.success(timelineList))
-                } catch {
-                    promise(.failure(error))
-                }
-            }
-        }
-        .eraseToAnyPublisher()
+        return Future {
+            let timelineList = try await self.timelineRepository.fetchTimelineList(id: id, day: day)
+            return timelineList
+        }.eraseToAnyPublisher()
     }
     
     func calculateDate(from startDate: String, with day: Int) -> String? {
@@ -64,41 +51,23 @@ final class TimelineUseCaseImpl: TimelineUseCase {
     }
     
     func deleteTravel(id: TravelID) -> AnyPublisher<Bool, Error> {
-        return Future { promise in
-            Task {
-                do {
-                    let result = try await self.postingRepository.deletePosting(id: id)
-                    promise(.success(result))
-                } catch {
-                    promise(.failure(error))
-                }
-            }
+        return Future {
+            let result = try await self.postingRepository.deletePosting(id: id)
+            return result
         }.eraseToAnyPublisher()
     }
     
     func reportTravel(id: TravelID) -> AnyPublisher<Bool, Error> {
-        return Future { promise in
-            Task {
-                do {
-                    let result = try await self.postingRepository.postReport(id: id)
-                    promise(.success(result))
-                } catch {
-                    promise(.failure(error))
-                }
-            }
+        return Future {
+            let result = try await self.postingRepository.postReport(id: id)
+            return result
         }.eraseToAnyPublisher()
     }
     
     func likeTravel(id: TravelID) -> AnyPublisher<Bool, Error> {
-        return Future { promise in
-            Task {
-                do {
-                    let result = try await self.postingRepository.postLike(id: id)
-                    promise(.success(result))
-                } catch {
-                    promise(.failure(error))
-                }
-            }
+        return Future {
+            let result = try await self.postingRepository.postLike(id: id)
+            return result
         }.eraseToAnyPublisher()
     }
     

--- a/iOS/traveline/Sources/Domain/UseCase/TimelineWritingUseCase.swift
+++ b/iOS/traveline/Sources/Domain/UseCase/TimelineWritingUseCase.swift
@@ -25,15 +25,8 @@ final class TimelineWritingUseCaseImpl: TimelineWritingUseCase {
     }
     
     func requestCreateTimeline(with info: TimelineDetailRequest) -> AnyPublisher<Void, Error> {
-        return Future { promise in
-            Task {
-                do {
-                    try await self.repository.createTimelineDetail(with: info)
-                    promise(.success(Void()))
-                } catch {
-                    promise(.failure(error))
-                }
-            }
+        return Future {
+            try await self.repository.createTimelineDetail(with: info)
         }.eraseToAnyPublisher()
     }
     
@@ -42,28 +35,16 @@ final class TimelineWritingUseCaseImpl: TimelineWritingUseCase {
             return .just([]).setFailureType(to: Error.self).eraseToAnyPublisher()
         }
         
-        return Future { promise in
-            Task {
-                do {
-                    let placeList = try await self.repository.fetchTimelinePlaces(keyword: keyword, offset: offset)
-                    promise(.success(placeList))
-                } catch {
-                    promise(.failure(error))
-                }
-            }
+        return Future {
+            let placeList = try await self.repository.fetchTimelinePlaces(keyword: keyword, offset: offset)
+            return placeList
         }.eraseToAnyPublisher()
     }
     
     func putTimeline(id: String, info: TimelineDetailRequest) -> AnyPublisher<Bool, Error> {
-        return Future { promise in
-            Task {
-                do {
-                    let result = try await self.repository.putTimeline(id: id, info: info)
-                    promise(.success(result))
-                } catch {
-                    promise(.failure(error))
-                }
-            }
+        return Future {
+            let result = try await self.repository.putTimeline(id: id, info: info)
+            return result
         }.eraseToAnyPublisher()
     }
     

--- a/iOS/traveline/Sources/Domain/UseCase/TravelUseCase.swift
+++ b/iOS/traveline/Sources/Domain/UseCase/TravelUseCase.swift
@@ -44,31 +44,16 @@ final class TravelUseCaseImpl: TravelUseCase {
     }
     
     func createTravel(data: TravelRequest) -> AnyPublisher<TravelID, Error> {
-        return Future { promise in
-            Task {
-                do {
-                    let id = try await self.repository.postPosting(data: data)
-                    promise(.success(id))
-                } catch {
-                    promise(.failure(error))
-                }
-            }
+        return Future {
+            let id = try await self.repository.postPosting(data: data)
+            return id
         }.eraseToAnyPublisher()
     }
     
     func putTravel(id: TravelID, data: TravelRequest) -> AnyPublisher<TravelID, Error> {
-        return Future { promise in
-            Task {
-                do {
-                    let id = try await self.repository.putPosting(
-                        id: id,
-                        data: data
-                    )
-                    promise(.success(id))
-                } catch {
-                    promise(.failure(error))
-                }
-            }
+        return Future {
+            let id = try await self.repository.putPosting(id: id, data: data)
+            return id
         }.eraseToAnyPublisher()
     }
     


### PR DESCRIPTION
## 🌎 PR 요약
- Future Extension을 통한 Future-Task 개선

🌱 작업한 브랜치
- feature/#373

## 📚 작업한 내용
### Future Extension 구현
- 아래와 같이 Future Extension에 convenience init으로 async 응답을 Future publisher로 변환할 수 있도록 구현했습니다!
~~~swift
/// async 응답 결과를 Future publisher로 변환합니다.
/// - Parameter asyncFulfill: 변환할 async 응답
convenience init(_ asyncFulfill: @escaping () async throws -> Output) {
    self.init { promise in
        Task {
            do {
                let result = try await asyncFulfill()
                promise(.success(result))
            } catch {
                promise(.failure(error))
            }
        }
    }
}
~~~
- 사용하는 곳에서는 아래와 같이 async한 결과 값을 넘겨주면 됩니다 ㅎ
- 기존과 동일하게 비즈니스 로직 처리 후 return 해주시면 됩니다!
~~~swift
func fetchSearchList(with query: SearchQuery) -> AnyPublisher<TravelList, Error> {
    return Future {
        let travelList = try await self.repository.fetchPostingList(with: query)
        return travelList
    }.eraseToAnyPublisher()
}
~~~
- 코드 뎁스도 얕아지고 좀 더 직관적으로 쓸 수 있는 것 같습니닷

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
마찬가지로 한번 싹 돌면서 테스트하긴 했는데 혹시 문제가 생긴 부분이 있으면 말씀주시면 감사드림다 😉

## 📸 스크린샷
|변경 전|
|:--:|
|![스크린샷 2023-12-14 오전 11 35 39](https://github.com/boostcampwm2023/iOS07-traveline/assets/51712973/4fe9615a-6464-4ab6-a5de-15300d3ccf8c)|
|변경 후|
|![스크린샷 2023-12-14 오전 11 12 53](https://github.com/boostcampwm2023/iOS07-traveline/assets/51712973/6c0e76bf-3413-4216-bb56-108a6fd8a36a)|

## 관련 이슈
- Resolved: #373
