### PR TITLE
[fix] 소셜 로그인과 개발용 로그인 라우터 순서 변경 & 경로 파라미터 관련 Swagger 추가

### DIFF
--- a/BE/src/auth/auth.controller.ts
+++ b/BE/src/auth/auth.controller.ts
@@ -9,7 +9,12 @@ import {
   Param,
 } from '@nestjs/common';
 import { AuthService } from './auth.service';
-import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import {
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiTags,
+} from '@nestjs/swagger';
 import { CreateAuthRequestForDevDto } from './dto/create-auth-request-for-dev.dto';
 import { AuthGuard } from './auth.guard';
 import { login, refresh, withdrawal } from './auth.swagger';
@@ -46,6 +51,11 @@ export class AuthController {
   }
 
   @Post('login/:social')
+  @ApiParam({
+    name: 'social',
+    enum: ['apple', 'kakao'],
+    description: '소셜 로그인 종류',
+  })
   @ApiOperation({
     summary: '로그인 또는 회원가입 API',
     description:
@@ -63,6 +73,11 @@ export class AuthController {
 
   @UseGuards(AuthGuard)
   @Delete('withdraw/:social')
+  @ApiParam({
+    name: 'social',
+    enum: ['apple', 'kakao'],
+    description: '소셜 로그인 종류',
+  })
   @ApiOperation({
     summary: '탈퇴 API',
     description:

--- a/BE/src/auth/auth.controller.ts
+++ b/BE/src/auth/auth.controller.ts
@@ -32,6 +32,19 @@ export class AuthController {
     return this.authService.refresh(headerMap);
   }
 
+  @Post('login/dev')
+  @ApiOperation({
+    summary: '개발용 로그인 API',
+    description:
+      '전달받은 회원 id를 확인하고 존재하는 회원이면 로그인을 진행합니다.' +
+      '개발 테스트용 API에서는 회원가입이 불가합니다.' +
+      '회원 생성이 필요한 경우 백엔드 팀원에게 요청해주세요.',
+  })
+  @ApiOkResponse({ description: 'OK', schema: { example: login } })
+  loginForDev(@Body() createAuthForDevDto: CreateAuthRequestForDevDto) {
+    return this.authService.loginForDev(createAuthForDevDto);
+  }
+
   @Post('login/:social')
   @ApiOperation({
     summary: '로그인 또는 회원가입 API',
@@ -46,19 +59,6 @@ export class AuthController {
   ) {
     const headerMap: Map<string, string> = this.makeHeaderMap(request);
     return this.authService.login(social, headerMap, socialLoginRequestDto);
-  }
-
-  @Post('login/dev')
-  @ApiOperation({
-    summary: '개발용 로그인 API',
-    description:
-      '전달받은 회원 id를 확인하고 존재하는 회원이면 로그인을 진행합니다.' +
-      '개발 테스트용 API에서는 회원가입이 불가합니다.' +
-      '회원 생성이 필요한 경우 백엔드 팀원에게 요청해주세요.',
-  })
-  @ApiOkResponse({ description: 'OK', schema: { example: login } })
-  loginForDev(@Body() createAuthForDevDto: CreateAuthRequestForDevDto) {
-    return this.authService.loginForDev(createAuthForDevDto);
   }
 
   @UseGuards(AuthGuard)


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- be-feature/#438-login-dev-router

## 📚 작업한 내용
- `login/dev` 라우터가 `login/:social` 라우터보다 먼저 등록되도록 순서 변경
- `login/:social`과 `withdraw/:social` 라우터에서 `social` 관련 Swagger 등록
    - `@ApiParam` 데코레이터로 경로 파라미터 social의 설명과 enum 등록

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 관련 이슈
- Resolved: #438
