### PR TITLE
[hotfix] 차단하기 기능 UI 구현

### DIFF
--- a/iOS/traveline/Sources/Core/Constant/Literal.swift
+++ b/iOS/traveline/Sources/Core/Constant/Literal.swift
@@ -118,6 +118,7 @@ enum Literal {
         static let modify: String = "수정하기"
         static let delete: String = "삭제하기"
         static let report: String = "신고하기"
+        static let block: String = "차단하기"
         static let translate: String = "번역하기"
     }
     

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/VC/TimelineVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/VC/TimelineVC.swift
@@ -22,11 +22,6 @@ final class TimelineVC: UIViewController {
         }
     }
     
-    private enum Constants {
-        static let didFinishDeleteWithSuccess: String = "여행 삭제를 완료했어요 !"
-        static let didFinishDeleteWithFailure: String = "여행 삭제에 실패했어요."
-    }
-    
     private enum TimelineSection: Int {
         case travelInfo
         case timeline
@@ -135,6 +130,9 @@ final class TimelineVC: UIViewController {
             ]
         } else {
             menuItems = [
+                .init(title: Literal.Action.block, attributes: .destructive, handler: { [weak self] _ in
+                    self?.viewModel.sendAction(.blockTravel)
+                }),
                 .init(title: Literal.Action.report, attributes: .destructive, handler: { [weak self] _ in
                     self?.viewModel.sendAction(.reportTravel)
                 })

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/VC/TimelineVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/VC/TimelineVC.swift
@@ -249,15 +249,27 @@ private extension TimelineVC {
             .store(in: &cancellables)
         
         viewModel.state
-            .map(\.isDeleteCompleted)
+            .map(\.timelineManageType)
             .removeDuplicates()
             .dropFirst()
             .withUnretained(self)
-            .sink { owner, isSuccess in
+            .sink { owner, type in
                 owner.navigationController?.popViewController(animated: true)
                 owner.delegate?.viewControllerDidFinishAction(
-                    isSuccess: isSuccess,
-                    message: isSuccess ? Constants.didFinishDeleteWithSuccess : Constants.didFinishDeleteWithFailure
+                    isSuccess: true,
+                    message: type.description
+                )
+            }
+            .store(in: &cancellables)
+        
+        viewModel.state
+            .compactMap(\.errorMsg)
+            .removeDuplicates()
+            .withUnretained(self)
+            .sink { owner, message in
+                owner.viewControllerDidFinishAction(
+                    isSuccess: false,
+                    message: message
                 )
             }
             .store(in: &cancellables)

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/ViewModel/TimelineViewModel.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/ViewModel/TimelineViewModel.swift
@@ -192,7 +192,7 @@ final class TimelineViewModel: BaseViewModel<TimelineAction, TimelineSideEffect,
             )
             
         case let .timelineError(error):
-            break
+            newState.errorMsg = error.errorDescription
             
         case .popToTimeline:
             newState.timelineWritingInfo = nil

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/ViewModel/TimelineViewModel.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/ViewModel/TimelineViewModel.swift
@@ -9,6 +9,29 @@
 import Combine
 import Foundation
 
+enum TimelineManageType {
+    case none
+    case delete
+    case block
+    case report
+    
+    private enum Constants {
+        static let didFinishDeleteWithSuccess: String = "여행 삭제를 완료했어요 !"
+        static let didFinishDeleteWithFailure: String = "여행 삭제에 실패했어요."
+        static let didFinishBlock: String = "해당 사용자를 차단했어요."
+        static let didFinishReport: String = "해당 게시글을 신고했어요."
+    }
+    
+    var description: String {
+        switch self {
+        case .delete: Constants.didFinishDeleteWithSuccess
+        case .block: Constants.didFinishBlock
+        case .report: Constants.didFinishReport
+        default: ""
+        }
+    }
+}
+
 enum TimelineAction: BaseAction {
     case viewWillAppear
     case enterToTimeline
@@ -19,6 +42,7 @@ enum TimelineAction: BaseAction {
     case editTravel
     case deleteTravel
     case reportTravel
+    case blockTravel
 }
 
 enum TimelineSideEffect: BaseSideEffect {
@@ -27,13 +51,15 @@ enum TimelineSideEffect: BaseSideEffect {
         case deleteFailed
         case reportFailed
         case likeFailed
+        case blockFailed
         
-        var errorDescription: String {
+        var errorDescription: String? {
             switch self {
             case .loadFailed: "서버 통신에 실패했습니다."
             case .deleteFailed: "여행 삭제에 실패했습니다."
             case .reportFailed: "여행 신고에 실패했습니다."
             case .likeFailed: "여행 좋아요에 실패했습니다."
+            case .blockFailed: "사용자 차단에 실패했습니다."
             }
         }
     }
@@ -46,7 +72,7 @@ enum TimelineSideEffect: BaseSideEffect {
     case showTimelineWriting
     case showTimelineEditing
     case popToTimeline
-    case popToHome
+    case popToHome(TimelineManageType)
     case timelineError(TimelineError)
     case resetState
     case none
@@ -66,7 +92,7 @@ struct TimelineState: BaseState {
     var date: String?
     var timelineWritingInfo: TimelineWritingInfo?
     var isEdit: Bool = false
-    var isDeleteCompleted: Bool = false
+    var timelineManageType: TimelineManageType = .none
     var errorMsg: String?
     var isEmptyList: Bool = false
 }
@@ -118,6 +144,9 @@ final class TimelineViewModel: BaseViewModel<TimelineAction, TimelineSideEffect,
             
         case .reportTravel:
             return reportTravel()
+            
+        case .blockTravel:
+            return blockTravel()
         }
     }
     
@@ -130,7 +159,7 @@ final class TimelineViewModel: BaseViewModel<TimelineAction, TimelineSideEffect,
             
         case .resetState:
             newState.isEdit = false
-            newState.isDeleteCompleted = false
+            newState.timelineManageType = .none
             newState.timelineWritingInfo = nil
             
         case let .loadTimeline(travelInfo):
@@ -168,8 +197,8 @@ final class TimelineViewModel: BaseViewModel<TimelineAction, TimelineSideEffect,
         case .popToTimeline:
             newState.timelineWritingInfo = nil
             
-        case .popToHome:
-            newState.isDeleteCompleted = true
+        case .popToHome(let type):
+            newState.timelineManageType = type
             
         case let .updateCurDate(date):
             newState.date = date
@@ -222,7 +251,7 @@ private extension TimelineViewModel {
     func deleteTravel() -> SideEffectPublisher {
         return timelineUseCase.deleteTravel(id: id)
             .map { _ in
-                return .popToHome
+                return .popToHome(.delete)
             }
             .catch { _ in
                 return Just(.timelineError(.deleteFailed))
@@ -230,10 +259,22 @@ private extension TimelineViewModel {
             .eraseToAnyPublisher()
     }
     
+    // TODO: 서버 연동 필요
+    func blockTravel() -> SideEffectPublisher {
+        return timelineUseCase.reportTravel(id: id)
+            .map { _ in
+                return .popToHome(.block)
+            }
+            .catch { _ in
+                return Just(.timelineError(.blockFailed))
+            }
+            .eraseToAnyPublisher()
+    }
+    
     func reportTravel() -> SideEffectPublisher {
         return timelineUseCase.reportTravel(id: id)
             .map { _ in
-                return .popToHome
+                return .popToHome(.report)
             }
             .catch { _ in
                 return Just(.timelineError(.reportFailed))


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- feature/#446

## 📚 작업한 내용
리젝 이슈로 차단하기 기능 추가합니다.
우선적으로 UI 및 기능 작업 완료했습니다.
기존 신고하기를 누르더라도 "타임라인 삭제를 완료했어요!" 팝업이 뜨는 오류도 함께 해결했습니다.

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

### TimelineMenuType 추가
... 더보기 란에서 볼 수 있는 menu 타입을 담은 enum 클래스 생성해서 관리해주도록 했습니다.
추후에 기능 추가가 있을 때도 해당 코드를 참고하면 될 것 같아요.

### errorMsg 값 업데이트
현재 삭제에 실패해도 성공 케이스의 토스트가 뜨는 상황이었습니다.
이에 기존에 만들어둔 errorDescription을 사용해 errorMsg 상태 값 업데이트하도록 했습니다.
state.errrorMsg를 VC쪽에서 바인딩해서 실패 토스트 띄울 수 있습니다.

## 📸 스크린샷
|차단하기 UI|차단 성공|차단 실패|
|:--:|:--:|:--:|
|<img src="https://github.com/boostcampwm2023/iOS07-traveline/assets/74968390/230bb659-65a3-4bd1-9653-f07befcab608">|<img src="https://github.com/boostcampwm2023/iOS07-traveline/assets/74968390/3ad41b0b-d89e-418e-b14c-108e68f9132e">|<img src="https://github.com/boostcampwm2023/iOS07-traveline/assets/74968390/af9f5073-0bba-470c-a373-a6e96dc91a2f">

## 관련 이슈
- Resolved: #446
