### PR TITLE
[feature] 유저 차단 API 연동

### DIFF
--- a/iOS/traveline/Sources/Core/Enum/VCFactory.swift
+++ b/iOS/traveline/Sources/Core/Enum/VCFactory.swift
@@ -30,15 +30,18 @@ enum VCFactory {
         return RootContainerVC()
     }
     
-    static func makeTimelineVC(id: TravelID) -> TimelineVC {
+    static func makeTimelineVC(id: TravelID, userID: UserID? = nil) -> TimelineVC {
         let postingRepository = PostingRepositoryImpl(network: network)
         let timelineRepository = TimelineRepositoryImpl(network: network)
+        let userRepository = UserRepositoryImpl(network: network)
         let useCase = TimelineUseCaseImpl(
             postingRepository: postingRepository,
-            timelineRepository: timelineRepository
+            timelineRepository: timelineRepository,
+            userRepository: userRepository
         )
         let viewModel = TimelineViewModel(
             id: id,
+            userID: userID,
             fetchTravelInfoUseCase: useCase
         )
         return TimelineVC(viewModel: viewModel)
@@ -72,7 +75,7 @@ enum VCFactory {
         let repository = PostingRepositoryImpl(network: network)
         let useCase = TravelUseCaseImpl(repository: repository)
         let viewModel = TravelViewModel(
-            id: id, 
+            id: id,
             travelInfo: travelInfo,
             travelUseCase: useCase
         )

--- a/iOS/traveline/Sources/Data/Network/API/UserEndPoint.swift
+++ b/iOS/traveline/Sources/Data/Network/API/UserEndPoint.swift
@@ -12,6 +12,7 @@ enum UserEndPoint {
     case requestUserInfo
     case updateUserInfo(UserRequestDTO)
     case checkDuplicatedName(String)
+    case blockUser(String)
 }
 
 extension UserEndPoint: EndPoint {
@@ -21,6 +22,8 @@ extension UserEndPoint: EndPoint {
             return "/users/duplicate?name=\(name)"
         case .requestUserInfo:
             return "/users"
+        case .blockUser(let id):
+            return "/users/\(id)/block"
         default:
             return "/users"
         }
@@ -32,6 +35,8 @@ extension UserEndPoint: EndPoint {
             return .PUT
         case .requestUserInfo:
             return .GET
+        case .blockUser:
+            return .POST
         default:
             return .GET
         }

--- a/iOS/traveline/Sources/Data/Network/DataMapping/PostingResponseDTO.swift
+++ b/iOS/traveline/Sources/Data/Network/DataMapping/PostingResponseDTO.swift
@@ -43,6 +43,7 @@ extension PostingResponseDTO {
             imagePath: thumbnailPath ?? Literal.empty,
             title: title,
             profile: .init(
+                id: writer.id ?? Literal.empty,
                 imageURL: writer.avatar ?? Literal.empty,
                 imagePath: writer.avatarPath ?? Literal.empty,
                 name: writer.name

--- a/iOS/traveline/Sources/Data/Network/DataMapping/UserResponseDTO.swift
+++ b/iOS/traveline/Sources/Data/Network/DataMapping/UserResponseDTO.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 struct UserResponseDTO: Codable {
+    let id: String
     let name: String
     let avatar: String?
     let avatarPath: String?
@@ -17,6 +18,7 @@ struct UserResponseDTO: Codable {
 extension UserResponseDTO {
     func toDomain() -> Profile {
         return .init(
+            id: id,
             imageURL: avatar ?? "",
             imagePath: avatarPath ?? "",
             name: name

--- a/iOS/traveline/Sources/Data/Repository/Mock/UserRepositoryMock.swift
+++ b/iOS/traveline/Sources/Data/Repository/Mock/UserRepositoryMock.swift
@@ -17,10 +17,12 @@ final class UserRepositoryMock: UserRepository {
         "kmi0817",
         "yaongmeow"
     ]
+    
     func fetchUserInfo() async throws -> Profile {
         try await Task.sleep(nanoseconds: 1_000_000_000)
         
         let mockData: Profile = .init(
+            id: "",
             imageURL: "https://avatars.githubusercontent.com/u/91725382?s=400&u=29b8023a56a09685aaab53d4eb0dd556254cd902&v=4",
             imagePath: "https://avatars.githubusercontent.com/u/91725382?s=400&u=29b8023a56a09685aaab53d4eb0dd556254cd902&v=4",
             name: "hongki"
@@ -32,6 +34,7 @@ final class UserRepositoryMock: UserRepository {
         try await Task.sleep(nanoseconds: 1_000_000_000)
         
         return .init(
+            id: "",
             imageURL: "https://avatars.githubusercontent.com/u/91725382?s=400&u=29b8023a56a09685aaab53d4eb0dd556254cd902&v=4",
             imagePath: "https://avatars.githubusercontent.com/u/91725382?s=400&u=29b8023a56a09685aaab53d4eb0dd556254cd902&v=4",
             name: "hongki"
@@ -42,5 +45,11 @@ final class UserRepositoryMock: UserRepository {
         try await Task.sleep(nanoseconds: 1_000_000)
         
         return alreadyNames.contains(name)
+    }
+    
+    func blockUser(id: UserID) async throws -> Bool {
+        try await Task.sleep(nanoseconds: 1_000_000)
+        
+        return true
     }
 }

--- a/iOS/traveline/Sources/Data/Repository/UserRepositoryImpl.swift
+++ b/iOS/traveline/Sources/Data/Repository/UserRepositoryImpl.swift
@@ -52,4 +52,10 @@ final class UserRepositoryImpl: UserRepository {
         
         return duplicatedNameResponseDTO.isDuplicated
     }
+    
+    func blockUser(id: UserID) async throws -> Bool {
+        let blockUserResponseDTO = try await network.requestWithNoResult(endPoint: UserEndPoint.blockUser(id.value))
+        
+        return blockUserResponseDTO
+    }
 }

--- a/iOS/traveline/Sources/Domain/Model/Auth/UserID.swift
+++ b/iOS/traveline/Sources/Domain/Model/Auth/UserID.swift
@@ -1,0 +1,17 @@
+//
+//  UserID.swift
+//  traveline
+//
+//  Created by 김영인 on 6/1/24.
+//  Copyright © 2024 traveline. All rights reserved.
+//
+
+import Foundation
+
+import Foundation
+
+struct UserID: Equatable, Hashable {
+    let value: String
+    
+    static let empty: Self = .init(value: "")
+}

--- a/iOS/traveline/Sources/Domain/Model/Profile.swift
+++ b/iOS/traveline/Sources/Domain/Model/Profile.swift
@@ -9,11 +9,13 @@
 import Foundation
 
 struct Profile: Hashable {
+    let id: String
     let imageURL: String
     let imagePath: String
     let name: String
     
     static let empty: Profile = .init(
+        id: Literal.empty,
         imageURL: Literal.empty,
         imagePath: Literal.empty,
         name: Literal.empty

--- a/iOS/traveline/Sources/Domain/Model/Sample/ProfileSample.swift
+++ b/iOS/traveline/Sources/Domain/Model/Sample/ProfileSample.swift
@@ -11,6 +11,7 @@ import Foundation
 enum ProfileSample {
     static func make() -> Profile {
         .init(
+            id: "",
             imageURL: "https://avatars.githubusercontent.com/u/74968390?v=4",
             imagePath: "https://avatars.githubusercontent.com/u/74968390?v=4",
             name: "0inn"

--- a/iOS/traveline/Sources/Domain/Model/Sample/TravelListSample.swift
+++ b/iOS/traveline/Sources/Domain/Model/Sample/TravelListSample.swift
@@ -24,7 +24,7 @@ enum TravelListSample {
                   imageURL: "",
                   imagePath: "",
                   title: "부산여행",
-                  profile: Profile(imageURL: "", imagePath: "", name: "영인"),
+                  profile: Profile(id: "", imageURL: "", imagePath: "", name: "영인"),
                   like: 10,
                   isLiked: false,
                   tags: TravelListSample.makeTags()
@@ -37,7 +37,7 @@ enum TravelListSample {
                   imageURL: "",
                   imagePath: "",
                   title: "부산여행",
-                  profile: Profile(imageURL: "", imagePath: "", name: "영인"),
+                  profile: Profile(id: "", imageURL: "", imagePath: "", name: "영인"),
                   like: 10,
                   isLiked: false,
                   tags: TravelListSample.makeTags()
@@ -46,7 +46,7 @@ enum TravelListSample {
                   imageURL: "",
                   imagePath: "",
                   title: "속초여행",
-                  profile: Profile(imageURL: "", imagePath: "", name: "0inn"),
+                  profile: Profile(id: "", imageURL: "", imagePath: "", name: "0inn"),
                   like: 20,
                   isLiked: true,
                   tags: TravelListSample.makeTags()
@@ -55,7 +55,7 @@ enum TravelListSample {
                   imageURL: "",
                   imagePath: "",
                   title: "제주도여행",
-                  profile: Profile(imageURL: "", imagePath: "", name: "youngin"),
+                  profile: Profile(id: "", imageURL: "", imagePath: "", name: "youngin"),
                   like: 30,
                   isLiked: true,
                   tags: TravelListSample.makeTags()
@@ -64,7 +64,7 @@ enum TravelListSample {
                   imageURL: "",
                   imagePath: "",
                   title: "제주도여행",
-                  profile: Profile(imageURL: "", imagePath: "", name: "youngin"),
+                  profile: Profile(id: "", imageURL: "", imagePath: "", name: "youngin"),
                   like: 30,
                   isLiked: false,
                   tags: TravelListSample.makeTags()
@@ -73,7 +73,7 @@ enum TravelListSample {
                   imageURL: "",
                   imagePath: "",
                   title: "제주도여행",
-                  profile: Profile(imageURL: "", imagePath: "", name: "youngin"),
+                  profile: Profile(id: "", imageURL: "", imagePath: "", name: "youngin"),
                   like: 30,
                   isLiked: true,
                   tags: TravelListSample.makeTags()
@@ -82,7 +82,7 @@ enum TravelListSample {
                   imageURL: "",
                   imagePath: "",
                   title: "제주도여행",
-                  profile: Profile(imageURL: "", imagePath: "", name: "youngin"),
+                  profile: Profile(id: "", imageURL: "", imagePath: "", name: "youngin"),
                   like: 0,
                   isLiked: false,
                   tags: TravelListSample.makeTags()

--- a/iOS/traveline/Sources/Domain/RepositoryInterface/UserRepository.swift
+++ b/iOS/traveline/Sources/Domain/RepositoryInterface/UserRepository.swift
@@ -12,4 +12,5 @@ protocol UserRepository {
     func fetchUserInfo() async throws -> Profile
     func updateUserInfo(name: String, imageData: Data?) async throws -> Profile
     func checkDuplication(name: String) async throws -> Bool
+    func blockUser(id: UserID) async throws -> Bool
 }

--- a/iOS/traveline/Sources/Domain/UseCase/TimelineUseCase.swift
+++ b/iOS/traveline/Sources/Domain/UseCase/TimelineUseCase.swift
@@ -15,19 +15,26 @@ protocol TimelineUseCase {
     func calculateDate(from startDate: String, with day: Int) -> String?
     func deleteTravel(id: TravelID) -> AnyPublisher<Bool, Error>
     func reportTravel(id: TravelID) -> AnyPublisher<Bool, Error>
+    func blockUser(id: UserID) -> AnyPublisher<Bool, Error>
     func likeTravel(id: TravelID) -> AnyPublisher<Bool, Error>
 }
 
 final class TimelineUseCaseImpl: TimelineUseCase {
-
+    
     private let postingRepository: PostingRepository
     private let timelineRepository: TimelineRepository
+    private let userRepository: UserRepository
     
-    init(postingRepository: PostingRepository, timelineRepository: TimelineRepository) {
+    init(
+        postingRepository: PostingRepository,
+        timelineRepository: TimelineRepository,
+        userRepository: UserRepository
+    ) {
         self.postingRepository = postingRepository
         self.timelineRepository = timelineRepository
+        self.userRepository = userRepository
     }
-
+    
     func fetchTimelineInfo(id: TravelID) -> AnyPublisher<TimelineTravelInfo, Error> {
         return Future {
             let travelInfo = try await self.postingRepository.fetchTimelineInfo(id: id)
@@ -47,7 +54,7 @@ final class TimelineUseCaseImpl: TimelineUseCase {
               let curDate = Calendar.current.date(byAdding: .day, value: day, to: date) else { return nil }
         
         return curDate.toString(with: "yyyy년 MM월 dd일")
-
+        
     }
     
     func deleteTravel(id: TravelID) -> AnyPublisher<Bool, Error> {
@@ -60,6 +67,13 @@ final class TimelineUseCaseImpl: TimelineUseCase {
     func reportTravel(id: TravelID) -> AnyPublisher<Bool, Error> {
         return Future {
             let result = try await self.postingRepository.postReport(id: id)
+            return result
+        }.eraseToAnyPublisher()
+    }
+    
+    func blockUser(id: UserID) -> AnyPublisher<Bool, any Error> {
+        return Future {
+            let result = try await self.userRepository.blockUser(id: id)
             return result
         }.eraseToAnyPublisher()
     }

--- a/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/VC/HomeVC.swift
+++ b/iOS/traveline/Sources/Feature/HomeFeature/HomeScene/VC/HomeVC.swift
@@ -268,7 +268,11 @@ private extension HomeVC {
             .withUnretained(self)
             .sink { owner, idx  in
                 let id = owner.viewModel.currentState.travelList[idx].id
-                let timelineVC = VCFactory.makeTimelineVC(id: TravelID(value: id))
+                let userID = owner.viewModel.currentState.travelList[idx].profile.id
+                let timelineVC = VCFactory.makeTimelineVC(
+                    id: TravelID(value: id),
+                    userID: UserID(value: userID)
+                )
                 timelineVC.delegate = owner
                 owner.navigationController?.pushViewController(
                     timelineVC,

--- a/iOS/traveline/Sources/Feature/MyPageFeature/MyPostListScene/VC/MyPostListVC.swift
+++ b/iOS/traveline/Sources/Feature/MyPageFeature/MyPostListScene/VC/MyPostListVC.swift
@@ -172,7 +172,8 @@ private extension MyPostListVC {
 extension MyPostListVC: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let id = TravelID(value: viewModel.currentState.travelList[indexPath.row].id)
-        let timelineVC = VCFactory.makeTimelineVC(id: id)
+        let userID = UserID(value: viewModel.currentState.travelList[indexPath.row].profile.id)
+        let timelineVC = VCFactory.makeTimelineVC(id: id, userID: userID)
         self.navigationController?.pushViewController(timelineVC, animated: true)
     }
 }

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/VC/TimelineVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/VC/TimelineVC.swift
@@ -470,8 +470,3 @@ extension TimelineVC: ToastDelegate {
         showToast(message: message, type: isSuccess ? .success : .failure)
     }
 }
-
-@available(iOS 17, *)
-#Preview {
-    UINavigationController(rootViewController: VCFactory.makeTimelineVC(id: .empty))
-}

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/ViewModel/TimelineViewModel.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineScene/ViewModel/TimelineViewModel.swift
@@ -100,13 +100,16 @@ struct TimelineState: BaseState {
 final class TimelineViewModel: BaseViewModel<TimelineAction, TimelineSideEffect, TimelineState> {
     
     private(set) var id: TravelID
+    private(set) var userID: UserID?
     private let timelineUseCase: TimelineUseCase
     
     init(
         id: TravelID,
+        userID: UserID?,
         fetchTravelInfoUseCase: TimelineUseCase
     ) {
         self.id = id
+        self.userID = userID
         self.timelineUseCase = fetchTravelInfoUseCase
     }
     
@@ -259,9 +262,12 @@ private extension TimelineViewModel {
             .eraseToAnyPublisher()
     }
     
-    // TODO: 서버 연동 필요
     func blockTravel() -> SideEffectPublisher {
-        return timelineUseCase.reportTravel(id: id)
+        guard let userID else {
+            return .just(.none)
+        }
+        
+        return timelineUseCase.blockUser(id: userID)
             .map { _ in
                 return .popToHome(.block)
             }

--- a/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/VC/TravelVC.swift
+++ b/iOS/traveline/Sources/Feature/TravelFeature/TravelScene/VC/TravelVC.swift
@@ -394,8 +394,3 @@ extension TravelVC: TLNavigationBarDelegate {
         viewModel.sendAction(.donePressed(selectedTags))
     }
 }
-
-@available(iOS 17, *)
-#Preview {
-    return UINavigationController(rootViewController: VCFactory.makeTravelVC())
-}


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- feature/#460

## 📚 작업한 내용
유저 차단 API 연동

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

### 기존 Profile 모델에 id 필드 추가
유저 차단 API 호출 시 유저 id가 필요하기에 추가해뒀습니다.
(+ 기존 posting id를 TravelID로 관리했기에 UserID 구조체도 생성해뒀습니다.)

### timelineVC 생성 시, userID 전달
timelineVC로 넘어가는 경우는 두 가지가 있는데요.
1. 리스트에서 클릭하여 상세 타임라인 뷰로 진입
2. 여행 생성 후 바로 타임라인 뷰로 진입

이 두가지 경우 중 여행 생성 시에는 userID가 필요하지 않다고 판단했습니다.
userID는 자기 자신이 될거기 때문에 유저 차단 기능을 지원하지 않기 때문이죠.
그래서 VCFactory에서 userID 파라미터는 optional로 선언하고 기본값으로 nil을 추가했습니다ㅏ.

```Swift
static func makeTimelineVC(id: TravelID, userID: UserID? = nil) -> TimelineVC {
   // 생략
}
```

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|차단하기|![Simulator Screen Recording - iPhone 13 mini - 2024-06-01 at 13 42 43](https://github.com/boostcampwm2023/iOS07-traveline/assets/74968390/3e692859-1fd7-493d-83b1-f0eb775529d7)| 

## 관련 이슈
- Resolved: #460 
