### PR TITLE
[fix] 타임라인 수정 / 삭제 간 문제 해결

### DIFF
--- a/iOS/traveline/Sources/Feature/TimelineDetailFeature/TimelineDetailScene/VC/TimelineDetailVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineDetailFeature/TimelineDetailScene/VC/TimelineDetailVC.swift
@@ -235,7 +235,6 @@ private extension TimelineDetailVC {
         viewModel.state
             .map(\.isEdit)
             .filter { $0 }
-            .removeDuplicates()
             .withUnretained(self)
             .sink { owner, _ in
                 let timelineDetailInfo = owner.viewModel.currentState.timelineDetailInfo
@@ -246,6 +245,7 @@ private extension TimelineDetailVC {
                     timelineDetailInfo: timelineDetailInfo
                 )
                 owner.navigationController?.pushViewController(timelineEditVC, animated: true)
+                owner.viewModel.sendAction(.movedToEdit)
             }
             .store(in: &cancellables)
         

--- a/iOS/traveline/Sources/Feature/TimelineDetailFeature/TimelineDetailScene/ViewModel/TimelineDetailViewModel.swift
+++ b/iOS/traveline/Sources/Feature/TimelineDetailFeature/TimelineDetailScene/ViewModel/TimelineDetailViewModel.swift
@@ -14,6 +14,7 @@ enum TimelineDetailAction: BaseAction {
     case editTimeline
     case deleteTimeline
     case translateTimeline
+    case movedToEdit
 }
 
 enum TimelineDetailSideEffect: BaseSideEffect {
@@ -34,6 +35,7 @@ enum TimelineDetailSideEffect: BaseSideEffect {
     case popToTimeline(Bool)
     case showTimelineDetailEditing
     case loadTimelineTranslatedInfo(TimelineTranslatedInfo)
+    case resetIsEditStatus
 }
 
 struct TimelineDetailState: BaseState {
@@ -68,6 +70,9 @@ final class TimelineDetailViewModel: BaseViewModel<TimelineDetailAction, Timelin
             
         case .translateTimeline:
             return translateTimeline()
+        
+        case .movedToEdit:
+            return .just(.resetIsEditStatus)
         }
     }
 
@@ -91,6 +96,9 @@ final class TimelineDetailViewModel: BaseViewModel<TimelineDetailAction, Timelin
             
         case let .timelineDetailError(error):
             print(error)
+            
+        case .resetIsEditStatus:
+            newState.isEdit = false
         }
         
         return newState

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/VC/TimelineWritingVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/VC/TimelineWritingVC.swift
@@ -163,13 +163,17 @@ final class TimelineWritingVC: UIViewController {
     }
     
     @objc private func imageButtonCancelTapped() {
-        selectImageButton.setImage(nil)
-        viewModel.sendAction(.imageDidChange(nil))
+        changeImage(to: nil)
     }
     
     @objc private func locationButtonCancelTapped() {
         selectLocation.setText(to: Constants.selectLocation)
         viewModel.sendAction(.placeDidChange(.emtpy))
+    }
+    
+    private func changeImage(to image: UIImage?) {
+        selectImageButton.setImage(image)
+        viewModel.sendAction(.imageDidChange)
     }
     
     private func actionKeyboardWillShow(_ keyboardFrame: CGRect) {
@@ -439,7 +443,7 @@ extension TimelineWritingVC: PHPickerViewControllerDelegate {
             guard let self = self else { return }
             DispatchQueue.main.async {
                 guard let selectedImage = image as? UIImage else { return }
-                self.selectImageButton.setImage(selectedImage)
+                self.changeImage(to: selectedImage)
             }
         }
         

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/VC/TimelineWritingVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/VC/TimelineWritingVC.swift
@@ -469,10 +469,7 @@ extension TimelineWritingVC: LocationSearchDelegate {
 extension TimelineWritingVC: TLNavigationBarDelegate {
     func rightButtonDidTapped() {
         if let selectedImage = selectImageButton.imageView.image {
-            var image: UIImage? = selectedImage
-            if !viewModel.currentState.isOriginImage {
-                image = image?.downSampling()
-            }
+            let image = viewModel.currentState.isOriginImage ? selectedImage : selectedImage.downSampling()
             let imageData = image?.jpegData(compressionQuality: 1)
             viewModel.sendAction(.tapCompleteButton(imageData))
         } else {

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/VC/TimelineWritingVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/VC/TimelineWritingVC.swift
@@ -165,7 +165,6 @@ final class TimelineWritingVC: UIViewController {
     @objc private func imageButtonCancelTapped() {
         selectImageButton.setImage(nil)
         viewModel.sendAction(.imageDidChange(nil))
-        selectImageButton.updateView()
     }
     
     @objc private func locationButtonCancelTapped() {
@@ -336,6 +335,7 @@ private extension TimelineWritingVC {
         
         viewModel.state
             .map(\.imageURLString)
+            .removeDuplicates()
             .withUnretained(self)
             .sink { owner, imageURLString in
                 owner.selectImageButton.setImage(urlString: imageURLString)

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/VC/TimelineWritingVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/VC/TimelineWritingVC.swift
@@ -465,7 +465,10 @@ extension TimelineWritingVC: LocationSearchDelegate {
 extension TimelineWritingVC: TLNavigationBarDelegate {
     func rightButtonDidTapped() {
         if let selectedImage = selectImageButton.imageView.image {
-            let image = selectedImage.downSampling()
+            var image: UIImage? = selectedImage
+            if !viewModel.currentState.isOriginImage {
+                image = image?.downSampling()
+            }
             let imageData = image?.jpegData(compressionQuality: 1)
             viewModel.sendAction(.tapCompleteButton(imageData))
         } else {

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/View/SelectImageButton.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/View/SelectImageButton.swift
@@ -21,7 +21,7 @@ final class SelectImageButton: UIView {
     
     // MARK: - UI Components
     
-    let view: UIView = {
+    private let view: UIView = {
         let view = UIView()
         view.layer.cornerRadius = Metric.cornerRadius
         view.clipsToBounds = true
@@ -41,7 +41,7 @@ final class SelectImageButton: UIView {
     
     let imageView: UIImageView = .init()
     
-    let selectView: UIStackView = {
+    private let selectView: UIStackView = {
         let view = UIStackView()
         view.axis = .vertical
         view.alignment = .center
@@ -51,25 +51,18 @@ final class SelectImageButton: UIView {
         return view
     }()
     
-    let selectViewIcon: UIImageView = {
+    private let selectViewIcon: UIImageView = {
         let view = UIImageView(image: TLImage.Common.album)
         view.contentMode = .scaleAspectFit
         
         return view
     }()
     
-    let selectViewLabel: TLLabel = {
+    private let selectViewLabel: TLLabel = {
         let label = TLLabel(font: TLFont.body2, color: TLColor.white)
         label.textAlignment = .center
         return label
     }()
-    
-    // MARK: - Properties
-    
-    private var hasImage: Bool {
-        imageView.image != nil
-    }
-    let width = Metric.viewWidth + Metric.buttonOffset
     
     // MARK: - initialize
     
@@ -86,7 +79,7 @@ final class SelectImageButton: UIView {
     
     // MARK: - Functions
     
-    func updateView() {
+    private func updateView(hasImage: Bool) {
         selectView.isHidden = hasImage
         imageView.isHidden = !hasImage
         cancelButton.isHidden = !hasImage
@@ -94,12 +87,12 @@ final class SelectImageButton: UIView {
     
     func setImage(_ image: UIImage?) {
         imageView.image = image
-        updateView()
+        updateView(hasImage: image != nil)
     }
     
     func setImage(urlString: String?, imagePath: String? = nil) {
         imageView.setImage(from: urlString, imagePath: imagePath)
-        updateView()
+        updateView(hasImage: urlString != nil)
     }
     
 }
@@ -111,7 +104,7 @@ private extension SelectImageButton {
     func setupAttributes() {
         selectViewLabel.setText(to: "선택")
         view.backgroundColor = TLColor.backgroundGray
-        updateView()
+        updateView(hasImage: false)
     }
     
     func setupLayout() {

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/ViewModel/TimelineWritingViewModel.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/ViewModel/TimelineWritingViewModel.swift
@@ -55,6 +55,7 @@ enum TimelineWritingSideEffect: BaseSideEffect {
 }
 
 struct TimelineWritingState: BaseState {
+    var isOriginImage: Bool = false
     var isCompletable: Bool = false
     var timelineDetailRequest: TimelineDetailRequest = .empty
     var popToTimeline: Bool = false
@@ -190,6 +191,7 @@ final class TimelineWritingViewModel: BaseViewModel<TimelineWritingAction, Timel
             
         case let .setOriginImage(imageURL):
             newState.imageURLString = imageURL
+            newState.isOriginImage = true
             
         case let .popToTimelineDetail(isSuccess):
             newState.isEditCompleted = isSuccess

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/ViewModel/TimelineWritingViewModel.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/ViewModel/TimelineWritingViewModel.swift
@@ -188,6 +188,7 @@ final class TimelineWritingViewModel: BaseViewModel<TimelineWritingAction, Timel
         case let .showTimelineInfo(detailRequest):
             newState.timelineDetailRequest = detailRequest
             newState.isEdit = true
+            newState.isCompletable = completeButtonState(newState)
             
         case let .setOriginImage(imageURL):
             newState.imageURLString = imageURL

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/ViewModel/TimelineWritingViewModel.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/ViewModel/TimelineWritingViewModel.swift
@@ -17,7 +17,7 @@ enum TimelineWritingAction: BaseAction {
     case metaDataTime(String)
     case searchPlace(String)
     case placeDidChange(TimelinePlace)
-    case imageDidChange(Data?)
+    case imageDidChange
     case placeDidScrollToBottom
     case tapCompleteButton(Data?)
     case configTimelineDetailInfo(TimelineDetailInfo)
@@ -43,7 +43,7 @@ enum TimelineWritingSideEffect: BaseSideEffect {
     case updateTitleState(String)
     case updateContentState(String)
     case updateTimeState(String)
-    case updateImageState(Data?)
+    case updateImageState
     case updatePlaceState(TimelinePlace)
     case updatePlaceKeyword(String)
     case fetchPlaceList(TimelinePlaceList)
@@ -114,8 +114,8 @@ final class TimelineWritingViewModel: BaseViewModel<TimelineWritingAction, Timel
         case .placeDidChange(let place):
             return .just(.updatePlaceState(place))
             
-        case .imageDidChange(let imageData):
-            return .just(.updateImageState(imageData))
+        case .imageDidChange:
+            return .just(.updateImageState)
             
         case let .searchPlace(keyword):
             return Publishers.Merge(
@@ -158,8 +158,8 @@ final class TimelineWritingViewModel: BaseViewModel<TimelineWritingAction, Timel
         case .updateTimeState(let time):
             newState.timelineDetailRequest.time = time
             
-        case .updateImageState(let imageData):
-            newState.timelineDetailRequest.image = imageData
+        case .updateImageState:
+            newState.isOriginImage = false
             
         case .createTimeline:
             newState.popToTimeline = true


### PR DESCRIPTION
## 🌎 PR 요약
- 타임라인 수정 / 삭제 간 발생하던 문제들을 해결했습니다~!

🌱 작업한 브랜치
- feature/#383

## 📚 작업한 내용
### 해결된 문제들
- [x] 수정 -> 취소 시 다시 수정이 안되는 현상 해결
- [x] 수정 화면 이동 시 기존 이미지가 노출되지 않는 문제 해결
- [x] 지속적으로 수정 시 다운샘플링이 중복 적용되는 문제 해결
- [x] 수정 화면의 이미지 갤러리에서 선택 시 간헐적으로 버튼에 이미지가 업데이트 되지 않는 문제 해결
- [x] 수정 화면에서 기존 이미지가 있을 때 이미지 갤러리에서 새로 선택 시 업데이트 안되는 문제 해결
- [x] 이미지 변경 후 글자 입력 시 기존 이미지로 바뀌는 현상 해결
- [x] 이미지만 변경했을 시 완료 버튼 활성화 되지 않는 현상 해결

### 추가로 발견된 문제
- 현재 다른 기능들은 정상작동하나, **이미지를 삭제하는 수정 작업**을 했을 시 타임라인 리스트 조회 혹은 상세 조회 시에 기존 이미지 URL이 그대로 넘어오고 있는 문제를 발견했습니다!
- 백엔드분들께는 디스코드로 공유드린 상태이고, 혹시 백엔드 문제가 아닐 시에는 다시 한 번 디버깅이 필요할 듯 합니닷

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
자꾸 하나 고치면 하나 안되는 상황이 반복되어서 밀고 첨부터 다시 고쳤더니 시간이 좀 걸렸습니다.. ㅎ
커밋 단위로 메세지 확인해보시면 문제 원인 확인하실 수 있습니다~!

## 📸 스크린샷
https://github.com/boostcampwm2023/iOS07-traveline/assets/51712973/dd2c6582-c42d-4849-857c-771a866a6d57


## 관련 이슈
close #383 
