### PR TITLE
[chore] 서버 내부 에러 로그 작성하도록 수정

### DIFF
--- a/BE/src/exception/exception.filter.ts
+++ b/BE/src/exception/exception.filter.ts
@@ -15,6 +15,9 @@ export class HttpExceptionFilter implements ExceptionFilter {
     const request = context.getRequest();
 
     if (!(exception instanceof HttpException)) {
+      winstonLogger.log(
+        `**Only Server: Response from ${request.method} ${request.url}\nresponse: ${exception.name} - ${exception.message}`
+      );
       exception = new InternalServerErrorException();
     }
 


### PR DESCRIPTION
서버 내부 에러는 곧바로 500번대 에러로 재할당하여 정확한 에러 원인 파악이 어려웠다. 따라서 500번대 에러로 할당하기 전에 기존 에러 내용을 로그에 남기도록 수정했다.

## 🌎 PR 요약

🌱 작업한 브랜치
- be-feature/#449-error-log

## 📚 작업한 내용
서버 내부 에러는 곧바로 500번대 에러로 재할당하여 정확한 에러 원인 파악이 어려웠습니다. 따라서 500번대 에러로 할당하기 전에 기존 에러 내용을 로그에 남기도록 수정했습니다.

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 관련 이슈
- Resolved: #449
