### PR TITLE
[Fix] QA 반영 (사이드바 버그 및 이미지 비율 수정)

### DIFF
--- a/iOS/Plugins/EnvPlugin/ProjectDescriptionHelpers/InfoPlist.swift
+++ b/iOS/Plugins/EnvPlugin/ProjectDescriptionHelpers/InfoPlist.swift
@@ -25,6 +25,7 @@ public extension Project {
                 ]
             ]
         ],
-        "BaseURL": "$(BASE_URL)"
+        "ProdURL": "$(PROD_URL)",
+        "DevURL": "$(DEV_URL)"
     ]
 }

--- a/iOS/traveline/Sources/Core/Constant/Literal.swift
+++ b/iOS/traveline/Sources/Core/Constant/Literal.swift
@@ -13,7 +13,8 @@ enum Literal {
     static let boundary: String = "Boundary-\(UUID().uuidString)"
     
     enum InfoPlistKey {
-        static let baseURL: String = "BaseURL"
+        static let devURL: String = "DevURL"
+        static let prodURL: String = "ProdURL"
     }
     
     enum Tag {

--- a/iOS/traveline/Sources/Data/Network/Base/EndPoint.swift
+++ b/iOS/traveline/Sources/Data/Network/Base/EndPoint.swift
@@ -19,7 +19,11 @@ protocol EndPoint {
 extension EndPoint {
     
     var baseURL: String? {
-        return Bundle.main.object(forInfoDictionaryKey: Literal.InfoPlistKey.baseURL) as? String
+        #if DEBUG
+        return Bundle.main.object(forInfoDictionaryKey: Literal.InfoPlistKey.devURL) as? String
+        #else
+        return Bundle.main.object(forInfoDictionaryKey: Literal.InfoPlistKey.prodURL) as? String
+        #endif
     }
     
     var body: Encodable? {

--- a/iOS/traveline/Sources/DesignSystem/View/TLList/TLInfoView.swift
+++ b/iOS/traveline/Sources/DesignSystem/View/TLList/TLInfoView.swift
@@ -39,6 +39,7 @@ final class TLInfoView: UIView {
         imageView.backgroundColor = TLColor.gray
         imageView.layer.cornerRadius = Metric.radius
         imageView.clipsToBounds = true
+        imageView.contentMode = .scaleAspectFill
         return imageView
     }()
     
@@ -62,6 +63,7 @@ final class TLInfoView: UIView {
         imageView.backgroundColor = TLColor.gray
         imageView.layer.cornerRadius = Metric.profileImageSize / 2
         imageView.clipsToBounds = true
+        imageView.contentMode = .scaleAspectFill
         return imageView
     }()
     

--- a/iOS/traveline/Sources/Domain/UseCase/LoginUseCase.swift
+++ b/iOS/traveline/Sources/Domain/UseCase/LoginUseCase.swift
@@ -23,6 +23,7 @@ final class LoginUseCaseImpl: LoginUseCase {
     
     func requestLogin(with info: AppleLoginRequest) -> AnyPublisher<Bool, Error> {
         return Future {
+            UserDefaultsList.userResponseDTO = nil
             let tlToken = try await self.repository.appleLogin(with: info)
             KeychainList.accessToken = tlToken.accessToken
             KeychainList.refreshToken = tlToken.refreshToken

--- a/iOS/traveline/Sources/Feature/MyPageFeature/ProfileEditingScene/VC/ProfileEditingVC.swift
+++ b/iOS/traveline/Sources/Feature/MyPageFeature/ProfileEditingScene/VC/ProfileEditingVC.swift
@@ -45,6 +45,7 @@ final class ProfileEditingVC: UIViewController {
         view.layer.cornerRadius = Metric.imageWidth / 2
         view.backgroundColor = TLColor.backgroundGray
         view.clipsToBounds = true
+        view.contentMode = .scaleAspectFill
         return view
     }()
     

--- a/iOS/traveline/Sources/Feature/SideFeature/SideScene/View/ProfileLabel.swift
+++ b/iOS/traveline/Sources/Feature/SideFeature/SideScene/View/ProfileLabel.swift
@@ -22,11 +22,11 @@ final class ProfileLabel: UIView {
     
     private let imageView: UIImageView = {
         let view = UIImageView()
-        view.image = UIImage(systemName: "person.fill")
         view.contentMode = .center
         view.layer.cornerRadius = Metric.imageWidth / 2
         view.backgroundColor = TLColor.backgroundGray
         view.clipsToBounds = true
+        view.contentMode = .scaleAspectFill
         return view
     }()
     

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/View/TimelineCardView.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/View/TimelineCardView.swift
@@ -78,6 +78,7 @@ private extension TimelineCardView {
         thumbnailImageView.backgroundColor = TLColor.disabledGray
         thumbnailImageView.layer.cornerRadius = 12.0
         thumbnailImageView.clipsToBounds = true
+        thumbnailImageView.contentMode = .scaleAspectFill
     }
     
     func setupLayout() {


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- feature/#

## 📚 작업한 내용

- 로그인 시 UserDefaults 유저 정보 초기화
- 이미지 뷰들 contentMode 전부 scaleAspectFill로 변경

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

### 로그인 시 UserDefaults 유저 정보 초기화
탈퇴 > 로그인 시 이전 유저 정보가 남아있어서 이걸 지울 시점이 필요했는데요.
어차피 다시 로그인한다면 결국 정보를 모르고 있는 게 나을 것 같아서 로그인 할 때, 해당 유저 정보 UserDefaults값 삭제되도록 구현했습니다 ~ !

앞선 PR 머지된 이후에 머지할게요 ~ ! (브랜치를 거기서 땄네요 ㅎ)

## 📸 스크린샷
|사이드바|이미지 수정|
|:--:|:--:|
|<img src="https://github.com/boostcampwm2023/iOS07-traveline/assets/74968390/442cbad0-0e76-44c1-8c21-528b95732a4a" width=280>|<img src="https://github.com/boostcampwm2023/iOS07-traveline/assets/74968390/9c0e9605-3e36-4a51-bd67-ae61171d6072" width=280>|

## 관련 이슈
- Resolved: #412
