### PR TITLE
[fix] apple login email 체크 로직 추가

### DIFF
--- a/iOS/traveline/Sources/Core/Enum/VCFactory.swift
+++ b/iOS/traveline/Sources/Core/Enum/VCFactory.swift
@@ -21,8 +21,9 @@ enum VCFactory {
     
     static func makeLoginVC() -> LoginVC {
         let repository = AuthRepositoryImpl(network: network)
-        let useCase = LoginUseCaseImpl(repository: repository)
-        let viewModel = LoginViewModel(useCase: useCase)
+        let loginUseCase = LoginUseCaseImpl(repository: repository)
+        let settingUseCase = SettingUseCaseImpl(repository: repository)
+        let viewModel = LoginViewModel(loginUseCase: loginUseCase, settingUseCase: settingUseCase)
         return LoginVC(viewModel: viewModel)
     }
     

--- a/iOS/traveline/Sources/Data/Repository/AuthRepositoryImpl.swift
+++ b/iOS/traveline/Sources/Data/Repository/AuthRepositoryImpl.swift
@@ -49,7 +49,7 @@ final class AuthRepositoryImpl: AuthRepository {
     
     func withdrawal(_ request: WithdrawRequest) async throws -> Bool {
         
-        let result = try await network.request(
+        let result: WithdrawalResponseDTO = try await network.request(
             endPoint: AuthEndPoint.withdrawal(request.toDTO()),
             type: WithdrawalResponseDTO.self
         )

--- a/iOS/traveline/Sources/Feature/MyPageFeature/SettingScene/ViewModel/SettingViewModel.swift
+++ b/iOS/traveline/Sources/Feature/MyPageFeature/SettingScene/ViewModel/SettingViewModel.swift
@@ -64,7 +64,7 @@ final class SettingViewModel: BaseViewModel<SettingAction, SettingSideEffect, Se
             newState.appleIDRequests = [request]
             
         case let .requestWithdraw(isSuccess):
-            newState.moveToLogin = isSuccess
+            newState.moveToLogin = true
             
         case .error:
             break

--- a/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/VC/TimelineWritingVC.swift
+++ b/iOS/traveline/Sources/Feature/TimelineFeature/TimelineWritingScene/VC/TimelineWritingVC.swift
@@ -26,7 +26,7 @@ final class TimelineWritingVC: UIViewController {
     
     private enum Constants {
         static let titlePlaceholder: String = "제목 *"
-        static let contentPlaceholder: String = "내용을 입력해주세요. *"
+        static let contentPlaceholder: String = "내용을 입력해주세요. *\n\n부적절하거나 불쾌감을 줄 수 있는 컨텐츠는 제재를 받을 수 있습니다."
         static let complete: String = "완료"
         static let selectTime: String = "시간선택"
         static let selectLocation: String = "장소 선택"


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- feature/#465

## 📚 작업한 내용
#### apple login email 체크 로직 추가
: 로그인 시 email 필드 존재하면 탈퇴하기 API 호출 후 로그인 진행
#### 탈퇴 후 무조건 로그인 화면 이동하도록 수정
: 현재 revoke 필드가 성공시에도 false로 내려와 우선적으로 무조건 true로 처리
#### EULA 약관 관련하여 부적절한 컨텐츠~ 문구 추가
: 관련 reject 대응하기 위해 문구 추가

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 관련 이슈
- Resolved: #465
