### PR TITLE
[fix] 타임라인 상세 글을 장소 등록 없이 작성했을 때 조회가 되지 않는 문제 해결

### DIFF
--- a/iOS/traveline/Sources/Data/Network/DataMapping/TimelineDetailResponseDTO.swift
+++ b/iOS/traveline/Sources/Data/Network/DataMapping/TimelineDetailResponseDTO.swift
@@ -18,7 +18,7 @@ struct TimelineDetailResponseDTO: Decodable {
     let coordX: Double?
     let coordY: Double?
     let date: String
-    let place: String
+    let place: String?
     let time: String
     let isOwner: Bool
     let posting: PostingID

--- a/iOS/traveline/Sources/Data/Network/DataMapping/TimelineResponseDTO.swift
+++ b/iOS/traveline/Sources/Data/Network/DataMapping/TimelineResponseDTO.swift
@@ -22,7 +22,7 @@ struct TimelineResponseDTO: Decodable {
     let imagePath: String?
     let coordX: Double?
     let coordY: Double?
-    let place: String
+    let place: String?
     let time: String
 }
 

--- a/iOS/traveline/Sources/Domain/Model/Timeline/TimelineCardInfo.swift
+++ b/iOS/traveline/Sources/Domain/Model/Timeline/TimelineCardInfo.swift
@@ -15,7 +15,7 @@ struct TimelineCardInfo: Hashable {
     let thumbnailURL: String?
     let imagePath: String?
     let title: String
-    let place: String
+    let place: String?
     let content: String
     let time: String
     let latitude: Double?

--- a/iOS/traveline/Sources/Domain/Model/Timeline/TimelineDetailInfo.swift
+++ b/iOS/traveline/Sources/Domain/Model/Timeline/TimelineDetailInfo.swift
@@ -19,7 +19,7 @@ struct TimelineDetailInfo: Hashable {
     let coordX: Double?
     let coordY: Double?
     let date: String
-    let location: String
+    let location: String?
     let time: String
     let isOwner: Bool
     

--- a/iOS/traveline/Sources/Domain/UseCase/TimelineWritingUseCase.swift
+++ b/iOS/traveline/Sources/Domain/UseCase/TimelineWritingUseCase.swift
@@ -55,7 +55,7 @@ final class TimelineWritingUseCaseImpl: TimelineWritingUseCase {
             time: info.time,
             date: info.date,
             place: .init(
-                title: info.location,
+                title: info.location ?? Literal.empty,
                 address: Literal.empty,
                 latitude: info.coordY ?? 0.0,
                 longitude: info.coordX ?? 0.0

--- a/iOS/traveline/Sources/Feature/TimelineDetailFeature/TimelineDetailScene/VC/TimelineDetailVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineDetailFeature/TimelineDetailScene/VC/TimelineDetailVC.swift
@@ -98,7 +98,12 @@ final class TimelineDetailVC: UIViewController {
         titleLabel.setText(to: info.title)
         dateLabel.setText(to: info.date)
         timeLabel.setText(to: info.time)
-        locationLabel.setText(to: info.location)
+        if let location = info.location {
+            locationLabel.setText(to: location)
+            locationLabel.isHidden = false
+        } else {
+            locationLabel.isHidden = true
+        }
         contentView.setText(to: info.description)
         guard let url = info.imageURL else {
             imageView.isHidden = true

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/View/TimelineCardView.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/View/TimelineCardView.swift
@@ -53,7 +53,9 @@ final class TimelineCardView: UIView {
     
     func setData(cardInfo: TimelineCardInfo) {
         titleLabel.setText(to: cardInfo.title)
-        subtitleLabel.setText(to: cardInfo.place)
+        if let place = cardInfo.place {
+            subtitleLabel.setText(to: place)
+        }
         contentLabel.setText(to: cardInfo.content)
         thumbnailImageView.setImage(from: cardInfo.thumbnailURL, imagePath: cardInfo.imagePath)
         thumbnailImageView.isHidden = cardInfo.thumbnailURL == nil

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/VC/TimelineWritingVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/VC/TimelineWritingVC.swift
@@ -29,7 +29,7 @@ final class TimelineWritingVC: UIViewController {
         static let contentPlaceholder: String = "내용을 입력해주세요. *"
         static let complete: String = "완료"
         static let selectTime: String = "시간선택"
-        static let selectLocation: String = "선택한 장소"
+        static let selectLocation: String = "장소 선택"
         static let alertContentVCKey = "contentViewController"
         static let metaDataKey = "{Exif}"
         static let dateKey = "DateTimeOriginal"
@@ -331,7 +331,7 @@ private extension TimelineWritingVC {
                     owner.textView.textColor = TLColor.white
                     owner.textView.text = detail.content
                 }
-                if let place = detail.place {
+                if let place = detail.place, !place.title.isEmpty {
                     owner.selectLocation.setText(to: place.title)
                 }
             }

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/View/SelectedLocationButton.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/View/SelectedLocationButton.swift
@@ -11,7 +11,7 @@ import UIKit
 final class SelectLocationButton: UIView {
     
     private enum Constants {
-        static let defaultText: String = "선택한 장소"
+        static let defaultText: String = "장소 선택"
         static let labelHeight: CGFloat = 24
         static let spacing: CGFloat = 6
         static let buttonSpacing: CGFloat = 2


### PR DESCRIPTION
## 🌎 PR 요약
- 타임라인 상세 글 작성 시 장소 등록하지 않았을 때 조회되지 않는 문제를 해결했습니다!
- 디스코드에 경미님이 공유 주신 부분 관련입니당

🌱 작업한 브랜치
- feature/#401

## 📚 작업한 내용
### 디코딩 관련 수정
<img width="567" alt="스크린샷 2024-01-16 오후 4 46 27" src="https://github.com/boostcampwm2023/iOS07-traveline/assets/51712973/70ad4e2b-e9a7-4924-9b0a-5562252be79f">

- 위와 같이 장소를 등록하지 않았을 때 place가 null 로 넘어오는데, 기존에 디코딩하던 ResponseDTO 들에서 place가 nullable하지 않아 디코딩 에러가 발생하고 있었습니다~!
- DTO 들에서 place를 옵셔널로 수정하고, 이에 따른 모델들의 수정 작업이 있었습니다.
- 타임라인 상세 화면에서 등록된 장소가 없다면 장소를 노출하지 않도록 수정했습니다!

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
N/A

## 📸 스크린샷
| | |
|:--:|:--:|
|![IMG_0235](https://github.com/boostcampwm2023/iOS07-traveline/assets/51712973/2900247a-596d-444b-913c-27a551b0f10f)|![IMG_0234](https://github.com/boostcampwm2023/iOS07-traveline/assets/51712973/17f47f14-69c7-4806-80bc-ebbdeaa11540)| -->

## 관련 이슈
- Resolved: #401 
