### PR TITLE
[chore] 앱 삭제 후 재진입 시 로그인 화면으로 이동하기 위해 UserDefaults에 첫 진입 (로그인) 여부 저장

### DIFF
--- a/iOS/traveline/Sources/Core/Constant/UserDefaultsList.swift
+++ b/iOS/traveline/Sources/Core/Constant/UserDefaultsList.swift
@@ -11,4 +11,5 @@ import Foundation
 enum UserDefaultsList {
     @UserDefaultsWrapper<UserResponseDTO>(key: "userResponseDTO") static var userResponseDTO
     @UserDefaultsWrapper<[String]>(key: "recentSearchKeyword") static var recentSearchKeyword
+    @UserDefaultsWrapper<Bool>(key: "isFirstEntry") static var isFirstEntry
 }

--- a/iOS/traveline/Sources/Domain/UseCase/AutoLoginUseCase.swift
+++ b/iOS/traveline/Sources/Domain/UseCase/AutoLoginUseCase.swift
@@ -23,7 +23,7 @@ final class AutoLoginUseCaseImpl: AutoLoginUseCase {
     
     func requestLogin() -> AnyPublisher<Bool, Error> {
         guard let isFirstEntry = UserDefaultsList.isFirstEntry,
-              isFirstEntry else {
+              !isFirstEntry else {
             return Just(false)
                 .setFailureType(to: Error.self)
                 .eraseToAnyPublisher()

--- a/iOS/traveline/Sources/Domain/UseCase/AutoLoginUseCase.swift
+++ b/iOS/traveline/Sources/Domain/UseCase/AutoLoginUseCase.swift
@@ -22,6 +22,13 @@ final class AutoLoginUseCaseImpl: AutoLoginUseCase {
     }
     
     func requestLogin() -> AnyPublisher<Bool, Error> {
+        guard let isFirstEntry = UserDefaultsList.isFirstEntry,
+              isFirstEntry else {
+            return Just(false)
+                .setFailureType(to: Error.self)
+                .eraseToAnyPublisher()
+        }
+        
         return Future {
             let accessToken = try await self.repository.refresh()
             KeychainList.accessToken = accessToken

--- a/iOS/traveline/Sources/Domain/UseCase/LoginUseCase.swift
+++ b/iOS/traveline/Sources/Domain/UseCase/LoginUseCase.swift
@@ -26,6 +26,7 @@ final class LoginUseCaseImpl: LoginUseCase {
             let tlToken = try await self.repository.appleLogin(with: info)
             KeychainList.accessToken = tlToken.accessToken
             KeychainList.refreshToken = tlToken.refreshToken
+            UserDefaultsList.isFirstEntry = false
             return true
         }.eraseToAnyPublisher()
     }


### PR DESCRIPTION
## 🌎 PR 요약
- 앱 삭제 후 재진입 시 로그인 화면으로 이동하기 위해 첫 진입 (로그인) 여부를 저장합니다.

🌱 작업한 브랜치
- feature/#407

## 📚 작업한 내용
### 첫 진입 (로그인) 여부 UserDefaults에 저장
- UserDefaultsList에 `isFirstEntry`를 추가했습니다!
- 앱을 켰을 때 자동 로그인 시도 시 해당 필드를 검증해 자동 로그인 대신 로그인 화면으로 이동합니다.
- 최초 로그인 성공 후 앱 재진입 시 자동 로그인을 시도합니다.

## 📍 참고 사항
N/A

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 관련 이슈
- Resolved: #407 
