### PR TITLE
[fix] 타임라인 이미지 제거 시 예전 이미지 URL이 반환되는 문제 해결

### DIFF
--- a/BE/src/timelines/timelines.service.ts
+++ b/BE/src/timelines/timelines.service.ts
@@ -61,7 +61,7 @@ export class TimelinesService {
       return this.timelinesRepository.save(timeline);
     } catch (error) {
       if (imagePath) {
-        this.storageService.delete(imagePath);
+        await this.storageService.delete(imagePath);
       }
 
       throw error;
@@ -119,6 +119,8 @@ export class TimelinesService {
         );
         imagePath = path;
         updatedTimeline.image = imagePath;
+      } else {
+        updatedTimeline.image = null;
       }
 
       const updatedResult = await this.timelinesRepository.update(
@@ -137,7 +139,7 @@ export class TimelinesService {
       return updatedResult;
     } catch (error) {
       if (imagePath) {
-        this.storageService.delete(imagePath);
+        await this.storageService.delete(imagePath);
       }
 
       throw error;


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- be-feature/#399-image-delete

## 📚 작업한 내용
- 이미지가 전송되지 않을 시 이미지 필드를 null로 초기화하는 else문을 추가했습니다

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 관련 이슈
- Close: #399
