### PR TITLE
[fix] getImageUrl()과 delete() 메서드 내에 basePath 제거

### DIFF
--- a/BE/src/file/file.service.ts
+++ b/BE/src/file/file.service.ts
@@ -27,10 +27,10 @@ export class FileService {
   }
 
   async getImageUrl(key: string): Promise<string> {
-    return this.basePath + key;
+    return key;
   }
 
   async delete(path: string) {
-    await unlink(this.basePath + path);
+    await unlink(path);
   }
 }


### PR DESCRIPTION
## 🌎 PR 요약

🌱 작업한 브랜치
- be-feature/#483-fix-static-path

## 📚 작업한 내용
이미지를 저장할 때를 제외하곤 basePath 제거

## 📍 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 관련 이슈
- Resolved: #483
