### PR TITLE
[fix] LoginStrategy에서 email 필드 선택적 반환으로 전환

### DIFF
--- a/BE/src/socialLogin/apple-login-strategy.ts
+++ b/BE/src/socialLogin/apple-login-strategy.ts
@@ -17,10 +17,13 @@ export class AppleLoginStrategy implements SocialLoginStrategy {
 
   async login(
     socialLoginRequestDto: SocialLoginRequestDto
-  ): Promise<{ resourceId: string; email: string }> {
+  ): Promise<{ resourceId: string; email?: string }> {
     try {
       const { idToken, email } = socialLoginRequestDto;
       const resourceId = (await this.decodeIdToken(idToken)).sub;
+      if (!email) {
+        return { resourceId };
+      }
       return { resourceId, email };
     } catch (error) {
       throw new UnauthorizedException('유효하지 않은 형식의 토큰입니다.');

--- a/BE/src/socialLogin/social-login-strategy.interface.ts
+++ b/BE/src/socialLogin/social-login-strategy.interface.ts
@@ -4,7 +4,7 @@ import { SocialLoginRequestDto } from './dto/social-login-request.dto';
 export interface SocialLoginStrategy {
   login(
     socialLoginRequestDto: SocialLoginRequestDto
-  ): Promise<{ resourceId: string; email: string }>;
+  ): Promise<{ resourceId: string; email?: string }>;
   withdraw(
     resourceId: string,
     socialWithdrawRequestDto: SocialWithdrawRequestDto


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- be-feature/#458

## 📚 작업한 내용
서버 로그 확인 결과 이메일 필드를 받아오는 과정에서 문제가 발생하는 것으로 추측되어 LoginStrategy의 이메일 필드를 선택 반환으로 설정해두었습니다.

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
애플로그인 부분만 수정하니 타입 충돌이 발생해서 LoginStrategy 부분을 건드렸는데 카카오 로그인 부분과 충돌은 없는지 확인하면 좋을 것 같아요!
<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 관련 이슈
- Resolved: #458
