### PR TITLE
[fix] 프로필 기본 이미지 변경 시 사이드 바 즉시 적용

### DIFF
--- a/iOS/traveline/Sources/Feature/SideFeature/SideScene/View/ProfileLabel.swift
+++ b/iOS/traveline/Sources/Feature/SideFeature/SideScene/View/ProfileLabel.swift
@@ -66,6 +66,10 @@ final class ProfileLabel: UIView {
     
     func updateProfile(_ profile: Profile) {
         idLabel.setText(to: profile.name)
+        guard profile.imageURL != Literal.empty else {
+            imageView.image = nil
+            return
+        }
         imageView.setImage(from: profile.imageURL, imagePath: profile.imagePath)
     }
 }


### PR DESCRIPTION
## 🌎 PR 요약
프로필 사진 기본 이미지로 변경 시 사이드 바에 바로 적용되도록 수정해요.

🌱 작업한 브랜치
- feature/#416

## 📚 작업한 내용
- 프로필 변경에서 기본 이미지로 변경 후 사이드 바에 바로 적용되지 않던 버그를 고쳤어요.

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
UserRepository에서 데이터가 UserResponseDTO -> Profile로 처리되는 과정에서 imageURL이 nil이면 ""로 변환되는데 
이렇게 사이드 바까지 넘어온 Profile.imageURL이 ""일 경우에 대한 처리가 되지않아서 기본 이미지가 바로 적용되지 않았습니다.
사이드 바의 프로필 이미지를 패치 요청하기 전에 ""일 경우 nil을 넣어서 처리해줬습니다.

## 📸 스크린샷

https://github.com/boostcampwm2023/iOS07-traveline/assets/91725382/59b26072-74b5-44cd-8184-ae0b9edae868


## 관련 이슈
- Resolved: #416 
