### PR TITLE
[hotfix] apple 탈퇴하기 endpoint 변경

### DIFF
--- a/iOS/Plugins/EnvPlugin/ProjectDescriptionHelpers/InfoPlist.swift
+++ b/iOS/Plugins/EnvPlugin/ProjectDescriptionHelpers/InfoPlist.swift
@@ -25,6 +25,7 @@ public extension Project {
                 ]
             ]
         ],
+        "ITSAppUsesNonExemptEncryption": "false",
         "ProdURL": "$(PROD_URL)",
         "DevURL": "$(DEV_URL)"
     ]

--- a/iOS/traveline/Sources/Data/Network/API/AuthEndPoint.swift
+++ b/iOS/traveline/Sources/Data/Network/API/AuthEndPoint.swift
@@ -18,7 +18,7 @@ extension AuthEndPoint: EndPoint {
     var path: String? {
         switch self {
         case .withdrawal:
-            return "/auth/withdrawal/apple"
+            return "/auth/withdraw/apple"
         case .appleLogin:
             return "/auth/login/apple"
         case .refresh:


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- feature/#451

## 📚 작업한 내용
- apple 탈퇴하기 endpoint 변경
- info.plist 키 추가

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

#### apple 탈퇴하기 endpoint 변경
AS-IS : /auth/withdrawal/apple
TO-BE : /auth/withdraw/apple

#### ITSAppUsesNonExemptEncryption = false 추가
기존에 build 후에 app store connect에서 missing compliance가 뜨면서 수동으로 None을 선택해줘야했는데요.
이걸 info.plist에 넣어주는 방식으로 변경했습니다 ~ !

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 관련 이슈
- Resolved: #451
