### PR TITLE
[feat] 번역하기 API 연결

### DIFF
--- a/iOS/traveline/Sources/Core/Constant/Literal.swift
+++ b/iOS/traveline/Sources/Core/Constant/Literal.swift
@@ -117,6 +117,7 @@ enum Literal {
         static let modify: String = "수정하기"
         static let delete: String = "삭제하기"
         static let report: String = "신고하기"
+        static let translate: String = "번역하기"
     }
     
     enum Query {

--- a/iOS/traveline/Sources/Data/Network/API/TimelineDetailEndPoint.swift
+++ b/iOS/traveline/Sources/Data/Network/API/TimelineDetailEndPoint.swift
@@ -14,6 +14,7 @@ enum TimelineDetailEndPoint {
     case fetchPlaceList(String, Int)
     case putTimeline(String, TimelineDetailRequestDTO)
     case deleteTimeline(String)
+    case translateTimeline(String)
 }
 
 extension TimelineDetailEndPoint: EndPoint {
@@ -34,6 +35,9 @@ extension TimelineDetailEndPoint: EndPoint {
         case .deleteTimeline(let id):
             return "\(curPath)/\(id)"
             
+        case .translateTimeline(let id):
+            return "\(curPath)/\(id)/translate"
+            
         default:
             return curPath
         }
@@ -41,7 +45,7 @@ extension TimelineDetailEndPoint: EndPoint {
     
     var httpMethod: HTTPMethod {
         switch self {
-        case .specificTimeline, .fetchPlaceList:
+        case .specificTimeline, .fetchPlaceList, .translateTimeline:
             return .GET
             
         case .createTimeline:

--- a/iOS/traveline/Sources/Data/Network/DataMapping/TimelineTranslatedResponseDTO.swift
+++ b/iOS/traveline/Sources/Data/Network/DataMapping/TimelineTranslatedResponseDTO.swift
@@ -1,0 +1,19 @@
+//
+//  TimelineTranslatedResponseDTO.swift
+//  traveline
+//
+//  Created by 김태현 on 12/14/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+struct TimelineTranslatedResponseDTO: Decodable {
+    let description: String
+}
+
+extension TimelineTranslatedResponseDTO {
+    func toDomain() -> TimelineTranslatedInfo {
+        return .init(description: description)
+    }
+}

--- a/iOS/traveline/Sources/Data/Repository/Mock/TimelineDetailRepositoryMock.swift
+++ b/iOS/traveline/Sources/Data/Repository/Mock/TimelineDetailRepositoryMock.swift
@@ -39,4 +39,10 @@ final class TimelineDetailRepositoryMock: TimelineDetailRepository {
         
         return true
     }
+    
+    func fetchTimelineTranslatedInfo(id: String) async throws -> TimelineTranslatedInfo {
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+        
+        return TimelineTranslatedInfo.empty
+    }
 }

--- a/iOS/traveline/Sources/Data/Repository/TimelineDetailRepositoryImpl.swift
+++ b/iOS/traveline/Sources/Data/Repository/TimelineDetailRepositoryImpl.swift
@@ -55,4 +55,13 @@ final class TimelineDetailRepositoryImpl: TimelineDetailRepository {
         return deleteTimelineDTO
     }
     
+    func fetchTimelineTranslatedInfo(id: String) async throws -> TimelineTranslatedInfo {
+        let translateTimelineDTO = try await network.request(
+            endPoint: TimelineDetailEndPoint.translateTimeline(id),
+            type: TimelineTranslatedResponseDTO.self
+        )
+        
+        return translateTimelineDTO.toDomain()
+    }
+    
 }

--- a/iOS/traveline/Sources/Domain/Model/Timeline/TimelineTranslatedInfo.swift
+++ b/iOS/traveline/Sources/Domain/Model/Timeline/TimelineTranslatedInfo.swift
@@ -1,0 +1,15 @@
+//
+//  TimelineTranslatedInfo.swift
+//  traveline
+//
+//  Created by 김태현 on 12/14/23.
+//  Copyright © 2023 traveline. All rights reserved.
+//
+
+import Foundation
+
+struct TimelineTranslatedInfo {
+    let description: String
+    
+    static let empty: TimelineTranslatedInfo = .init(description: Literal.empty)
+}

--- a/iOS/traveline/Sources/Domain/RepositoryInterface/TimelineDetailRepository.swift
+++ b/iOS/traveline/Sources/Domain/RepositoryInterface/TimelineDetailRepository.swift
@@ -14,4 +14,5 @@ protocol TimelineDetailRepository {
     func fetchTimelinePlaces(keyword: String, offset: Int) async throws -> TimelinePlaceList
     func putTimeline(id: String, info: TimelineDetailRequest) async throws -> Bool
     func deleteTimeline(id: String) async throws -> Bool
+    func fetchTimelineTranslatedInfo(id: String) async throws -> TimelineTranslatedInfo
 }

--- a/iOS/traveline/Sources/Domain/UseCase/TimelineDetailUseCase.swift
+++ b/iOS/traveline/Sources/Domain/UseCase/TimelineDetailUseCase.swift
@@ -12,6 +12,7 @@ import Foundation
 protocol TimelineDetailUseCase {
     func fetchTimelineDetail(with id: String) -> AnyPublisher<TimelineDetailInfo, Error>
     func deleteTimeline(id: String) -> AnyPublisher<Bool, Error>
+    func fetchTranslateTimelineDetail(with id: String) -> AnyPublisher<TimelineTranslatedInfo, Error>
 }
 
 final class TimelineDetailUseCaseImpl: TimelineDetailUseCase {
@@ -36,4 +37,10 @@ final class TimelineDetailUseCaseImpl: TimelineDetailUseCase {
         }.eraseToAnyPublisher()
     }
     
+    func fetchTranslateTimelineDetail(with id: String) -> AnyPublisher<TimelineTranslatedInfo, Error> {
+        return Future {
+            let translatedInfo = try await self.repository.fetchTimelineTranslatedInfo(id: id)
+            return translatedInfo
+        }.eraseToAnyPublisher()
+    }
 }

--- a/iOS/traveline/Sources/Feature/TimelineDetailFeature/TimelineDetailScene/VC/TimelineDetailVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineDetailFeature/TimelineDetailScene/VC/TimelineDetailVC.swift
@@ -113,11 +113,20 @@ final class TimelineDetailVC: UIViewController {
         
         if isOwner {
             menuItems = [
+                .init(title: Literal.Action.translate, handler: { [weak self] _ in
+                    self?.viewModel.sendAction(.translateTimeline)
+                }),
                 .init(title: Literal.Action.modify, handler: { [weak self] _ in
                     self?.viewModel.sendAction(.editTimeline)
                 }),
                 .init(title: Literal.Action.delete, attributes: .destructive, handler: {  [weak self] _ in
                     self?.viewModel.sendAction(.deleteTimeline)
+                })
+            ]
+        } else {
+            menuItems = [
+                .init(title: Literal.Action.translate, handler: { [weak self] _ in
+                    self?.viewModel.sendAction(.translateTimeline)
                 })
             ]
         }
@@ -237,6 +246,18 @@ private extension TimelineDetailVC {
                     timelineDetailInfo: timelineDetailInfo
                 )
                 owner.navigationController?.pushViewController(timelineEditVC, animated: true)
+            }
+            .store(in: &cancellables)
+        
+        viewModel.state
+            .map(\.isTranslated)
+            .dropFirst()
+            .withUnretained(self)
+            .sink { owner, isTranslated in
+                let description = isTranslated
+                ? owner.viewModel.currentState.timelineTranslatedInfo.description
+                : owner.viewModel.currentState.timelineDetailInfo.description
+                owner.contentView.setText(to: description)
             }
             .store(in: &cancellables)
     }


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- feature/#380

## 📚 작업한 내용
### 번역하기 기능 연결
- TimelineDetail 화면에서 번역하기 선택 시 description 번역 기능을 연결했습니다!
- 번역된 정보와 아닌 정보를 따로 관리해서 이후에 수정하기 선택 시에는 번역되지 않은 정보를 넘기도록 했습니다!

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
https://github.com/boostcampwm2023/iOS07-traveline/assets/51712973/e4f223d6-95cb-49f8-b63e-811bd11a73ec


## 관련 이슈
- Resolved: #380 
