### PR TITLE
[feat] 이미지 rollback 기능 구현

### DIFF
--- a/BE/src/timelines/timelines.service.ts
+++ b/BE/src/timelines/timelines.service.ts
@@ -31,30 +31,41 @@ export class TimelinesService {
     file: Express.Multer.File,
     createTimelineDto: CreateTimelineDto
   ) {
-    const posting = await this.postingsService.findOne(
-      createTimelineDto.posting
-    );
+    let imagePath: string;
 
-    if (posting.writer.id !== userId) {
-      throw new ForbiddenException(
-        '본인이 작성한 게시글에 대해서만 타임라인을 생성할 수 있습니다.'
+    try {
+      const posting = await this.postingsService.findOne(
+        createTimelineDto.posting
       );
-    }
 
-    const timeline = await this.initialize(createTimelineDto);
-    timeline.posting = posting;
-
-    if (file) {
-      const filePath = `${userId}/${posting.id}/`;
-      const { path } = await this.storageService.upload(filePath, file);
-      timeline.image = path;
-
-      if (!posting.thumbnail) {
-        await this.postingsRepository.updateThumbnail(posting.id, path);
+      if (posting.writer.id !== userId) {
+        throw new ForbiddenException(
+          '본인이 작성한 게시글에 대해서만 타임라인을 생성할 수 있습니다.'
+        );
       }
-    }
 
-    return this.timelinesRepository.save(timeline);
+      const timeline = await this.initialize(createTimelineDto);
+      timeline.posting = posting;
+
+      if (file) {
+        const filePath = `${userId}/${posting.id}/`;
+        const { path } = await this.storageService.upload(filePath, file);
+        imagePath = path;
+        timeline.image = imagePath;
+
+        if (!posting.thumbnail) {
+          await this.postingsRepository.updateThumbnail(posting.id, imagePath);
+        }
+      }
+
+      return this.timelinesRepository.save(timeline);
+    } catch (error) {
+      if (imagePath) {
+        this.storageService.delete(imagePath);
+      }
+
+      throw error;
+    }
   }
 
   async findAll(postingId: string, day: number) {


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- be-feature/#388-image-rollback

## 📚 작업한 내용

에러가 발생했을 때 기존에 스토리지에서 삭제/저장한 이미지를 어떻게 rollback 할까 고민하던 중...
단순히 try ~ catch문으로 해결할 수 있단 걸 깨달았습니다 ㅎㅎ... 타임라인 생성과 수정에만 롤백 기능이 필요하고, 삭제할 때는 필요가 없더군요!

- 타임라인 생성 시
    - 스토리지에 이미지 A 저장 (저장 경로를 변수에 할당)
    - SQL문 처리
    - 만약 SQL문 처리 과정에서 에러가 발생하면, catch문에서 스토리지에서 이미지 A 삭제

- 타임라인 수정 시
    - 상황: 기존 스토리지에 이미지 A 저장되어 있고, 변경하려는 이미지는 X
    - 로직
        - 스토리지에 이미지 X 저장 (저장 경로를 변수에 할당)
        - 모든 SQL문 처리
        - return 직전에 기존 이미지 A 삭제
        - 만약 SQL문 처리 과정에서 에러가 발생하면, catch문에서 스토리지에서 새로 저장한 이미지 X 삭제 (이미지 A는 그대로 존재함)

- 타임라인 삭제 시 (코드 변화 없긴 합니다!)
    - SQL문 처리
    - return 직전에 스토리지에서 이미지 X 삭제
    - 만약 SQL문 처리 과정에서 에러가 발생하더라도, 아직 스토리지에서 이미지 X가 삭제되지 않았으므로 별도 try ~ catch문 필요 없음

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
반복되는 try ~ catch문을 interceptor로 만들어서 처리해볼까 했는데, 스토리지에 새로 저장하는 이미지의 경로는 동적으로 변수에 할당되기 때문에 interceptor 코드에서 어떻게 알아낼 수 없을 것 같더라고요. 메서드를 실행하면서 알 수 있는 이미지 경로를 interceptor 코드에서도 알아낼 수 있다면 알려주세요!! ㅎㅎ

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 관련 이슈
- Close: #388
