### PR TITLE
[feat] 카카오 소셜 로그인 및 탈퇴 구현

### DIFF
--- a/BE/src/auth/auth.controller.ts
+++ b/BE/src/auth/auth.controller.ts
@@ -6,6 +6,7 @@ import {
   Get,
   Req,
   UseGuards,
+  Param,
 } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
@@ -14,6 +15,7 @@ import { CreateAuthRequestForDevDto } from './dto/create-auth-request-for-dev.dt
 import { DeleteAuthDto } from './dto/delete-auth.dto';
 import { AuthGuard } from './auth.guard';
 import { login, refresh, withdrawal } from './auth.swagger';
+import { LoginRequestDto } from './dto/login-request.dto.interface';
 
 @Controller('auth')
 @ApiTags('Auth API')
@@ -27,7 +29,7 @@ export class AuthController {
   })
   @ApiOkResponse({ description: 'OK', schema: { example: refresh } })
   refresh(@Req() request) {
-    return this.authService.refresh(request);
+    return this.authService.refreshApple(request);
   }
 
   @Post('login')
@@ -38,7 +40,17 @@ export class AuthController {
   })
   @ApiOkResponse({ description: 'OK', schema: { example: login } })
   login(@Req() request, @Body() createAuthDto: CreateAuthRequestDto) {
-    return this.authService.login(request, createAuthDto);
+    return this.authService.loginApple(request, createAuthDto);
+  }
+
+  @Post('login/:social')
+  socialLogin(
+    @Req() request,
+    @Param('social') social: string,
+    @Body() loginRequestDto: LoginRequestDto
+  ) {
+    const ipAddress: string = request.headers['x-real-ip'];
+    return this.authService.login(social, ipAddress, loginRequestDto);
   }
 
   @Post('login/dev')
@@ -66,7 +78,7 @@ export class AuthController {
     schema: { example: withdrawal },
   })
   withdrawal(@Req() request, @Body() deleteAuthDto: DeleteAuthDto) {
-    return this.authService.withdrawal(request, deleteAuthDto);
+    return this.authService.withdrawalApple(request, deleteAuthDto);
   }
 
   // 추후 수정 예정

--- a/BE/src/auth/auth.controller.ts
+++ b/BE/src/auth/auth.controller.ts
@@ -67,6 +67,13 @@ export class AuthController {
   }
 
   @UseGuards(AuthGuard)
+  @Post('withdraw/:social')
+  socialWithdraw(@Req() request, @Param('social') social: string) {
+    const userId = request['user'].id;
+    return this.authService.withdraw(social, userId);
+  }
+
+  @UseGuards(AuthGuard)
   @Delete('withdrawal')
   @ApiOperation({
     summary: '탈퇴 API',

--- a/BE/src/auth/auth.module.ts
+++ b/BE/src/auth/auth.module.ts
@@ -7,10 +7,17 @@ import { StorageService } from 'src/storage/storage.service';
 import { HttpModule } from '@nestjs/axios';
 import { AuthGuard } from './auth.guard';
 import { EmailModule } from 'src/email/email.module';
+import { KakaoLoginStrategy } from 'src/socialLogin/kakao-login-strategy';
 
 @Module({
   imports: [UsersModule, HttpModule, EmailModule],
   controllers: [AuthController],
-  providers: [AuthService, UsersService, StorageService, AuthGuard],
+  providers: [
+    AuthService,
+    UsersService,
+    StorageService,
+    AuthGuard,
+    KakaoLoginStrategy,
+  ],
 })
 export class AuthModule {}

--- a/BE/src/auth/auth.service.ts
+++ b/BE/src/auth/auth.service.ts
@@ -259,6 +259,20 @@ export class AuthService {
     );
   }
 
+  async withdraw(social: string, userId: string) {
+    const socialLoginStrategy: SocialLoginStrategy =
+      this.getLoginStrategy(social);
+    const { id, resourceId } = await this.usersService.findUserById(userId);
+
+    try {
+      socialLoginStrategy.withdraw(resourceId);
+      await this.usersService.deleteUser(id);
+      return { revoke: true };
+    } catch {
+      return { revoke: false };
+    }
+  }
+
   clientSecretGenerator(clientId) {
     const header = { alg: 'ES256', kid: process.env.KEY_ID };
     const iat = Math.floor(Date.now() / 1000);

--- a/BE/src/auth/auth.service.ts
+++ b/BE/src/auth/auth.service.ts
@@ -262,7 +262,7 @@ export class AuthService {
     const { id, resourceId } = await this.usersService.findUserById(userId);
 
     try {
-      socialLoginStrategy.withdraw(resourceId);
+      await socialLoginStrategy.withdraw(resourceId);
       await this.usersService.deleteUser(id);
       return { revoke: true };
     } catch {

--- a/BE/src/auth/auth.service.ts
+++ b/BE/src/auth/auth.service.ts
@@ -35,6 +35,17 @@ export class AuthService {
     this.socialLoginStrategyMap.set('kakao', kakaoLoginStrategy);
   }
 
+  private getLoginStrategy(social: string) {
+    const socialLoginStrategy: SocialLoginStrategy =
+      this.socialLoginStrategyMap.get(social);
+
+    if (!socialLoginStrategy) {
+      throw new BadRequestException('지원하지 않는 소셜 로그인 플랫폼입니다');
+    }
+
+    return socialLoginStrategy;
+  }
+
   async refreshApple(request) {
     const ipAddress = request.headers['x-real-ip'];
     const [type, token] = request.headers.authorization?.split(' ') ?? [];
@@ -112,12 +123,7 @@ export class AuthService {
     loginRequestDto: LoginRequestDto
   ) {
     const socialLoginStrategy: SocialLoginStrategy =
-      this.socialLoginStrategyMap.get(social);
-
-    if (!socialLoginStrategy) {
-      throw new BadRequestException('지원하지 않는 소셜 로그인 플랫폼입니다');
-    }
-
+      this.getLoginStrategy(social);
     const resourceId: string = await socialLoginStrategy.login(loginRequestDto);
     const findUser =
       await this.usersService.getUserInfoByResourceId(resourceId);

--- a/BE/src/auth/auth.service.ts
+++ b/BE/src/auth/auth.service.ts
@@ -124,7 +124,8 @@ export class AuthService {
   ) {
     const socialLoginStrategy: SocialLoginStrategy =
       this.getLoginStrategy(social);
-    const resourceId: string = await socialLoginStrategy.login(loginRequestDto);
+    const { resourceId, email } =
+      await socialLoginStrategy.login(loginRequestDto);
     const findUser =
       await this.usersService.getUserInfoByResourceId(resourceId);
 
@@ -132,11 +133,7 @@ export class AuthService {
     if (findUser) {
       user = findUser;
     } else {
-      user = await this.usersService.createUser(
-        resourceId,
-        'temp@temp.com',
-        ipAddress
-      );
+      user = await this.usersService.createUser(resourceId, email, ipAddress);
     }
     const payload = { id: user.id };
 

--- a/BE/src/auth/auth.service.ts
+++ b/BE/src/auth/auth.service.ts
@@ -13,17 +13,29 @@ import { CreateAuthRequestForDevDto } from './dto/create-auth-request-for-dev.dt
 import { firstValueFrom } from 'rxjs';
 import { JwksClient } from 'jwks-rsa';
 import { EmailService } from 'src/email/email.service';
+import { SocialLoginStrategy } from 'src/socialLogin/social-login-strategy.interface';
+import { KakaoLoginStrategy } from 'src/socialLogin/kakao-login-strategy';
+import { User } from 'src/users/entities/user.entity';
+import { LoginRequestDto } from './dto/login-request.dto.interface';
 
 @Injectable()
 export class AuthService {
+  private socialLoginStrategyMap: Map<string, SocialLoginStrategy> = new Map<
+    string,
+    SocialLoginStrategy
+  >();
+
   constructor(
     private readonly jwtService: JwtService,
     private readonly httpService: HttpService,
     private readonly usersService: UsersService,
-    private readonly emilService: EmailService
-  ) {}
+    private readonly emilService: EmailService,
+    private readonly kakaoLoginStrategy: KakaoLoginStrategy
+  ) {
+    this.socialLoginStrategyMap.set('kakao', kakaoLoginStrategy);
+  }
 
-  async refresh(request) {
+  async refreshApple(request) {
     const ipAddress = request.headers['x-real-ip'];
     const [type, token] = request.headers.authorization?.split(' ') ?? [];
     if (type !== 'Bearer') {
@@ -94,7 +106,43 @@ export class AuthService {
     return decodedIdToken;
   }
 
-  async login(request, createAuthDto: CreateAuthRequestDto) {
+  async login(
+    social: string,
+    ipAddress: string,
+    loginRequestDto: LoginRequestDto
+  ) {
+    const socialLoginStrategy: SocialLoginStrategy =
+      this.socialLoginStrategyMap.get(social);
+
+    if (!socialLoginStrategy) {
+      throw new BadRequestException('지원하지 않는 소셜 로그인 플랫폼입니다');
+    }
+
+    const resourceId: string = await socialLoginStrategy.login(loginRequestDto);
+    const findUser =
+      await this.usersService.getUserInfoByResourceId(resourceId);
+    let user: User;
+    if (findUser) {
+      user = findUser;
+    } else {
+      user = await this.usersService.createUser(
+        resourceId,
+        'temp@temp.com',
+        ipAddress
+      );
+    }
+    const payload = { id: user.id };
+
+    return {
+      accessToken: await this.jwtService.signAsync(payload),
+      refreshToken: await this.jwtService.signAsync(payload, {
+        expiresIn: '30d',
+        secret: process.env.JWT_SECRET_REFRESH,
+      }),
+    };
+  }
+
+  async loginApple(request, createAuthDto: CreateAuthRequestDto) {
     const ipAddress = request.headers['x-real-ip'];
     const [type, token] = request.headers.authorization?.split(' ') ?? [];
     if (type === 'Bearer' && token) {
@@ -234,7 +282,7 @@ export class AuthService {
     });
   }
 
-  async withdrawal(request, deleteAuthDto) {
+  async withdrawalApple(request, deleteAuthDto) {
     const revokeUser = await this.usersService.findUserById(request['user'].id);
 
     const idToken = deleteAuthDto.idToken;

--- a/BE/src/auth/auth.service.ts
+++ b/BE/src/auth/auth.service.ts
@@ -127,6 +127,7 @@ export class AuthService {
     const resourceId: string = await socialLoginStrategy.login(loginRequestDto);
     const findUser =
       await this.usersService.getUserInfoByResourceId(resourceId);
+
     let user: User;
     if (findUser) {
       user = findUser;

--- a/BE/src/auth/dto/kakao-login-request.dto.ts
+++ b/BE/src/auth/dto/kakao-login-request.dto.ts
@@ -1,0 +1,7 @@
+import { LoginRequestDto } from './login-request.dto.interface';
+import { IsString } from 'class-validator';
+
+export class KakaoLoginRequestDto implements LoginRequestDto {
+  @IsString()
+  idToken: string;
+}

--- a/BE/src/auth/dto/login-request.dto.interface.ts
+++ b/BE/src/auth/dto/login-request.dto.interface.ts
@@ -1,0 +1,3 @@
+export interface LoginRequestDto {
+  idToken: string;
+}

--- a/BE/src/socialLogin/kakao-login-strategy.ts
+++ b/BE/src/socialLogin/kakao-login-strategy.ts
@@ -23,7 +23,7 @@ export class KakaoLoginStrategy implements SocialLoginStrategy {
     return;
   }
 
-  withdrawal(): void {
+  withdraw(): void {
     // TO DO
     return;
   }

--- a/BE/src/socialLogin/kakao-login-strategy.ts
+++ b/BE/src/socialLogin/kakao-login-strategy.ts
@@ -1,0 +1,30 @@
+import { SocialLoginStrategy } from './social-login-strategy.interface';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { HttpService } from '@nestjs/axios';
+import * as jwt from 'jsonwebtoken';
+import { LoginRequestDto } from 'src/auth/dto/login-request.dto.interface';
+
+@Injectable()
+export class KakaoLoginStrategy implements SocialLoginStrategy {
+  constructor(private readonly httpService: HttpService) {}
+
+  async login(loginRequestDto: LoginRequestDto): Promise<string> {
+    try {
+      const { idToken } = loginRequestDto;
+      const decodedIdToken = jwt.decode(idToken);
+      return String(decodedIdToken.sub);
+    } catch (error) {
+      throw new UnauthorizedException('유효하지 않은 형식의 토큰입니다.');
+    }
+  }
+
+  refresh(): void {
+    // TO DO
+    return;
+  }
+
+  withdrawal(): void {
+    // TO DO
+    return;
+  }
+}

--- a/BE/src/socialLogin/kakao-login-strategy.ts
+++ b/BE/src/socialLogin/kakao-login-strategy.ts
@@ -9,11 +9,16 @@ import { firstValueFrom } from 'rxjs';
 export class KakaoLoginStrategy implements SocialLoginStrategy {
   constructor(private readonly httpService: HttpService) {}
 
-  async login(loginRequestDto: LoginRequestDto): Promise<string> {
+  async login(
+    loginRequestDto: LoginRequestDto
+  ): Promise<{ resourceId: string; email: string }> {
     try {
       const { idToken } = loginRequestDto;
-      const decodedIdToken = jwt.decode(idToken);
-      return String(decodedIdToken.sub);
+      const { sub, email } = jwt.decode(idToken) as {
+        sub: string;
+        email: string;
+      };
+      return { resourceId: sub, email };
     } catch (error) {
       throw new UnauthorizedException('유효하지 않은 형식의 토큰입니다.');
     }

--- a/BE/src/socialLogin/kakao-login-strategy.ts
+++ b/BE/src/socialLogin/kakao-login-strategy.ts
@@ -3,6 +3,7 @@ import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import * as jwt from 'jsonwebtoken';
 import { LoginRequestDto } from 'src/auth/dto/login-request.dto.interface';
+import { firstValueFrom } from 'rxjs';
 
 @Injectable()
 export class KakaoLoginStrategy implements SocialLoginStrategy {
@@ -23,8 +24,28 @@ export class KakaoLoginStrategy implements SocialLoginStrategy {
     return;
   }
 
-  withdraw(): void {
-    // TO DO
-    return;
+  async withdraw(resourceId: string): Promise<void> {
+    const payload = {
+      target_id_type: 'user_id',
+      target_id: resourceId,
+    };
+    const headers = {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: `KakaoAK ${process.env.KAKAO_SERVICE_APP_ADMIN_KEY}`,
+    };
+
+    try {
+      await firstValueFrom(
+        this.httpService.post(
+          'https://kapi.kakao.com/v1/user/unlink',
+          payload,
+          {
+            headers: headers,
+          }
+        )
+      );
+    } catch (error) {
+      throw new Error(error.msg);
+    }
   }
 }

--- a/BE/src/socialLogin/kakao-login-strategy.ts
+++ b/BE/src/socialLogin/kakao-login-strategy.ts
@@ -24,11 +24,6 @@ export class KakaoLoginStrategy implements SocialLoginStrategy {
     }
   }
 
-  refresh(): void {
-    // TO DO
-    return;
-  }
-
   async withdraw(resourceId: string): Promise<void> {
     const payload = {
       target_id_type: 'user_id',

--- a/BE/src/socialLogin/social-login-strategy.interface.ts
+++ b/BE/src/socialLogin/social-login-strategy.interface.ts
@@ -1,7 +1,9 @@
 import { LoginRequestDto } from 'src/auth/dto/login-request.dto.interface';
 
 export interface SocialLoginStrategy {
-  login(loginRequestDto: LoginRequestDto): Promise<string>;
+  login(
+    loginRequestDto: LoginRequestDto
+  ): Promise<{ resourceId: string; email: string }>;
   refresh(): void;
   withdraw(resourceId: string): void;
 }

--- a/BE/src/socialLogin/social-login-strategy.interface.ts
+++ b/BE/src/socialLogin/social-login-strategy.interface.ts
@@ -3,5 +3,5 @@ import { LoginRequestDto } from 'src/auth/dto/login-request.dto.interface';
 export interface SocialLoginStrategy {
   login(loginRequestDto: LoginRequestDto): Promise<string>;
   refresh(): void;
-  withdrawal(): void;
+  withdraw(): void;
 }

--- a/BE/src/socialLogin/social-login-strategy.interface.ts
+++ b/BE/src/socialLogin/social-login-strategy.interface.ts
@@ -5,5 +5,5 @@ export interface SocialLoginStrategy {
     loginRequestDto: LoginRequestDto
   ): Promise<{ resourceId: string; email: string }>;
   refresh(): void;
-  withdraw(resourceId: string): void;
+  withdraw(resourceId: string): Promise<void>;
 }

--- a/BE/src/socialLogin/social-login-strategy.interface.ts
+++ b/BE/src/socialLogin/social-login-strategy.interface.ts
@@ -4,6 +4,5 @@ export interface SocialLoginStrategy {
   login(
     loginRequestDto: LoginRequestDto
   ): Promise<{ resourceId: string; email: string }>;
-  refresh(): void;
   withdraw(resourceId: string): Promise<void>;
 }

--- a/BE/src/socialLogin/social-login-strategy.interface.ts
+++ b/BE/src/socialLogin/social-login-strategy.interface.ts
@@ -3,5 +3,5 @@ import { LoginRequestDto } from 'src/auth/dto/login-request.dto.interface';
 export interface SocialLoginStrategy {
   login(loginRequestDto: LoginRequestDto): Promise<string>;
   refresh(): void;
-  withdraw(): void;
+  withdraw(resourceId: string): void;
 }

--- a/BE/src/socialLogin/social-login-strategy.interface.ts
+++ b/BE/src/socialLogin/social-login-strategy.interface.ts
@@ -1,0 +1,7 @@
+import { LoginRequestDto } from 'src/auth/dto/login-request.dto.interface';
+
+export interface SocialLoginStrategy {
+  login(loginRequestDto: LoginRequestDto): Promise<string>;
+  refresh(): void;
+  withdrawal(): void;
+}


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- be-feature/#421-kakao

## 📚 작업한 내용
- 소셜 로그인 전략 인터페이스 및 카카오 구현체 생성
    - login, withdraw 메서드 有
- 카카오 로그인(회원가입) 구현
- 카카오 계정 회원의 탈퇴 구현

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 새로 작성한 메서드와 구분하기 위해 authService의 기존 애플 관련 로직에는 Apple을 붙여 놓았어요! 전략 패턴에 맞춰 소셜 로그인을 구현하고 싶어서 애플 관련 코드? 구조?도 리팩토링할 계획입니다 ㅎㅎ 그래서 나중에 엔드 포인트가 바뀔 수도 있을 것 같아요.

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 관련 이슈
- Resolved: #
